### PR TITLE
Refactor browser test setup and PresetDatabase integration

### DIFF
--- a/setupBrowserTests.ts
+++ b/setupBrowserTests.ts
@@ -4,6 +4,20 @@ import "@testing-library/jest-dom/vitest";
 import { beforeEach, vi } from "vitest";
 import "./src/App.css";
 
+// Mock the webmidi module
+vi.mock("webmidi", () => ({
+	WebMidi: {
+		enabled: false,
+		inputs: [],
+		outputs: [],
+		enable: vi.fn().mockResolvedValue(undefined),
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		getInputByName: vi.fn().mockReturnValue(undefined),
+		getOutputByName: vi.fn().mockReturnValue(undefined),
+	},
+}));
+
 // Mock the MIDIAccess object
 const mockMIDIAccess = {
 	inputs: new Map(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,10 +5,12 @@ import { useEffect, useState } from "react";
 import Button from "@/components/ui/Button";
 import { MidiChannelProvider } from "@/context/MidiChannelContext";
 import { MidiPortProvider } from "@/context/MidiPortContext";
+import { PresetDatabaseProvider } from "@/context/PresetDatabaseContext";
 import { SearchFilterProvider } from "@/context/SearchFilterContext";
 import { SidebarProvider } from "@/context/SidebarContext";
 import { ToastProvider, useToast } from "@/context/ToastContext";
 import { refreshOnlineAuthSession } from "@/lib/auth/onlineAuthSession";
+import { IndexedDbPresetDatabase } from "@/lib/db/browserDatabase";
 import {
 	acceptFactoryPresetsOnboarding,
 	declineFactoryPresetsOnboarding,
@@ -98,18 +100,22 @@ function AppInner() {
 }
 
 export default function App() {
+	const presetDatabase = new IndexedDbPresetDatabase();
+
 	return (
 		<ToastProvider>
 			<QueryClientProvider client={queryClient}>
-				<MidiPortProvider>
-					<MidiChannelProvider>
-						<SearchFilterProvider>
-							<SidebarProvider>
-								<AppInner />
-							</SidebarProvider>
-						</SearchFilterProvider>
-					</MidiChannelProvider>
-				</MidiPortProvider>
+				<PresetDatabaseProvider database={presetDatabase}>
+					<MidiPortProvider>
+						<MidiChannelProvider>
+							<SearchFilterProvider>
+								<SidebarProvider>
+									<AppInner />
+								</SidebarProvider>
+							</SearchFilterProvider>
+						</MidiChannelProvider>
+					</MidiPortProvider>
+				</PresetDatabaseProvider>
 			</QueryClientProvider>
 		</ToastProvider>
 	);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import {
 	acceptFactoryPresetsOnboarding,
 	declineFactoryPresetsOnboarding,
 	ensureFactoryPresetsOnFirstUse,
+	setPresetDatabase,
 } from "@/lib/presets/presetManager";
 import { saveOnlineSyncSettings } from "@/lib/sync/onlineSyncSettings";
 import { configurePresetSyncAdapterFromSettings } from "@/lib/sync/remotePresetSyncAdapter";
@@ -100,7 +101,11 @@ function AppInner() {
 }
 
 export default function App() {
-	const presetDatabase = new IndexedDbPresetDatabase();
+	const [presetDatabase] = useState(() => {
+		const db = new IndexedDbPresetDatabase();
+		setPresetDatabase(db);
+		return db;
+	});
 
 	return (
 		<ToastProvider>

--- a/src/context/PresetDatabaseContext.tsx
+++ b/src/context/PresetDatabaseContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, type ReactNode, useContext } from "react";
-import type { PresetDatabase } from "@/lib/presets/presetManager";
+import type { PresetDatabase } from "@/lib/db/PresetDatabase";
 
 const PresetDatabaseContext = createContext<PresetDatabase | undefined>(
 	undefined,

--- a/src/lib/db/PresetDatabase.ts
+++ b/src/lib/db/PresetDatabase.ts
@@ -1,7 +1,5 @@
 import type { Preset } from "@/lib/presets/types";
 
-export type { Preset };
-
 export interface PresetDatabase {
 	getPresets(): Promise<Preset[]>;
 	getPresetById(id: string): Promise<Preset | null>;

--- a/src/lib/db/PresetDatabase.ts
+++ b/src/lib/db/PresetDatabase.ts
@@ -1,0 +1,12 @@
+import type { Preset } from "@/lib/presets/presetManager";
+
+export interface PresetDatabase {
+	getPresets(): Promise<Preset[]>;
+	addPreset(preset: Preset): Promise<Preset>;
+	updatePreset(preset: Preset): Promise<void>;
+	deletePreset(id: string): Promise<void>;
+	syncPresets(localPresets: Preset[]): Promise<void>;
+	isAvailable(): Promise<boolean>;
+	import(json: string): Promise<void>;
+	export(): Promise<string>;
+}

--- a/src/lib/db/PresetDatabase.ts
+++ b/src/lib/db/PresetDatabase.ts
@@ -1,7 +1,10 @@
-import type { Preset } from "@/lib/presets/presetManager";
+import type { Preset } from "@/lib/presets/types";
+
+export type { Preset };
 
 export interface PresetDatabase {
 	getPresets(): Promise<Preset[]>;
+	getPresetById(id: string): Promise<Preset | null>;
 	addPreset(preset: Preset): Promise<Preset>;
 	updatePreset(preset: Preset): Promise<void>;
 	deletePreset(id: string): Promise<void>;

--- a/src/lib/db/browserDatabase.ts
+++ b/src/lib/db/browserDatabase.ts
@@ -1,4 +1,5 @@
-import type { Preset, PresetDatabase } from "@/lib/presets/presetManager";
+import type { PresetDatabase } from "@/lib/db/PresetDatabase";
+import type { Preset } from "@/lib/presets/types";
 
 const DB_NAME = "PresetDatabase";
 const STORE_NAME = "presets";

--- a/src/lib/db/fakePresetDatabase.test.ts
+++ b/src/lib/db/fakePresetDatabase.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { beforeEach, describe, expect, it } from "vitest";
 import { FakePresetDatabase } from "@/lib/db/fakePresetDatabase";
-import type { Preset } from "@/lib/presets/presetManager";
+import type { Preset } from "@/lib/presets/types";
 
 describe("FakePresetDatabase", () => {
 	let db: FakePresetDatabase;

--- a/src/lib/db/fakePresetDatabase.ts
+++ b/src/lib/db/fakePresetDatabase.ts
@@ -1,7 +1,8 @@
 // src/lib/fakePresetDatabase.ts
 
 import { v4 as uuidv4 } from "uuid";
-import type { Preset, PresetDatabase } from "@/lib/presets/presetManager";
+import type { PresetDatabase } from "@/lib/db/PresetDatabase";
+import type { Preset } from "@/lib/presets/types";
 
 let fakePresets: Preset[] = [
 	{

--- a/src/lib/db/postgresDatabase.ts
+++ b/src/lib/db/postgresDatabase.ts
@@ -1,5 +1,6 @@
 import { Client } from "pg";
-import type { Preset, PresetDatabase } from "@/lib/presets/presetManager";
+import type { PresetDatabase } from "@/lib/db/PresetDatabase";
+import type { Preset } from "@/lib/presets/types";
 
 const client = new Client({
 	connectionString: "postgresql://user:password@localhost:5432/presets",

--- a/src/lib/db/postgresDatabaseWithFallback.ts
+++ b/src/lib/db/postgresDatabaseWithFallback.ts
@@ -1,6 +1,7 @@
 import { IndexedDbPresetDatabase } from "@/lib/db/browserDatabase";
+import type { PresetDatabase } from "@/lib/db/PresetDatabase";
 import { PostgresPresetDatabase } from "@/lib/db/postgresDatabase";
-import type { Preset, PresetDatabase } from "@/lib/presets/presetManager";
+import type { Preset } from "@/lib/presets/types";
 
 export class PostgresPresetDatabaseWithFallback implements PresetDatabase {
 	private postgresDb: PostgresPresetDatabase;

--- a/src/lib/presets/presetManager.ts
+++ b/src/lib/presets/presetManager.ts
@@ -33,16 +33,16 @@ import {
 	type RemotePresetSyncAdapter,
 } from "@/lib/sync/presetSync";
 
-let presetDatabase: PresetDatabase;
+let presetDatabase: PresetDatabase = new IndexedDbPresetDatabase();
 const presetSync = new PresetSyncCoordinator();
 const DEFAULT_USER_PRESET_AUTHOR = "User";
 
-export function setPresetDatabase(database: PresetDatabase): void {
-	presetDatabase = database;
-}
-
 export function resetPresetDatabase(): void {
 	presetDatabase = new IndexedDbPresetDatabase();
+}
+
+export function setPresetDatabase(database: PresetDatabase): void {
+	presetDatabase = database;
 }
 
 export function setPresetSyncAdapter(adapter: RemotePresetSyncAdapter): void {

--- a/src/lib/presets/presetManager.ts
+++ b/src/lib/presets/presetManager.ts
@@ -19,6 +19,11 @@ import {
 } from "@/lib/collections/synthBackupManager";
 //import { FakePresetDatabase } from './fakePresetDatabase'
 import { IndexedDbPresetDatabase } from "@/lib/db/browserDatabase";
+import type { PresetDatabase } from "@/lib/db/PresetDatabase";
+import type { Preset } from "@/lib/presets/types";
+
+export type { Preset, PresetDatabase };
+
 import {
 	FACTORY_PRESET_AUTHOR,
 	getFactoryPresetJson,
@@ -858,22 +863,6 @@ export async function getBackupFiles(): Promise<string[]> {
 	return fileList.sort(natsort());
 }
 
-export type Preset = {
-	id: string;
-	name: string;
-	createdDate: string;
-	modifiedDate: string;
-	slot?: number;
-	filename: string;
-	sysexData: Uint8Array;
-	tags: string[];
-	author?: string;
-	description?: string;
-	isFactoryPreset?: boolean;
-	favorite?: boolean;
-	rating?: 1 | 2 | 3 | 4 | 5;
-};
-
 export function createPresetFromSysex(params: {
 	filename: string;
 	name: string;
@@ -1008,17 +997,6 @@ export async function createPresetData(
 	}
 
 	return presets;
-}
-export interface PresetDatabase {
-	getPresets(): Promise<Preset[]>;
-	getPresetById(id: string): Promise<Preset | null>;
-	addPreset(preset: Preset): Promise<Preset>;
-	updatePreset(preset: Preset): Promise<void>;
-	deletePreset(id: string): Promise<void>;
-	syncPresets(localPresets: Preset[]): Promise<void>;
-	isAvailable(): Promise<boolean>;
-	import(json: string): Promise<void>;
-	export(): Promise<string>;
 }
 
 export async function getPresets(): Promise<Preset[]> {

--- a/src/lib/presets/types.ts
+++ b/src/lib/presets/types.ts
@@ -1,0 +1,15 @@
+export type Preset = {
+	id: string;
+	name: string;
+	createdDate: string;
+	modifiedDate: string;
+	slot?: number;
+	filename: string;
+	sysexData: Uint8Array;
+	tags: string[];
+	author?: string;
+	description?: string;
+	isFactoryPreset?: boolean;
+	favorite?: boolean;
+	rating?: 1 | 2 | 3 | 4 | 5;
+};


### PR DESCRIPTION
This pull request introduces a new `PresetDatabase` abstraction and integrates it throughout the application, improving the way preset data is managed and accessed. The main changes include implementing the `PresetDatabase` interface, updating context providers, and ensuring the application uses the new database layer by default.

**Preset database abstraction and integration:**

* Added a new `PresetDatabase` interface in `src/lib/db/PresetDatabase.ts` to standardize preset data operations.
* Updated the `PresetDatabaseContext` to use the new interface, ensuring consistent access to preset data across the app.
* Wrapped the application in a `PresetDatabaseProvider` using an `IndexedDbPresetDatabase` instance, making the preset database available via context. (`src/App.tsx`) [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R8-R13) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R103-R108) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R118)

**Preset manager refactoring:**

* Changed the default `presetDatabase` in `presetManager.ts` to use `IndexedDbPresetDatabase`, and refactored `setPresetDatabase`/`resetPresetDatabase` for better control and testability.

**Testing improvements:**

* Mocked the `webmidi` module in browser tests for more reliable test runs and removed unnecessary global teardown.