### PR TITLE
Phase 03: Centralize pd101 library query key constant

### DIFF
--- a/packages/cz-explorer/src/components/PhaseDistortionVisualizer.tsx
+++ b/packages/cz-explorer/src/components/PhaseDistortionVisualizer.tsx
@@ -4,6 +4,7 @@ import {
 	createInitialPd101UiState,
 	pd101UiReducer,
 } from "@/features/pd101/state/pd101UiState";
+import { PD101_LIBRARY_QUERY_KEY } from "@/features/pd101/constants";
 import { decodeCzPatch } from "@/lib/midi/czSysexDecoder";
 import { fetchPresetData, type Preset } from "@/lib/presets/presetManager";
 import { convertDecodedPatchToSynthPreset } from "@/lib/synth/czPresetConverter";
@@ -560,7 +561,7 @@ export default function PhaseDistortionVisualizer() {
 	}, []);
 
 	const { data: libraryPresets = [] } = useQuery({
-		queryKey: ["presets", "pd101-library"],
+		queryKey: PD101_LIBRARY_QUERY_KEY,
 		queryFn: async () => {
 			const result = await fetchPresetData(
 				0,

--- a/packages/cz-explorer/src/features/pd101/constants.ts
+++ b/packages/cz-explorer/src/features/pd101/constants.ts
@@ -1,0 +1,1 @@
+export const PD101_LIBRARY_QUERY_KEY = ["presets", "pd101-library"] as const;


### PR DESCRIPTION
## Summary
- add a shared pd101 constants module for query-key values
- replace inline `pd101-library` query key literal in the visualizer with a shared constant

## Notes
- keeps current pd101 naming and does not reintroduce `/lab` route terminology

## Stacking
- base branch: `phase-02-pd101-ui-reducer-integration`
- head branch: `phase-03-pd101-query-key-constants`