### PR TITLE
Phase 01b: Rename lab route/state terminology to pd101

### DIFF
--- a/packages/cz-explorer/src/components/PhaseDistortionVisualizer.tsx
+++ b/packages/cz-explorer/src/components/PhaseDistortionVisualizer.tsx
@@ -544,7 +544,7 @@ export default function PhaseDistortionVisualizer() {
 	}, []);
 
 	const { data: libraryPresets = [] } = useQuery({
-		queryKey: ["presets", "lab-library"],
+		queryKey: ["presets", "pd101-library"],
 		queryFn: async () => {
 			const result = await fetchPresetData(
 				0,
@@ -590,7 +590,7 @@ export default function PhaseDistortionVisualizer() {
 				label: name,
 				type: "local" as const,
 			})),
-			...libraryPresets.map((preset) => ({
+			...libraryPresets.map((preset: Preset) => ({
 				id: `library:${preset.id}`,
 				label: preset.name,
 				type: "library" as const,

--- a/packages/cz-explorer/src/components/layout/AppSidebar.tsx
+++ b/packages/cz-explorer/src/components/layout/AppSidebar.tsx
@@ -37,7 +37,7 @@ const routeToMode: Record<string, AppMode> = {
 	"/setlists": "setlists",
 	"/tags": "tagManager",
 	"/duplicates": "duplicateFinder",
-	"/lab": "visualizer",
+	"/pd101": "visualizer",
 };
 
 const modeToRoute: Record<AppMode, string> = {
@@ -47,7 +47,7 @@ const modeToRoute: Record<AppMode, string> = {
 	setlists: "/setlists",
 	tagManager: "/tags",
 	duplicateFinder: "/duplicates",
-	visualizer: "/lab",
+	visualizer: "/pd101",
 };
 
 interface AppSidebarProps {

--- a/packages/cz-explorer/src/features/pd101/state/pd101UiState.ts
+++ b/packages/cz-explorer/src/features/pd101/state/pd101UiState.ts
@@ -1,21 +1,21 @@
-export const LAB_UI_SCALE_OPTIONS = [50, 60, 70, 80, 90, 100] as const;
+export const PD101_UI_SCALE_OPTIONS = [50, 60, 70, 80, 90, 100] as const;
 
-export type UiScale = (typeof LAB_UI_SCALE_OPTIONS)[number];
+export type UiScale = (typeof PD101_UI_SCALE_OPTIONS)[number];
 
-export type LabUiState = {
+export type Pd101UiState = {
 	scopeCycles: number;
 	scopeVerticalZoom: number;
 	scopeTriggerLevel: number;
 	uiScale: UiScale;
 };
 
-export type LabUiAction =
+export type Pd101UiAction =
 	| { type: "setScopeCycles"; value: number }
 	| { type: "setScopeVerticalZoom"; value: number }
 	| { type: "setScopeTriggerLevel"; value: number }
 	| { type: "setUiScale"; value: UiScale };
 
-export function createInitialLabUiState(): LabUiState {
+export function createInitialPd101UiState(): Pd101UiState {
 	return {
 		scopeCycles: 2,
 		scopeVerticalZoom: 1,
@@ -25,10 +25,13 @@ export function createInitialLabUiState(): LabUiState {
 }
 
 export function isUiScale(value: number): value is UiScale {
-	return LAB_UI_SCALE_OPTIONS.includes(value as UiScale);
+	return PD101_UI_SCALE_OPTIONS.includes(value as UiScale);
 }
 
-export function labUiReducer(state: LabUiState, action: LabUiAction): LabUiState {
+export function pd101UiReducer(
+	state: Pd101UiState,
+	action: Pd101UiAction,
+): Pd101UiState {
 	switch (action.type) {
 		case "setScopeCycles":
 			return { ...state, scopeCycles: action.value };

--- a/packages/cz-explorer/src/routes/router.tsx
+++ b/packages/cz-explorer/src/routes/router.tsx
@@ -85,7 +85,7 @@ const duplicatesRoute = createRoute({
 
 const visualizerRoute = createRoute({
 	getParentRoute: () => rootRoute,
-	path: "/lab",
+	path: "/pd101",
 	component: VisualizerPage,
 });
 


### PR DESCRIPTION
## Summary
- rename route path from `/lab` to `/pd101`
- rename shared reducer module path and symbols from `lab*` to `pd101*`
- update PD101 library query key terminology from `lab-library` to `pd101-library`

## Notes
- keeps the visible header wording as requested
- focused terminology cleanup phase only