### PR TITLE
ci: run plugin and desktop builds on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
@@ -104,7 +102,6 @@ jobs:
 
   build-plugins:
     name: Build plugins (${{ matrix.platform }})
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:
@@ -128,7 +125,6 @@ jobs:
 
   build-desktop:
     name: Build desktop app (${{ matrix.os }})
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- remove `main` branch filters from workflow triggers
- remove main-only `if` guards from `build-plugins` and `build-desktop`
- keep migration job main-only as-is

## Result
- plugin and desktop build jobs now run for pushes and pull requests on all branches