### PR TITLE
Centralize localStorage access and update related contexts

### DIFF
--- a/src/components/layout/MidiQuickSettings.tsx
+++ b/src/components/layout/MidiQuickSettings.tsx
@@ -4,7 +4,6 @@ import SelectInput from "@/components/forms/SelectInput";
 import Button from "@/components/ui/Button";
 import { useMidiChannel } from "@/context/MidiChannelContext";
 import { useMidiPort } from "@/context/MidiPortContext";
-import { saveToLocalStorage } from "@/utils/utils";
 
 interface MidiQuickSettingsProps {
 	minimalTrigger?: boolean;
@@ -56,7 +55,6 @@ export default function MidiQuickSettings({
 									value={selectedMidiPort}
 									onChange={(e) => {
 										setSelectedMidiPort(e.target.value);
-										saveToLocalStorage("selectedMidiPort", e.target.value);
 									}}
 								>
 									{midiPorts.length === 0 ? (
@@ -80,7 +78,6 @@ export default function MidiQuickSettings({
 									onChange={(e) => {
 										const channel = parseInt(e.target.value, 10);
 										setSelectedMidiChannel(channel);
-										saveToLocalStorage("selectedMidiChannel", channel);
 									}}
 								>
 									{Array.from({ length: 16 }, (_, i) => i + 1).map(

--- a/src/context/MidiChannelContext.tsx
+++ b/src/context/MidiChannelContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, type ReactNode, useContext, useState } from "react";
-import { loadFromLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 interface MidiChannelContextType {
 	selectedMidiChannel: number;
@@ -12,11 +12,20 @@ const MidiChannelContext = createContext<MidiChannelContextType | undefined>(
 
 export const MidiChannelProvider = ({ children }: { children: ReactNode }) => {
 	const [selectedMidiChannel, setSelectedMidiChannel] = useState<number>(
-		loadFromLocalStorage("selectedMidiChannel", 1),
+		getItem(STORAGE_KEYS.SELECTED_MIDI_CHANNEL, 1),
 	);
+
+	const handleSetSelectedMidiChannel = (channel: number) => {
+		setItem(STORAGE_KEYS.SELECTED_MIDI_CHANNEL, channel);
+		setSelectedMidiChannel(channel);
+	};
+
 	return (
 		<MidiChannelContext.Provider
-			value={{ selectedMidiChannel, setSelectedMidiChannel }}
+			value={{
+				selectedMidiChannel,
+				setSelectedMidiChannel: handleSetSelectedMidiChannel,
+			}}
 		>
 			{children}
 		</MidiChannelContext.Provider>

--- a/src/context/MidiPortContext.tsx
+++ b/src/context/MidiPortContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, type ReactNode, useContext, useState } from "react";
-import { loadFromLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 interface MidiPortContextType {
 	midiPorts: string[];
@@ -15,12 +15,22 @@ const MidiPortContext = createContext<MidiPortContextType | undefined>(
 export const MidiPortProvider = ({ children }: { children: ReactNode }) => {
 	const [midiPorts, setMidiPorts] = useState<string[]>([]);
 	const [selectedMidiPort, setSelectedMidiPort] = useState<string>(
-		loadFromLocalStorage("selectedMidiPort", ""),
+		getItem(STORAGE_KEYS.SELECTED_MIDI_PORT, ""),
 	);
+
+	const handleSetSelectedMidiPort = (port: string) => {
+		setItem(STORAGE_KEYS.SELECTED_MIDI_PORT, port);
+		setSelectedMidiPort(port);
+	};
 
 	return (
 		<MidiPortContext.Provider
-			value={{ midiPorts, setMidiPorts, selectedMidiPort, setSelectedMidiPort }}
+			value={{
+				midiPorts,
+				setMidiPorts,
+				selectedMidiPort,
+				setSelectedMidiPort: handleSetSelectedMidiPort,
+			}}
 		>
 			{children}
 		</MidiPortContext.Provider>

--- a/src/context/SearchFilterContext.tsx
+++ b/src/context/SearchFilterContext.tsx
@@ -1,7 +1,7 @@
 import type { SortingState } from "@tanstack/react-table";
 import type React from "react";
 import { createContext, type ReactNode, useContext, useState } from "react";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 interface SearchFilterContextProps {
 	sorting: SortingState | [];
@@ -46,12 +46,12 @@ export const SearchFilterProvider: React.FC<SearchFilterProviderProps> = ({
 	const [randomOrder, setRandomOrder] = useState(false);
 	const [duplicatesOnly, setDuplicatesOnly] = useState(false);
 	const [userPresetsOnly, setUserPresetsOnlyState] = useState(
-		loadFromLocalStorage("userPresetsOnly", false),
+		getItem(STORAGE_KEYS.USER_PRESETS_ONLY, false),
 	);
 
 	const setUserPresetsOnly = (nextValue: boolean) => {
+		setItem(STORAGE_KEYS.USER_PRESETS_ONLY, nextValue);
 		setUserPresetsOnlyState(nextValue);
-		saveToLocalStorage("userPresetsOnly", nextValue);
 	};
 
 	const [activePlaylistId, setActivePlaylistId] = useState<string | null>(null);

--- a/src/features/presets/components/OptionPanel.tsx
+++ b/src/features/presets/components/OptionPanel.tsx
@@ -5,7 +5,6 @@ import Button from "@/components/ui/Button";
 import { useMidiChannel } from "@/context/MidiChannelContext";
 import { useMidiPort } from "@/context/MidiPortContext";
 import type { Preset } from "@/lib/presets/presetManager";
-import { saveToLocalStorage } from "@/utils/utils";
 
 interface OptionPanelProps {
 	autoSend: boolean;
@@ -64,7 +63,6 @@ const OptionPanel: React.FC<OptionPanelProps> = ({
 					value={selectedMidiPort}
 					onChange={(e) => {
 						setSelectedMidiPort(e.target.value);
-						saveToLocalStorage("selectedMidiPort", e.target.value);
 					}}
 				>
 					{midiPorts.map((port) => (
@@ -78,7 +76,6 @@ const OptionPanel: React.FC<OptionPanelProps> = ({
 					onChange={(e) => {
 						const channel = parseInt(e.target.value, 10);
 						setSelectedMidiChannel(channel);
-						saveToLocalStorage("selectedMidiChannel", channel);
 					}}
 				>
 					{Array.from({ length: 16 }, (_, i) => i + 1).map((channel) => (

--- a/src/features/presets/hooks/usePresetMode.ts
+++ b/src/features/presets/hooks/usePresetMode.ts
@@ -11,7 +11,7 @@ import {
 	retrievePresetSlotFromSynth,
 	writePresetToSynthSlot,
 } from "@/lib/presets/presetManager";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 type AppMode =
 	| "presets"
@@ -43,7 +43,7 @@ export function usePresetMode({
 	const { notifySuccess, notifyInfo, notifyError } = useToast();
 	const [editMode, setEditMode] = useState(false);
 	const [autoSend, setAutoSend] = useState(
-		loadFromLocalStorage("autoSend", false),
+		getItem(STORAGE_KEYS.AUTO_SEND, false),
 	);
 
 	const [saveDraftPresetState, setSaveDraftPresetState] =
@@ -120,7 +120,7 @@ export function usePresetMode({
 	const handleToggleAutoSend = () => {
 		setAutoSend((prevAutoSend: boolean) => {
 			const newAutoSend = !prevAutoSend;
-			saveToLocalStorage("autoSend", newAutoSend);
+			setItem(STORAGE_KEYS.AUTO_SEND, newAutoSend);
 			return newAutoSend;
 		});
 	};

--- a/src/lib/auth/onlineAuthSession.ts
+++ b/src/lib/auth/onlineAuthSession.ts
@@ -4,21 +4,22 @@ import {
 	signInWithNeonProvider,
 	signOutNeonSession,
 } from "@/lib/auth/neonAuthClient";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
-
-const ONLINE_AUTH_SESSION_KEY = "cz101.online-auth-session.v1";
+import { getItem, removeItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 export function loadOnlineAuthSession(): OnlineAuthSession | null {
 	if (typeof window === "undefined") {
 		return null;
 	}
 
-	const stored = loadFromLocalStorage(ONLINE_AUTH_SESSION_KEY, null);
+	const stored = getItem<Partial<OnlineAuthSession> | null>(
+		STORAGE_KEYS.ONLINE_AUTH_SESSION,
+		null,
+	);
 	if (!stored || typeof stored !== "object") {
 		return null;
 	}
 
-	const session = stored as Partial<OnlineAuthSession>;
+	const session = stored;
 	if (!session.userId) {
 		return null;
 	}
@@ -39,7 +40,7 @@ export function saveOnlineAuthSession(session: OnlineAuthSession): void {
 		return;
 	}
 
-	saveToLocalStorage(ONLINE_AUTH_SESSION_KEY, {
+	setItem(STORAGE_KEYS.ONLINE_AUTH_SESSION, {
 		userId: session.userId,
 		displayName: session.displayName,
 		provider: session.provider,
@@ -52,7 +53,7 @@ export function clearOnlineAuthSession(): void {
 		return;
 	}
 
-	window.localStorage.removeItem(ONLINE_AUTH_SESSION_KEY);
+	removeItem(STORAGE_KEYS.ONLINE_AUTH_SESSION);
 }
 
 export async function refreshOnlineAuthSession(): Promise<OnlineAuthSession | null> {

--- a/src/lib/backup/workspaceBackup.ts
+++ b/src/lib/backup/workspaceBackup.ts
@@ -9,16 +9,16 @@ import {
 	type SerializedSynthBackup,
 } from "@/lib/collections/synthBackupManager";
 import { exportPresets, importPresets } from "@/lib/presets/presetManager";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 const WORKSPACE_BACKUP_SCHEMA = "cz101-workspace-backup";
 const WORKSPACE_BACKUP_VERSION = 1;
 
 const APP_SETTINGS_KEYS = [
-	"selectedMidiPort",
-	"selectedMidiChannel",
-	"autoSend",
-];
+	STORAGE_KEYS.SELECTED_MIDI_PORT,
+	STORAGE_KEYS.SELECTED_MIDI_CHANNEL,
+	STORAGE_KEYS.AUTO_SEND,
+] as const;
 
 type WorkspaceBackupSection = {
 	format: string;
@@ -60,7 +60,7 @@ export function isWorkspaceBackupEnvelope(
 function getAppSettingsSnapshot() {
 	return APP_SETTINGS_KEYS.reduce(
 		(acc, key) => {
-			acc[key] = loadFromLocalStorage(key, null);
+			acc[key] = getItem(key, null);
 			return acc;
 		},
 		{} as Record<string, unknown>,
@@ -70,7 +70,7 @@ function getAppSettingsSnapshot() {
 function applyAppSettingsSnapshot(snapshot: Record<string, unknown>) {
 	APP_SETTINGS_KEYS.forEach((key) => {
 		if (Object.hasOwn(snapshot, key)) {
-			saveToLocalStorage(key, snapshot[key]);
+			setItem(key, snapshot[key]);
 		}
 	});
 }

--- a/src/lib/collections/playlistManager.ts
+++ b/src/lib/collections/playlistManager.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 export interface PlaylistEntry {
 	id: string;
@@ -13,14 +13,12 @@ export interface Playlist {
 	entries: PlaylistEntry[];
 }
 
-const PLAYLIST_STORAGE_KEY = "cz101Playlists";
-
 function loadPlaylists(): Playlist[] {
-	return loadFromLocalStorage(PLAYLIST_STORAGE_KEY, []) as Playlist[];
+	return getItem<Playlist[]>(STORAGE_KEYS.PLAYLISTS, []);
 }
 
 function savePlaylists(playlists: Playlist[]): void {
-	saveToLocalStorage(PLAYLIST_STORAGE_KEY, playlists);
+	setItem(STORAGE_KEYS.PLAYLISTS, playlists);
 }
 
 export function exportAllPlaylists(): Playlist[] {

--- a/src/lib/collections/setlistManager.ts
+++ b/src/lib/collections/setlistManager.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 export type SetlistSource = "internal-16" | "manual";
 
@@ -29,8 +29,6 @@ export interface SerializedSetlist extends Omit<Setlist, "entries"> {
 	entries: SerializedSetlistEntry[];
 }
 
-const SETLIST_STORAGE_KEY = "cz101Setlists";
-
 function serializeSetlist(setlist: Setlist): SerializedSetlist {
 	return {
 		...setlist,
@@ -52,11 +50,11 @@ function deserializeSetlist(setlist: SerializedSetlist): Setlist {
 }
 
 function loadSerializedSetlists(): SerializedSetlist[] {
-	return loadFromLocalStorage(SETLIST_STORAGE_KEY, []) as SerializedSetlist[];
+	return getItem<SerializedSetlist[]>(STORAGE_KEYS.SETLISTS, []);
 }
 
 function saveSerializedSetlists(setlists: SerializedSetlist[]) {
-	saveToLocalStorage(SETLIST_STORAGE_KEY, setlists);
+	setItem(STORAGE_KEYS.SETLISTS, setlists);
 }
 
 export function exportAllSetlists(): SerializedSetlist[] {

--- a/src/lib/collections/synthBackupManager.ts
+++ b/src/lib/collections/synthBackupManager.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from "uuid";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 export type SynthBackupSource = "internal-16" | "manual";
 
@@ -30,8 +30,6 @@ export interface SerializedSynthBackup extends Omit<SynthBackup, "entries"> {
 	entries: SerializedSynthBackupEntry[];
 }
 
-const SYNTH_BACKUP_STORAGE_KEY = "cz101SynthBackups";
-
 function serializeSynthBackup(backup: SynthBackup): SerializedSynthBackup {
 	return {
 		...backup,
@@ -53,20 +51,19 @@ function deserializeSynthBackup(backup: SerializedSynthBackup): SynthBackup {
 }
 
 function loadSerializedSynthBackups(): SerializedSynthBackup[] {
-	// Migrate from old key if present
-	const legacy = loadFromLocalStorage("cz101Setlists", null);
+	const legacy = getItem<SerializedSynthBackup[] | null>(
+		STORAGE_KEYS.CZ101_SETLISTS,
+		null,
+	);
 	if (legacy !== null) {
-		saveToLocalStorage(SYNTH_BACKUP_STORAGE_KEY, legacy);
-		saveToLocalStorage("cz101Setlists", null);
+		setItem(STORAGE_KEYS.SYNTH_BACKUPS, legacy);
+		setItem(STORAGE_KEYS.CZ101_SETLISTS, null);
 	}
-	return loadFromLocalStorage(
-		SYNTH_BACKUP_STORAGE_KEY,
-		[],
-	) as SerializedSynthBackup[];
+	return getItem<SerializedSynthBackup[]>(STORAGE_KEYS.SYNTH_BACKUPS, []);
 }
 
 function saveSerializedSynthBackups(backups: SerializedSynthBackup[]) {
-	saveToLocalStorage(SYNTH_BACKUP_STORAGE_KEY, backups);
+	setItem(STORAGE_KEYS.SYNTH_BACKUPS, backups);
 }
 
 export function exportAllSynthBackups(): SerializedSynthBackup[] {

--- a/src/lib/presets/presetManager.ts
+++ b/src/lib/presets/presetManager.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/presets/factoryPresets";
 import { filterPresets } from "@/lib/presets/filterPresets";
 import { getPresetFingerprint } from "@/lib/presets/presetFingerprint";
+import { getItem, removeItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 import { isOnlineSyncEnabled } from "@/lib/sync/onlineSyncSettings";
 import {
 	PresetSyncCoordinator,
@@ -35,7 +36,6 @@ import {
 let presetDatabase: PresetDatabase;
 const presetSync = new PresetSyncCoordinator();
 const DEFAULT_USER_PRESET_AUTHOR = "User";
-const FACTORY_PRESETS_ONBOARDING_KEY = "cz101.factory-presets.onboarding.v1";
 
 export function setPresetDatabase(database: PresetDatabase): void {
 	presetDatabase = database;
@@ -96,17 +96,17 @@ export async function ensureFactoryPresetsOnFirstUse(): Promise<
 		return false;
 	}
 
-	const onboardingState = loadFromLocalStorage(
-		FACTORY_PRESETS_ONBOARDING_KEY,
+	const onboardingState = getItem<string | null>(
+		STORAGE_KEYS.FACTORY_PRESETS_ONBOARDING,
 		null,
-	) as string | null;
+	);
 	if (onboardingState) {
 		return false;
 	}
 
 	const existingPresets = await presetDatabase.getPresets();
 	if (existingPresets.length > 0) {
-		saveToLocalStorage(FACTORY_PRESETS_ONBOARDING_KEY, "skipped");
+		setItem(STORAGE_KEYS.FACTORY_PRESETS_ONBOARDING, "skipped");
 		return false;
 	}
 
@@ -114,13 +114,13 @@ export async function ensureFactoryPresetsOnFirstUse(): Promise<
 }
 
 export async function acceptFactoryPresetsOnboarding(): Promise<boolean> {
-	saveToLocalStorage(FACTORY_PRESETS_ONBOARDING_KEY, "accepted");
+	setItem(STORAGE_KEYS.FACTORY_PRESETS_ONBOARDING, "accepted");
 	const addedCount = await addFactoryPresetsToLibrary();
 	return addedCount > 0;
 }
 
 export function declineFactoryPresetsOnboarding(): void {
-	saveToLocalStorage(FACTORY_PRESETS_ONBOARDING_KEY, "declined");
+	setItem(STORAGE_KEYS.FACTORY_PRESETS_ONBOARDING, "declined");
 }
 
 export async function cloudBackupPresets(): Promise<boolean> {
@@ -168,7 +168,7 @@ export async function resetLocalAppData(): Promise<void> {
 	clearAllSynthBackups();
 
 	if (typeof window !== "undefined") {
-		window.localStorage.removeItem(FACTORY_PRESETS_ONBOARDING_KEY);
+		removeItem(STORAGE_KEYS.FACTORY_PRESETS_ONBOARDING);
 	}
 }
 
@@ -901,7 +901,6 @@ export function createPresetFromSysex(params: {
 }
 
 import { patches } from "@/assets/cznames";
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
 
 // Helper to parse preset names from cznames.json
 async function parsePresetNames(): Promise<{

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -1,0 +1,2 @@
+export { STORAGE_KEYS, type StorageKey } from "./keys";
+export { clear, getItem, removeItem, setItem } from "./storage";

--- a/src/lib/storage/keys.ts
+++ b/src/lib/storage/keys.ts
@@ -9,7 +9,7 @@ export const STORAGE_KEYS = {
 	PLAYLISTS: "cz101Playlists",
 	SETLISTS: "cz101Setlists",
 	SYNTH_BACKUPS: "cz101SynthBackups",
-	CZ101_SETLISTS: "cz101Setlists",
+	CZ101_SETLISTS: "cz101SetlistsLegacy",
 } as const;
 
 export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/src/lib/storage/keys.ts
+++ b/src/lib/storage/keys.ts
@@ -1,0 +1,15 @@
+export const STORAGE_KEYS = {
+	FACTORY_PRESETS_ONBOARDING: "cz101.factory-presets.onboarding.v1",
+	ONLINE_AUTH_SESSION: "cz101.online-auth-session.v1",
+	ONLINE_SYNC_SETTINGS: "cz101.online-sync-settings.v1",
+	SELECTED_MIDI_CHANNEL: "selectedMidiChannel",
+	SELECTED_MIDI_PORT: "selectedMidiPort",
+	USER_PRESETS_ONLY: "userPresetsOnly",
+	AUTO_SEND: "autoSend",
+	PLAYLISTS: "cz101Playlists",
+	SETLISTS: "cz101Setlists",
+	SYNTH_BACKUPS: "cz101SynthBackups",
+	CZ101_SETLISTS: "cz101Setlists",
+} as const;
+
+export type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];

--- a/src/lib/storage/storage.test.ts
+++ b/src/lib/storage/storage.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { STORAGE_KEYS } from "./keys";
+import { clear, getItem, removeItem, setItem } from "./storage";
+
+describe("storage", () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("getItem", () => {
+		it("returns defaultValue when key is not set", () => {
+			expect(getItem(STORAGE_KEYS.AUTO_SEND, false)).toBe(false);
+		});
+
+		it("returns defaultValue when key is not set (null default)", () => {
+			expect(getItem(STORAGE_KEYS.SELECTED_MIDI_PORT, null)).toBeNull();
+		});
+
+		it("returns stored value for a string", () => {
+			localStorage.setItem(
+				STORAGE_KEYS.SELECTED_MIDI_PORT,
+				JSON.stringify("myPort"),
+			);
+			expect(getItem(STORAGE_KEYS.SELECTED_MIDI_PORT, null)).toBe("myPort");
+		});
+
+		it("returns stored value for a boolean", () => {
+			localStorage.setItem(STORAGE_KEYS.AUTO_SEND, JSON.stringify(true));
+			expect(getItem(STORAGE_KEYS.AUTO_SEND, false)).toBe(true);
+		});
+
+		it("returns stored value for a number", () => {
+			localStorage.setItem(
+				STORAGE_KEYS.SELECTED_MIDI_CHANNEL,
+				JSON.stringify(5),
+			);
+			expect(getItem(STORAGE_KEYS.SELECTED_MIDI_CHANNEL, 1)).toBe(5);
+		});
+
+		it("returns stored value for an object", () => {
+			const obj = [{ id: "1", name: "Test" }];
+			localStorage.setItem(STORAGE_KEYS.PLAYLISTS, JSON.stringify(obj));
+			expect(getItem(STORAGE_KEYS.PLAYLISTS, [])).toEqual(obj);
+		});
+
+		it("returns defaultValue when stored value is invalid JSON", () => {
+			localStorage.setItem(STORAGE_KEYS.AUTO_SEND, "not-valid-json{");
+			expect(getItem(STORAGE_KEYS.AUTO_SEND, false)).toBe(false);
+		});
+
+		it("returns defaultValue when localStorage throws", () => {
+			vi.spyOn(Storage.prototype, "getItem").mockImplementationOnce(() => {
+				throw new Error("Storage unavailable");
+			});
+			expect(getItem(STORAGE_KEYS.AUTO_SEND, false)).toBe(false);
+		});
+	});
+
+	describe("setItem", () => {
+		it("persists a string value", () => {
+			setItem(STORAGE_KEYS.SELECTED_MIDI_PORT, "myPort");
+			expect(localStorage.getItem(STORAGE_KEYS.SELECTED_MIDI_PORT)).toBe(
+				JSON.stringify("myPort"),
+			);
+		});
+
+		it("persists a boolean value", () => {
+			setItem(STORAGE_KEYS.AUTO_SEND, true);
+			expect(localStorage.getItem(STORAGE_KEYS.AUTO_SEND)).toBe("true");
+		});
+
+		it("persists an object value", () => {
+			const obj = [{ id: "1" }];
+			setItem(STORAGE_KEYS.PLAYLISTS, obj);
+			expect(localStorage.getItem(STORAGE_KEYS.PLAYLISTS)).toBe(
+				JSON.stringify(obj),
+			);
+		});
+
+		it("does not throw when localStorage.setItem fails", () => {
+			vi.spyOn(localStorage, "setItem").mockImplementationOnce(() => {
+				throw new Error("QuotaExceededError");
+			});
+			expect(() => setItem(STORAGE_KEYS.AUTO_SEND, true)).not.toThrow();
+		});
+
+		it("logs an error when write fails", () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(localStorage, "setItem").mockImplementationOnce(() => {
+				throw new Error("QuotaExceededError");
+			});
+			setItem(STORAGE_KEYS.AUTO_SEND, true);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining(STORAGE_KEYS.AUTO_SEND),
+				expect.any(Error),
+			);
+		});
+	});
+
+	describe("removeItem", () => {
+		it("removes a stored value", () => {
+			localStorage.setItem(STORAGE_KEYS.AUTO_SEND, "true");
+			removeItem(STORAGE_KEYS.AUTO_SEND);
+			expect(localStorage.getItem(STORAGE_KEYS.AUTO_SEND)).toBeNull();
+		});
+
+		it("does not throw when localStorage.removeItem fails", () => {
+			vi.spyOn(localStorage, "removeItem").mockImplementationOnce(() => {
+				throw new Error("Storage unavailable");
+			});
+			expect(() => removeItem(STORAGE_KEYS.AUTO_SEND)).not.toThrow();
+		});
+
+		it("logs an error when removeItem fails", () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(localStorage, "removeItem").mockImplementationOnce(() => {
+				throw new Error("Storage unavailable");
+			});
+			removeItem(STORAGE_KEYS.AUTO_SEND);
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining(STORAGE_KEYS.AUTO_SEND),
+				expect.any(Error),
+			);
+		});
+	});
+
+	describe("clear", () => {
+		it("clears all stored values", () => {
+			localStorage.setItem(STORAGE_KEYS.AUTO_SEND, "true");
+			localStorage.setItem(
+				STORAGE_KEYS.SELECTED_MIDI_PORT,
+				JSON.stringify("p1"),
+			);
+			clear();
+			expect(localStorage.getItem(STORAGE_KEYS.AUTO_SEND)).toBeNull();
+			expect(localStorage.getItem(STORAGE_KEYS.SELECTED_MIDI_PORT)).toBeNull();
+		});
+
+		it("does not throw when localStorage.clear fails", () => {
+			vi.spyOn(localStorage, "clear").mockImplementationOnce(() => {
+				throw new Error("Storage unavailable");
+			});
+			expect(() => clear()).not.toThrow();
+		});
+
+		it("logs an error when clear fails", () => {
+			const consoleSpy = vi
+				.spyOn(console, "error")
+				.mockImplementation(() => {});
+			vi.spyOn(localStorage, "clear").mockImplementationOnce(() => {
+				throw new Error("Storage unavailable");
+			});
+			clear();
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining("clear localStorage"),
+				expect.any(Error),
+			);
+		});
+	});
+});

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -21,9 +21,17 @@ export function setItem<T>(key: StorageKey, value: T): void {
 }
 
 export function removeItem(key: StorageKey): void {
-	localStorage.removeItem(key);
+	try {
+		localStorage.removeItem(key);
+	} catch (error) {
+		console.error(`Failed to remove ${key} from localStorage:`, error);
+	}
 }
 
 export function clear(): void {
-	localStorage.clear();
+	try {
+		localStorage.clear();
+	} catch (error) {
+		console.error("Failed to clear localStorage:", error);
+	}
 }

--- a/src/lib/storage/storage.ts
+++ b/src/lib/storage/storage.ts
@@ -1,0 +1,29 @@
+import type { StorageKey } from "./keys";
+
+export function getItem<T>(key: StorageKey, defaultValue: T): T {
+	try {
+		const item = localStorage.getItem(key);
+		if (item === null) {
+			return defaultValue;
+		}
+		return JSON.parse(item) as T;
+	} catch {
+		return defaultValue;
+	}
+}
+
+export function setItem<T>(key: StorageKey, value: T): void {
+	try {
+		localStorage.setItem(key, JSON.stringify(value));
+	} catch (error) {
+		console.error(`Failed to save ${key} to localStorage:`, error);
+	}
+}
+
+export function removeItem(key: StorageKey): void {
+	localStorage.removeItem(key);
+}
+
+export function clear(): void {
+	localStorage.clear();
+}

--- a/src/lib/sync/onlineSyncSettings.ts
+++ b/src/lib/sync/onlineSyncSettings.ts
@@ -1,6 +1,4 @@
-import { loadFromLocalStorage, saveToLocalStorage } from "@/utils/utils";
-
-const ONLINE_SYNC_SETTINGS_KEY = "cz101.online-sync-settings.v1";
+import { getItem, STORAGE_KEYS, setItem } from "@/lib/storage";
 
 export interface OnlineSyncSettings {
 	enabled: boolean;
@@ -15,10 +13,10 @@ export function loadOnlineSyncSettings(): OnlineSyncSettings {
 		return DEFAULT_ONLINE_SYNC_SETTINGS;
 	}
 
-	const stored = loadFromLocalStorage(
-		ONLINE_SYNC_SETTINGS_KEY,
+	const stored = getItem<Partial<OnlineSyncSettings>>(
+		STORAGE_KEYS.ONLINE_SYNC_SETTINGS,
 		DEFAULT_ONLINE_SYNC_SETTINGS,
-	) as Partial<OnlineSyncSettings>;
+	);
 
 	return {
 		enabled: Boolean(stored.enabled),
@@ -30,7 +28,7 @@ export function saveOnlineSyncSettings(settings: OnlineSyncSettings): void {
 		return;
 	}
 
-	saveToLocalStorage(ONLINE_SYNC_SETTINGS_KEY, {
+	setItem(STORAGE_KEYS.ONLINE_SYNC_SETTINGS, {
 		enabled: settings.enabled,
 	});
 }


### PR DESCRIPTION
- Create @/lib/storage module with typed STORAGE_KEYS
- Add getItem/setItem/removeItem/clear functions
- Update MidiChannelContext, MidiPortContext, SearchFilterContext to use centralized storage
- Update playlistManager, setlistManager, synthBackupManager to use centralized storage
- Update onlineAuthSession, onlineSyncSettings to use centralized storage
- Update presetManager to use centralized storage
- Update usePresetMode hook to use centralized storage
- Remove redundant localStorage writes from MidiQuickSettings and OptionPanel (context setters persist)
- Update workspaceBackup to use centralized storage
- Remove unused loadFromLocalStorage/saveToLocalStorage imports