### PR TITLE
test(cosmo-pd101): add webview and Rust coverage

### DIFF
--- a/packages/cosmo-pd101/src/lib.rs
+++ b/packages/cosmo-pd101/src/lib.rs
@@ -675,14 +675,14 @@ impl CzParameters {
 #[allow(dead_code, unused_variables, clippy::items_after_statements)]
 fn _assert_synth_params_coverage(p: SynthParams) {
     use cosmo_synth_engine::params::{
-        ChorusParams, CzLineParams, DelayParams, FilterParams, LineParams, LfoParams,
+        ChorusParams, CzLineParams, DelayParams, FilterParams, LfoParams, LineParams,
         PortamentoParams, ReverbParams, VibratoParams,
     };
 
     let SynthParams {
         line_select,
         mod_mode,
-        ring_gain: _ring_gain,             // intentionally not a VST param
+        ring_gain: _ring_gain, // intentionally not a VST param
         octave,
         line1,
         line2,
@@ -690,7 +690,7 @@ fn _assert_synth_params_coverage(p: SynthParams) {
         int_pm_ratio,
         ext_pm_amount,
         pm_pre,
-        frequency: _frequency,             // set by the MIDI layer, not a VST param
+        frequency: _frequency, // set by the MIDI layer, not a VST param
         volume,
         poly_mode,
         legato,
@@ -702,14 +702,25 @@ fn _assert_synth_params_coverage(p: SynthParams) {
         portamento,
         lfo,
         filter,
-        pitch_bend_range: _pitch_bend_range,               // not yet a VST param
+        pitch_bend_range: _pitch_bend_range, // not yet a VST param
         mod_wheel_vibrato_depth: _mod_wheel_vibrato_depth, // not yet a VST param
-        mod_matrix: _mod_matrix,                           // not yet a VST param
+        mod_matrix: _mod_matrix,             // not yet a VST param
     } = p;
 
-    let ChorusParams { rate: _cho_rate, depth: _cho_depth, mix: _cho_mix } = chorus;
-    let DelayParams { time: _del_time, feedback: _del_fb, mix: _del_mix } = delay;
-    let ReverbParams { size: _rev_size, mix: _rev_mix } = reverb;
+    let ChorusParams {
+        rate: _cho_rate,
+        depth: _cho_depth,
+        mix: _cho_mix,
+    } = chorus;
+    let DelayParams {
+        time: _del_time,
+        feedback: _del_fb,
+        mix: _del_mix,
+    } = delay;
+    let ReverbParams {
+        size: _rev_size,
+        mix: _rev_mix,
+    } = reverb;
     let VibratoParams {
         enabled: _vib_enabled,
         waveform: _vib_waveform,
@@ -792,8 +803,17 @@ fn _assert_synth_params_coverage(p: SynthParams) {
 
     // Suppress unused-variable warnings for fields that ARE mapped to VST params.
     let _ = (
-        line_select, mod_mode, octave, int_pm_amount, int_pm_ratio, ext_pm_amount,
-        pm_pre, volume, poly_mode, legato, velocity_target,
+        line_select,
+        mod_mode,
+        octave,
+        int_pm_amount,
+        int_pm_ratio,
+        ext_pm_amount,
+        pm_pre,
+        volume,
+        poly_mode,
+        legato,
+        velocity_target,
     );
 }
 
@@ -900,9 +920,7 @@ struct CzWebViewHandler {
 }
 
 impl CzWebViewHandler {
-    fn parse_set_envelope_args(
-        args: &[serde_json::Value],
-    ) -> Result<(&str, StepEnvData), String> {
+    fn parse_set_envelope_args(args: &[serde_json::Value]) -> Result<(&str, StepEnvData), String> {
         if args.len() == 2 {
             let envelope_id = args[0]
                 .as_str()
@@ -996,7 +1014,10 @@ impl WebViewHandler for CzWebViewHandler {
         method: &str,
         args: &[serde_json::Value],
     ) -> Result<serde_json::Value, String> {
-        append_log(&format!("webview invoke method={method} args={}", args.len()));
+        append_log(&format!(
+            "webview invoke method={method} args={}",
+            args.len()
+        ));
 
         match method {
             "setEnvelope" => {
@@ -1290,3 +1311,98 @@ impl Processor for CzProcessor {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmo_synth_engine::params::EnvStep;
+    use serde_json::json;
+
+    fn make_env(
+        level: f32,
+        rate: u8,
+        step_count: usize,
+        sustain_step: usize,
+        loop_: bool,
+    ) -> StepEnvData {
+        let mut env = StepEnvData::default();
+        env.steps[0] = EnvStep { level, rate };
+        env.step_count = step_count;
+        env.sustain_step = sustain_step;
+        env.loop_ = loop_;
+        env
+    }
+
+    #[test]
+    fn scope_frame_keeps_samples_in_chronological_order_after_wrap() {
+        let mut frame = ScopeFrame::default();
+        let initial: Vec<f32> = (0..SCOPE_CAPACITY).map(|sample| sample as f32).collect();
+        frame.push_block(&initial, 48_000.0, 110.0);
+        frame.push_block(&[4096.0, 4097.0, 4098.0], 48_000.0, 220.0);
+
+        let linear = frame.to_linear();
+        assert_eq!(linear.len(), SCOPE_CAPACITY);
+        assert_eq!(&linear[..3], &[3.0, 4.0, 5.0]);
+        assert_eq!(&linear[linear.len() - 3..], &[4096.0, 4097.0, 4098.0]);
+        assert_eq!(frame.sample_rate, 48_000.0);
+        assert_eq!(frame.hz, 220.0);
+    }
+
+    #[test]
+    fn envelope_state_applies_updates_and_serializes_expected_keys() {
+        let mut state = EnvelopeState {
+            l1_dco: StepEnvData::default(),
+            l1_dcw: StepEnvData::default(),
+            l1_dca: StepEnvData::default(),
+            l2_dco: StepEnvData::default(),
+            l2_dcw: StepEnvData::default(),
+            l2_dca: StepEnvData::default(),
+        };
+        let updated = make_env(0.25, 33, 6, 4, true);
+
+        state.set("l1_dco", updated.clone()).unwrap();
+
+        let mut params = SynthParams::default();
+        state.apply_to(&mut params);
+
+        assert_eq!(params.line1.dco_env.step_count, 6);
+        assert_eq!(params.line1.dco_env.sustain_step, 4);
+        assert!(params.line1.dco_env.loop_);
+        assert_eq!(params.line1.dco_env.steps[0].level, 0.25);
+        assert_eq!(params.line1.dco_env.steps[0].rate, 33);
+        assert_eq!(state.to_json()["l1_dco"]["stepCount"], json!(6));
+        assert_eq!(state.to_json()["l1_dco"]["sustainStep"], json!(4));
+        assert_eq!(state.to_json()["l1_dco"]["loop"], json!(true));
+        assert!(state.set("missing", StepEnvData::default()).is_err());
+    }
+
+    #[test]
+    fn algo_controls_state_applies_per_line_values_and_rejects_unknown_lines() {
+        let mut state = AlgoControlsState::default();
+        let line1 = vec![AlgoControlValueV1 {
+            id: "warp".to_string(),
+            value: 0.25,
+        }];
+        let line2 = vec![AlgoControlValueV1 {
+            id: "bias".to_string(),
+            value: 0.75,
+        }];
+
+        state.set(1, line1).unwrap();
+        state.set(2, line2).unwrap();
+
+        let mut params = SynthParams::default();
+        state.apply_to(&mut params);
+
+        let applied_line1 = params.line1.algo_controls.as_ref().unwrap();
+        let applied_line2 = params.line2.algo_controls.as_ref().unwrap();
+        assert_eq!(applied_line1.len(), 1);
+        assert_eq!(applied_line1[0].id, "warp");
+        assert_eq!(applied_line1[0].value, 0.25);
+        assert_eq!(applied_line2.len(), 1);
+        assert_eq!(applied_line2[0].id, "bias");
+        assert_eq!(applied_line2[0].value, 0.75);
+        assert_eq!(state.to_json()["line1"][0]["id"], json!("warp"));
+        assert_eq!(state.to_json()["line2"][0]["value"], json!(0.75));
+        assert!(state.set(3, Vec::new()).is_err());
+    }
+}

--- a/packages/cosmo-pd101/webview/e2e/plugin-presets.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-presets.spec.ts
@@ -1,10 +1,23 @@
 import { expect, test } from "@playwright/test";
 import { setupPluginPage } from "./helpers/pluginBridge";
 
+const LATEST_RELEASE_URL =
+	"https://api.github.com/repos/fpbrault/cosmo-pd/releases/latest";
+
 test.beforeEach(async ({ page }) => {
 	await page.addInitScript(() => {
 		localStorage.clear();
 		sessionStorage.clear();
+	});
+	await page.route(LATEST_RELEASE_URL, async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				tag_name: "v0.0.0",
+				html_url: "https://github.com/fpbrault/cosmo-pd/releases/tag/v0.0.0",
+			}),
+		});
 	});
 	await setupPluginPage(page);
 });

--- a/packages/cosmo-pd101/webview/e2e/plugin-presets.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-presets.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { setupPluginPage } from "./helpers/pluginBridge";
+
+test.beforeEach(async ({ page }) => {
+	await page.addInitScript(() => {
+		localStorage.clear();
+		sessionStorage.clear();
+	});
+	await setupPluginPage(page);
+});
+
+test.describe("Preset management", () => {
+	test("saves, renames, and deletes a local preset", async ({ page }) => {
+		await page.getByRole("button", { name: /^preset /i }).click();
+
+		const saveInput = page.getByPlaceholder("Preset name…");
+		await saveInput.fill("E2E Patch");
+		await page.getByRole("button", { name: "Save" }).click();
+
+		await expect(page.getByRole("button", { name: "E2E Patch local" })).toBeVisible();
+		await expect
+			.poll(() => page.evaluate(() => localStorage.getItem("cz101-preset-E2E Patch")))
+			.not.toBeNull();
+
+		await page.getByTitle("Rename preset").click();
+		const renameInput = page.getByRole("textbox").nth(1);
+		await renameInput.fill("Renamed Patch");
+		await renameInput.press("Enter");
+
+		await expect(page.getByRole("button", { name: "Renamed Patch local" })).toBeVisible();
+		await expect
+			.poll(
+				() =>
+					page.evaluate(() => ({
+						original: localStorage.getItem("cz101-preset-E2E Patch"),
+						renamed: localStorage.getItem("cz101-preset-Renamed Patch"),
+					})),
+			)
+			.toEqual({ original: null, renamed: expect.any(String) });
+
+		await page.getByTitle("Delete preset").click();
+		await expect(page.getByRole("button", { name: "Renamed Patch local" })).toHaveCount(0);
+		await expect
+			.poll(
+				() => page.evaluate(() => localStorage.getItem("cz101-preset-Renamed Patch")),
+			)
+			.toBeNull();
+	});
+});

--- a/packages/cosmo-pd101/webview/e2e/plugin-update-check.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-update-check.spec.ts
@@ -10,6 +10,7 @@ test.describe("Plugin update checks", () => {
 	}) => {
 		await page.addInitScript(() => {
 			sessionStorage.clear();
+			sessionStorage.setItem("cosmo-pd101.update.latestNotified", "9.9.9");
 		});
 
 		await page.route(LATEST_RELEASE_URL, async (route) => {

--- a/packages/cosmo-pd101/webview/e2e/plugin-update-check.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-update-check.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { setupPluginPage } from "./helpers/pluginBridge";
+
+const LATEST_RELEASE_URL =
+	"https://api.github.com/repos/fpbrault/cosmo-pd/releases/latest";
+
+test.describe("Plugin update checks", () => {
+	test("shows and dismisses the release modal when a newer version is available", async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			sessionStorage.clear();
+		});
+
+		await page.route(LATEST_RELEASE_URL, async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify({
+					tag_name: "v9.9.9",
+					html_url: "https://github.com/fpbrault/cosmo-pd/releases/tag/v9.9.9",
+				}),
+			});
+		});
+
+		await setupPluginPage(page);
+		await page.getByRole("button", { name: /check updates/i }).click();
+
+		await expect(page.getByText("New Version Available")).toBeVisible();
+		await expect(page.getByText(/version v9\.9\.9 is available/i)).toBeVisible();
+		await expect(page.getByRole("link", { name: "View Release" })).toHaveAttribute(
+			"href",
+			"https://github.com/fpbrault/cosmo-pd/releases/tag/v9.9.9",
+		);
+
+		await page.getByRole("button", { name: "Later" }).click();
+		await expect(page.getByText("New Version Available")).toBeHidden();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/App.test.tsx
+++ b/packages/cosmo-pd101/webview/src/App.test.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+
+const mockEnsureBeamerLegacyBridge = vi.hoisted(() => vi.fn());
+const mockCheckForPluginUpdate = vi.hoisted(() => vi.fn());
+
+vi.mock("./PluginPage", () => ({
+	default: ({ headerExtra }: { headerExtra?: ReactNode }) => (
+		<div data-testid="plugin-page">{headerExtra}</div>
+	),
+}));
+
+vi.mock("./lib/beamerLegacyBridge", () => ({
+	ensureBeamerLegacyBridge: mockEnsureBeamerLegacyBridge,
+}));
+
+vi.mock("./update/checkPluginUpdate", () => ({
+	checkForPluginUpdate: mockCheckForPluginUpdate,
+}));
+
+describe("App", () => {
+	beforeEach(() => {
+		mockEnsureBeamerLegacyBridge.mockReset();
+		mockEnsureBeamerLegacyBridge.mockReturnValue(true);
+		mockCheckForPluginUpdate.mockReset();
+		mockCheckForPluginUpdate.mockResolvedValue(null);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("polls for the legacy bridge until it becomes ready", () => {
+		vi.useFakeTimers();
+		mockEnsureBeamerLegacyBridge
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(true);
+
+		const { unmount } = render(<App />);
+		expect(mockEnsureBeamerLegacyBridge).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			vi.advanceTimersByTime(50);
+		});
+
+		expect(mockEnsureBeamerLegacyBridge).toHaveBeenCalledTimes(2);
+		unmount();
+	});
+
+	it("shows and dismisses an available update from the initial check", async () => {
+		mockCheckForPluginUpdate.mockResolvedValueOnce({
+			currentVersion: "0.1.0",
+			latestVersion: "0.2.0",
+			releaseUrl: "https://example.com/releases/v0.2.0",
+		});
+
+		render(<App />);
+
+		expect(await screen.findByText("New Version Available")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Later" }));
+		await waitFor(() => {
+			expect(screen.queryByText("New Version Available")).not.toBeInTheDocument();
+		});
+	});
+
+	it("shows an up-to-date message when a manual check finds no update", async () => {
+		mockCheckForPluginUpdate
+			.mockResolvedValueOnce(null)
+			.mockResolvedValueOnce(null);
+
+		render(<App />);
+		fireEvent.click(screen.getByRole("button", { name: /check updates/i }));
+
+		await waitFor(() => {
+			expect(mockCheckForPluginUpdate).toHaveBeenNthCalledWith(2, {
+				manual: true,
+			});
+		});
+		expect(await screen.findByText("You are up to date.")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/preset/PresetNavigator.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/preset/PresetNavigator.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LibraryPreset } from "@/features/synth/types/libraryPreset";
+import type { PresetEntry } from "@/features/synth/types/presetEntry";
+import PresetNavigator from "./PresetNavigator";
+
+const libraryPreset: LibraryPreset = {
+	id: "library-1",
+	name: "Archive Pad",
+};
+
+const entries: PresetEntry[] = [
+	{
+		id: "builtin:factory-bass",
+		label: "Factory Bass",
+		type: "builtin",
+	},
+	{
+		id: "local:local-keys",
+		label: "Local Keys",
+		type: "local",
+	},
+	{
+		id: "library:archive-pad",
+		label: libraryPreset.name,
+		type: "library",
+		preset: libraryPreset,
+	},
+];
+
+function createProps() {
+	return {
+		allEntries: entries,
+		activeEntryId: null,
+		activePresetName: "Current State",
+		onLoadLocal: vi.fn(),
+		onLoadLibrary: vi.fn(),
+		onLoadBuiltin: vi.fn(),
+		onStepPreset: vi.fn(),
+		onSavePreset: vi.fn(),
+		onDeletePreset: vi.fn(),
+		onRenamePreset: vi.fn(),
+		onExportPreset: vi.fn(),
+		onExportCurrentState: vi.fn(),
+		onImportPreset: vi.fn(),
+		onInitPreset: vi.fn(),
+	};
+}
+
+function openPresetPanel() {
+	fireEvent.click(screen.getByRole("button", { name: /^preset /i }));
+}
+
+describe("PresetNavigator", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("routes preset selection to the matching callbacks", () => {
+		const props = createProps();
+		const { rerender } = render(<PresetNavigator {...props} />);
+
+		openPresetPanel();
+		fireEvent.click(screen.getByRole("button", { name: /factory bass/i }));
+		expect(props.onLoadBuiltin).toHaveBeenCalledWith("Factory Bass");
+		expect(screen.queryByText("Preset List")).not.toBeInTheDocument();
+
+		rerender(<PresetNavigator {...props} activePresetName="Factory Bass" />);
+		openPresetPanel();
+		fireEvent.click(screen.getByRole("button", { name: /local keys/i }));
+		expect(props.onLoadLocal).toHaveBeenCalledWith("Local Keys");
+
+		rerender(<PresetNavigator {...props} activePresetName="Local Keys" />);
+		openPresetPanel();
+		fireEvent.click(screen.getByRole("button", { name: /archive pad/i }));
+		expect(props.onLoadLibrary).toHaveBeenCalledWith(libraryPreset);
+	});
+
+	it("trims save and export names before invoking callbacks", () => {
+		const props = createProps();
+		render(<PresetNavigator {...props} />);
+
+		openPresetPanel();
+		const saveInput = screen.getByPlaceholderText("Preset name…");
+		fireEvent.change(saveInput, { target: { value: "  New Patch  " } });
+		fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+		expect(props.onSavePreset).toHaveBeenCalledWith("New Patch");
+		expect(saveInput).toHaveValue("");
+
+		fireEvent.change(saveInput, { target: { value: "  Snapshot  " } });
+		fireEvent.click(screen.getByRole("button", { name: "Export" }));
+		expect(props.onExportCurrentState).toHaveBeenCalledWith("Snapshot");
+	});
+
+	it("commits inline renames with trimmed values and ignores cancelled edits", () => {
+		const props = createProps();
+		render(<PresetNavigator {...props} />);
+
+		openPresetPanel();
+		fireEvent.click(screen.getByTitle("Rename preset"));
+
+		const renameInput = screen.getByDisplayValue("Local Keys");
+		fireEvent.change(renameInput, { target: { value: "  Renamed Keys  " } });
+		fireEvent.keyDown(renameInput, { key: "Enter" });
+		expect(props.onRenamePreset).toHaveBeenCalledWith(
+			"Local Keys",
+			"Renamed Keys",
+		);
+
+		fireEvent.click(screen.getByTitle("Rename preset"));
+		const cancelledInput = screen.getByDisplayValue("Local Keys");
+		fireEvent.change(cancelledInput, { target: { value: "Ignored Name" } });
+		fireEvent.keyDown(cancelledInput, { key: "Escape" });
+		expect(props.onRenamePreset).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows an import error when the imported JSON is rejected", async () => {
+		const props = createProps();
+		props.onImportPreset.mockImplementation(() => {
+			throw new Error("bad preset");
+		});
+
+		class MockFileReader {
+			public onload: ((event: ProgressEvent<FileReader>) => void) | null = null;
+
+			readAsText() {
+				this.onload?.({
+					target: { result: '{"invalid":true}' },
+				} as ProgressEvent<FileReader>);
+			}
+		}
+
+		vi.stubGlobal("FileReader", MockFileReader);
+
+		const { container } = render(<PresetNavigator {...props} />);
+		openPresetPanel();
+
+		const fileInput = container.querySelector('input[type="file"]');
+		if (!(fileInput instanceof HTMLInputElement)) {
+			throw new Error("expected hidden file input");
+		}
+
+		const file = new File(["{}"], "bad-patch.json", {
+			type: "application/json",
+		});
+		fireEvent.change(fileInput, { target: { files: [file] } });
+
+		await waitFor(() => {
+			expect(props.onImportPreset).toHaveBeenCalledWith(
+				'{"invalid":true}',
+				"bad-patch",
+			);
+		});
+		expect(screen.getByText("Invalid preset file.")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/update/checkPluginUpdate.test.ts
+++ b/packages/cosmo-pd101/webview/src/update/checkPluginUpdate.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { checkForPluginUpdate } from "./checkPluginUpdate";
+
+const SESSION_KEY = "cosmo-pd101.update.latestNotified";
+const fetchMock = vi.fn<typeof fetch>();
+
+function mockLatestRelease(payload: Record<string, unknown>, ok = true) {
+	fetchMock.mockResolvedValue({
+		ok,
+		json: async () => payload,
+	} as Response);
+}
+
+describe("checkForPluginUpdate", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		fetchMock.mockReset();
+		vi.stubGlobal("fetch", fetchMock);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("returns update info for a newer stable release and stores the notified version", async () => {
+		mockLatestRelease({
+			tag_name: "v1.2.3",
+			html_url: "https://example.com/releases/v1.2.3",
+		});
+
+		await expect(checkForPluginUpdate()).resolves.toEqual({
+			currentVersion: "0.0.0",
+			latestVersion: "1.2.3",
+			releaseUrl: "https://example.com/releases/v1.2.3",
+			forcedByEnv: false,
+		});
+		expect(sessionStorage.getItem(SESSION_KEY)).toBe("1.2.3");
+	});
+
+	it("suppresses duplicate automatic notifications for the same release", async () => {
+		mockLatestRelease({
+			tag_name: "v1.2.3",
+			html_url: "https://example.com/releases/v1.2.3",
+		});
+		await expect(checkForPluginUpdate()).resolves.not.toBeNull();
+
+		mockLatestRelease({
+			tag_name: "v1.2.3",
+			html_url: "https://example.com/releases/v1.2.3",
+		});
+		await expect(checkForPluginUpdate()).resolves.toBeNull();
+	});
+
+	it("allows manual checks to bypass the duplicate-notification guard", async () => {
+		sessionStorage.setItem(SESSION_KEY, "1.2.3");
+		mockLatestRelease({
+			tag_name: "v1.2.3",
+			html_url: "https://example.com/releases/v1.2.3",
+		});
+
+		await expect(checkForPluginUpdate({ manual: true })).resolves.toEqual({
+			currentVersion: "0.0.0",
+			latestVersion: "1.2.3",
+			releaseUrl: "https://example.com/releases/v1.2.3",
+			forcedByEnv: false,
+		});
+	});
+
+	it("ignores prerelease payloads", async () => {
+		mockLatestRelease({
+			tag_name: "v9.9.9-beta.1",
+			html_url: "https://example.com/releases/v9.9.9-beta.1",
+			prerelease: true,
+		});
+
+		await expect(checkForPluginUpdate()).resolves.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- add webview component and update-check unit coverage for App, PresetNavigator, and plugin update logic
- add Playwright coverage for preset lifecycle and plugin release update flows
- add Rust unit tests for scope buffering and helper state application in cosmo-pd101

## Validation
- bun run build
- bun run test:all
- bun run test:e2e
- cargo fmt --all --check
- cargo clippy -p cosmo-pd101 --all-targets
- cargo test -p cosmo-pd101 --lib