### PR TITLE
test: extend plugin bridge and payload parser coverage

### DIFF
--- a/packages/cosmo-pd101/src/lib.rs
+++ b/packages/cosmo-pd101/src/lib.rs
@@ -675,14 +675,14 @@ impl CzParameters {
 #[allow(dead_code, unused_variables, clippy::items_after_statements)]
 fn _assert_synth_params_coverage(p: SynthParams) {
     use cosmo_synth_engine::params::{
-        ChorusParams, CzLineParams, DelayParams, FilterParams, LineParams, LfoParams,
+        ChorusParams, CzLineParams, DelayParams, FilterParams, LfoParams, LineParams,
         PortamentoParams, ReverbParams, VibratoParams,
     };
 
     let SynthParams {
         line_select,
         mod_mode,
-        ring_gain: _ring_gain,             // intentionally not a VST param
+        ring_gain: _ring_gain, // intentionally not a VST param
         octave,
         line1,
         line2,
@@ -690,7 +690,7 @@ fn _assert_synth_params_coverage(p: SynthParams) {
         int_pm_ratio,
         ext_pm_amount,
         pm_pre,
-        frequency: _frequency,             // set by the MIDI layer, not a VST param
+        frequency: _frequency, // set by the MIDI layer, not a VST param
         volume,
         poly_mode,
         legato,
@@ -702,14 +702,25 @@ fn _assert_synth_params_coverage(p: SynthParams) {
         portamento,
         lfo,
         filter,
-        pitch_bend_range: _pitch_bend_range,               // not yet a VST param
+        pitch_bend_range: _pitch_bend_range, // not yet a VST param
         mod_wheel_vibrato_depth: _mod_wheel_vibrato_depth, // not yet a VST param
-        mod_matrix: _mod_matrix,                           // not yet a VST param
+        mod_matrix: _mod_matrix,             // not yet a VST param
     } = p;
 
-    let ChorusParams { rate: _cho_rate, depth: _cho_depth, mix: _cho_mix } = chorus;
-    let DelayParams { time: _del_time, feedback: _del_fb, mix: _del_mix } = delay;
-    let ReverbParams { size: _rev_size, mix: _rev_mix } = reverb;
+    let ChorusParams {
+        rate: _cho_rate,
+        depth: _cho_depth,
+        mix: _cho_mix,
+    } = chorus;
+    let DelayParams {
+        time: _del_time,
+        feedback: _del_fb,
+        mix: _del_mix,
+    } = delay;
+    let ReverbParams {
+        size: _rev_size,
+        mix: _rev_mix,
+    } = reverb;
     let VibratoParams {
         enabled: _vib_enabled,
         waveform: _vib_waveform,
@@ -792,8 +803,17 @@ fn _assert_synth_params_coverage(p: SynthParams) {
 
     // Suppress unused-variable warnings for fields that ARE mapped to VST params.
     let _ = (
-        line_select, mod_mode, octave, int_pm_amount, int_pm_ratio, ext_pm_amount,
-        pm_pre, volume, poly_mode, legato, velocity_target,
+        line_select,
+        mod_mode,
+        octave,
+        int_pm_amount,
+        int_pm_ratio,
+        ext_pm_amount,
+        pm_pre,
+        volume,
+        poly_mode,
+        legato,
+        velocity_target,
     );
 }
 
@@ -900,9 +920,7 @@ struct CzWebViewHandler {
 }
 
 impl CzWebViewHandler {
-    fn parse_set_envelope_args(
-        args: &[serde_json::Value],
-    ) -> Result<(&str, StepEnvData), String> {
+    fn parse_set_envelope_args(args: &[serde_json::Value]) -> Result<(&str, StepEnvData), String> {
         if args.len() == 2 {
             let envelope_id = args[0]
                 .as_str()
@@ -996,7 +1014,10 @@ impl WebViewHandler for CzWebViewHandler {
         method: &str,
         args: &[serde_json::Value],
     ) -> Result<serde_json::Value, String> {
-        append_log(&format!("webview invoke method={method} args={}", args.len()));
+        append_log(&format!(
+            "webview invoke method={method} args={}",
+            args.len()
+        ));
 
         match method {
             "setEnvelope" => {
@@ -1290,3 +1311,125 @@ impl Processor for CzProcessor {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cosmo_synth_engine::params::{ModDestination, ModSource};
+    use serde_json::json;
+
+    #[test]
+    fn parse_set_envelope_args_accepts_wrapped_and_unwrapped_payloads() {
+        let unwrapped_args = [
+            json!("l1_dco"),
+            json!({
+                "steps": [{ "level": 1.0, "rate": 10.0 }],
+                "sustainStep": 0,
+                "stepCount": 1,
+                "loop": false,
+            }),
+        ];
+        let unwrapped = CzWebViewHandler::parse_set_envelope_args(&unwrapped_args)
+            .expect("unwrapped setEnvelope payload should parse");
+        assert_eq!(unwrapped.0, "l1_dco");
+        assert_eq!(unwrapped.1.step_count, 1);
+        assert_eq!(unwrapped.1.steps[0].rate, 10);
+
+        let wrapped_args = [json!({
+            "envelopeId": "l2_dca",
+            "data": {
+                "steps": [{ "level": 0.5, "rate": 22.0 }],
+                "sustainStep": 0,
+                "stepCount": 1,
+                "loop": true,
+            }
+        })];
+        let wrapped = CzWebViewHandler::parse_set_envelope_args(&wrapped_args)
+            .expect("wrapped setEnvelope payload should parse");
+        assert_eq!(wrapped.0, "l2_dca");
+        assert!(wrapped.1.loop_);
+        assert_eq!(wrapped.1.steps[0].level, 0.5);
+    }
+
+    #[test]
+    fn parse_set_algo_controls_args_accepts_wrapped_and_unwrapped_payloads() {
+        let unwrapped = CzWebViewHandler::parse_set_algo_controls_args(&[
+            json!(2),
+            json!([{ "id": "curve", "value": 0.75 }]),
+        ])
+        .expect("unwrapped setAlgoControls payload should parse");
+        assert_eq!(unwrapped.0, 2);
+        assert_eq!(unwrapped.1.len(), 1);
+        assert_eq!(unwrapped.1[0].id, "curve");
+        assert_eq!(unwrapped.1[0].value, 0.75);
+
+        let wrapped = CzWebViewHandler::parse_set_algo_controls_args(&[json!({
+            "lineId": 1,
+            "algo_controls": [{ "id": "spread", "value": 0.25 }]
+        })])
+        .expect("wrapped setAlgoControls payload should parse");
+        assert_eq!(wrapped.0, 1);
+        assert_eq!(wrapped.1.len(), 1);
+        assert_eq!(wrapped.1[0].id, "spread");
+        assert_eq!(wrapped.1[0].value, 0.25);
+    }
+
+    #[test]
+    fn parse_set_mod_matrix_args_accepts_raw_and_wrapped_payloads() {
+        let raw = CzWebViewHandler::parse_set_mod_matrix_args(&[json!({
+            "routes": [{
+                "source": "lfo1",
+                "destination": "volume",
+                "amount": 0.5,
+                "enabled": true,
+            }]
+        })])
+        .expect("raw setModMatrix payload should parse");
+        assert_eq!(raw.routes.len(), 1);
+        assert_eq!(raw.routes[0].source, ModSource::Lfo1);
+        assert_eq!(raw.routes[0].destination, ModDestination::Volume);
+        assert_eq!(raw.routes[0].amount, 0.5);
+        assert!(raw.routes[0].enabled);
+
+        let wrapped = CzWebViewHandler::parse_set_mod_matrix_args(&[json!({
+            "modMatrix": {
+                "routes": [{
+                    "source": "modWheel",
+                    "destination": "line1AlgoParam2",
+                    "amount": -0.25,
+                    "enabled": false,
+                }]
+            }
+        })])
+        .expect("wrapped setModMatrix payload should parse");
+        assert_eq!(wrapped.routes.len(), 1);
+        assert_eq!(wrapped.routes[0].source, ModSource::ModWheel);
+        assert_eq!(
+            wrapped.routes[0].destination,
+            ModDestination::Line1AlgoParam2
+        );
+        assert_eq!(wrapped.routes[0].amount, -0.25);
+        assert!(!wrapped.routes[0].enabled);
+    }
+
+    #[test]
+    fn parse_set_mod_matrix_args_rejects_missing_wrapped_payloads() {
+        let error = CzWebViewHandler::parse_set_mod_matrix_args(&[
+            json!({ "unexpected": { "routes": [] } }),
+            json!({}),
+        ])
+        .expect_err("invalid wrapped setModMatrix payload should fail");
+        assert!(error.contains("missing mod_matrix"));
+    }
+
+    #[test]
+    fn map_waveform_normalizes_double_sine_to_multi_sine() {
+        assert_eq!(
+            CzParameters::map_waveform(Waveform::DoubleSine),
+            cosmo_synth_engine::params::CzWaveform::MultiSine
+        );
+        assert_eq!(
+            CzParameters::map_waveform(Waveform::MultiSine),
+            cosmo_synth_engine::params::CzWaveform::MultiSine
+        );
+    }
+}

--- a/packages/cosmo-pd101/webview/src/App.test.tsx
+++ b/packages/cosmo-pd101/webview/src/App.test.tsx
@@ -1,0 +1,65 @@
+import { act, cleanup, render } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+import { __resetBeamerLegacyBridgeForTests } from "./lib/beamerLegacyBridge";
+
+vi.mock("./PluginPage", () => ({
+	default: ({ headerExtra }: { headerExtra?: React.ReactNode }) => (
+		<div data-testid="plugin-page">{headerExtra}</div>
+	),
+}));
+
+vi.mock("./update/checkPluginUpdate", () => ({
+	checkForPluginUpdate: vi.fn().mockResolvedValue(null),
+}));
+
+function createRuntime() {
+	return {
+		_onInit: vi.fn(),
+		_onParams: vi.fn(),
+		invoke: vi.fn().mockResolvedValue({
+			samples: [],
+			sampleRate: 44_100,
+			hz: 220,
+		}),
+		params: {
+			info: () => undefined,
+			beginEdit: vi.fn(),
+			set: vi.fn(),
+			endEdit: vi.fn(),
+		},
+	};
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	__resetBeamerLegacyBridgeForTests();
+	window.__BEAMER__ = undefined;
+	vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+	vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	cleanup();
+	vi.runOnlyPendingTimers();
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	__resetBeamerLegacyBridgeForTests();
+	window.__BEAMER__ = undefined;
+});
+
+describe("App bridge polling", () => {
+	it("installs the bridge after the runtime appears later", async () => {
+		render(<App />);
+		expect(window.ipc).toBeUndefined();
+
+		window.__BEAMER__ = createRuntime();
+		act(() => {
+			vi.advanceTimersByTime(60);
+		});
+		await Promise.resolve();
+
+		expect(window.ipc).toBeDefined();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/hooks/usePluginParamBridge.test.ts
+++ b/packages/cosmo-pd101/webview/src/hooks/usePluginParamBridge.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+	CZ_WAVEFORM_IDX,
+	mapAlgoKeyToId,
+	mapAlgoKeyToWaveform,
+	mapInboundOptionalWarpAlgoId,
+	mapInboundWarpAlgoId,
+	mapInboundWaveformIndex,
+} from "./usePluginParamBridge";
+
+describe("usePluginParamBridge mapping helpers", () => {
+	it("maps waveform algos to cz101 with the waveform index carried separately", () => {
+		expect(mapAlgoKeyToId("saw")).toBe(0);
+		expect(mapAlgoKeyToWaveform("sawPulse", "square")).toBe(
+			CZ_WAVEFORM_IDX.sawPulse,
+		);
+	});
+
+	it("uses the current slot waveform when the algo is cz101", () => {
+		expect(mapAlgoKeyToId("cz101")).toBe(0);
+		expect(mapAlgoKeyToWaveform("cz101", "pulse2")).toBe(
+			CZ_WAVEFORM_IDX.pulse2,
+		);
+	});
+
+	it("forces sine-carrier waveform for non-CZ warp algos", () => {
+		expect(mapAlgoKeyToId("bend")).toBe(1);
+		expect(mapAlgoKeyToWaveform("bend", "pulse2")).toBe(0);
+	});
+
+	it("maps DoubleSine and MultiSine indices back to multiSine", () => {
+		expect(mapInboundWaveformIndex(5)).toBe("multiSine");
+		expect(mapInboundWaveformIndex(7)).toBe("multiSine");
+	});
+
+	it("ignores invalid inbound waveform indices", () => {
+		expect(mapInboundWaveformIndex(999)).toBeUndefined();
+	});
+
+	it("maps inbound warp ids and optional warp ids safely", () => {
+		expect(mapInboundWarpAlgoId(1)).toBe("bend");
+		expect(mapInboundWarpAlgoId(999)).toBe("cz101");
+		expect(mapInboundOptionalWarpAlgoId(-1)).toBeNull();
+		expect(mapInboundOptionalWarpAlgoId(12)).toBe("karpunk");
+	});
+});

--- a/packages/cosmo-pd101/webview/src/hooks/usePluginParamBridge.ts
+++ b/packages/cosmo-pd101/webview/src/hooks/usePluginParamBridge.ts
@@ -122,7 +122,7 @@ function sendParam(parameterId: number, value: number) {
 // Maps CzWaveform strings to Rust Waveform enum 0-based indices.
 // The Rust enum includes DoubleSine=5 (no CzWaveform counterpart), so
 // sawPulse, multiSine, and pulse2 are at indices 6, 7, 8 respectively.
-const CZ_WAVEFORM_IDX: Readonly<Record<CzWaveform, number>> = {
+export const CZ_WAVEFORM_IDX: Readonly<Record<CzWaveform, number>> = {
 	saw: 0,
 	square: 1,
 	pulse: 2,
@@ -135,7 +135,7 @@ const CZ_WAVEFORM_IDX: Readonly<Record<CzWaveform, number>> = {
 
 // Reverse mapping for incoming param updates from Rust (index → CzWaveform).
 // DoubleSine (5) maps to multiSine since that's how Rust's map_waveform handles it.
-const IDX_TO_CZ_WAVEFORM: Record<number, CzWaveform> = {
+export const IDX_TO_CZ_WAVEFORM: Record<number, CzWaveform> = {
 	0: "saw",
 	1: "square",
 	2: "pulse",
@@ -146,6 +146,37 @@ const IDX_TO_CZ_WAVEFORM: Record<number, CzWaveform> = {
 	7: "multiSine",
 	8: "pulse2",
 };
+
+export function mapAlgoKeyToId(key: Algo | null): number {
+	if (key === null || isWaveformId(key)) return 0;
+	return WARP_ALGO_IDS[key as keyof typeof WARP_ALGO_IDS] ?? 0;
+}
+
+export function mapAlgoKeyToWaveform(
+	key: Algo | null,
+	slotWaveform: CzWaveform,
+): number {
+	if (key === null) return CZ_WAVEFORM_IDX.saw;
+	if (isWaveformId(key)) return CZ_WAVEFORM_IDX[key as CzWaveform] ?? 0;
+	if (key === "cz101") return CZ_WAVEFORM_IDX[slotWaveform] ?? 0;
+	return 0;
+}
+
+export function mapInboundWaveformIndex(value: number): CzWaveform | undefined {
+	return IDX_TO_CZ_WAVEFORM[Math.round(value)];
+}
+
+export function mapInboundWarpAlgoId(value: number): Algo {
+	return (WARP_ALGO_FROM_ID[Math.round(value)] ?? "cz101") as Algo;
+}
+
+export function mapInboundOptionalWarpAlgoId(value: number): Algo | null {
+	if (value < 0) {
+		return null;
+	}
+
+	return mapInboundWarpAlgoId(value);
+}
 
 export function usePluginParamBridge(synthState: UseSynthStateResult) {
 	const {
@@ -340,24 +371,6 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 		}
 	}, []);
 
-	const algoKeyToId = useCallback((key: Algo | null): number => {
-		if (key === null || isWaveformId(key)) return 0; // CZ waveform algos → cz101 (index 0)
-		return WARP_ALGO_IDS[key as keyof typeof WARP_ALGO_IDS] ?? 0;
-	}, []);
-
-	const algoKeyToWaveform = useCallback(
-		(key: Algo | null, slotWaveform: CzWaveform): number => {
-			if (key === null) return CZ_WAVEFORM_IDX.saw;
-			// CZ waveform algos: the algo string IS the waveform
-			if (isWaveformId(key)) return CZ_WAVEFORM_IDX[key as CzWaveform] ?? 0;
-			// cz101 warp: waveform comes from the explicit slot setting
-			if (key === "cz101") return CZ_WAVEFORM_IDX[slotWaveform] ?? 0;
-			// other warp algos use a sine carrier; waveform param is irrelevant
-			return 0;
-		},
-		[],
-	);
-
 	const adapter = useMemo<SynthEngineAdapter>(
 		() => ({
 			sync(snapshot) {
@@ -374,8 +387,14 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 				queueParam(P_INT_PM_AMOUNT, snapshot.intPmAmount);
 				queueParam(P_INT_PM_RATIO, snapshot.intPmRatio);
 				queueParam(P_PM_PRE, snapshot.pmPre ? 1 : 0);
-				queueParam(P_L1_WAVEFORM, algoKeyToWaveform(snapshot.warpAAlgo, snapshot.line1CzSlotAWaveform));
-				queueParam(P_L1_WARP_ALGO, algoKeyToId(snapshot.warpAAlgo));
+				queueParam(
+					P_L1_WAVEFORM,
+					mapAlgoKeyToWaveform(
+						snapshot.warpAAlgo,
+						snapshot.line1CzSlotAWaveform,
+					),
+				);
+				queueParam(P_L1_WARP_ALGO, mapAlgoKeyToId(snapshot.warpAAlgo));
 				queueParam(P_L1_DCW_BASE, snapshot.warpAAmount);
 				queueParam(P_L1_DCA_BASE, snapshot.line1Level);
 				queueParam(P_L1_DCO_DEPTH, snapshot.line1DcoDepth);
@@ -386,10 +405,16 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 				queueParam(P_L1_ALGO_BLEND, snapshot.algoBlendA);
 				queueParam(
 					P_L1_WARP_ALGO2,
-					snapshot.algo2A === null ? -1 : algoKeyToId(snapshot.algo2A),
+					snapshot.algo2A === null ? -1 : mapAlgoKeyToId(snapshot.algo2A),
 				);
-				queueParam(P_L2_WAVEFORM, algoKeyToWaveform(snapshot.warpBAlgo, snapshot.line2CzSlotAWaveform));
-				queueParam(P_L2_WARP_ALGO, algoKeyToId(snapshot.warpBAlgo));
+				queueParam(
+					P_L2_WAVEFORM,
+					mapAlgoKeyToWaveform(
+						snapshot.warpBAlgo,
+						snapshot.line2CzSlotAWaveform,
+					),
+				);
+				queueParam(P_L2_WARP_ALGO, mapAlgoKeyToId(snapshot.warpBAlgo));
 				queueParam(P_L2_DCW_BASE, snapshot.warpBAmount);
 				queueParam(P_L2_DCA_BASE, snapshot.line2Level);
 				queueParam(P_L2_DCO_DEPTH, snapshot.line2DcoDepth);
@@ -400,7 +425,7 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 				queueParam(P_L2_ALGO_BLEND, snapshot.algoBlendB);
 				queueParam(
 					P_L2_WARP_ALGO2,
-					snapshot.algo2B === null ? -1 : algoKeyToId(snapshot.algo2B),
+					snapshot.algo2B === null ? -1 : mapAlgoKeyToId(snapshot.algo2B),
 				);
 				queueParam(P_VIB_ENABLED, snapshot.vibratoEnabled ? 1 : 0);
 				queueParam(P_VIB_WAVEFORM, snapshot.vibratoWave);
@@ -451,14 +476,7 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 				sendModMatrix(snapshot.modMatrix);
 			},
 		}),
-		[
-			queueParam,
-			sendEnvelope,
-			sendAlgoControls,
-			sendModMatrix,
-			algoKeyToId,
-			algoKeyToWaveform,
-		],
+		[queueParam, sendEnvelope, sendAlgoControls, sendModMatrix],
 	);
 
 	const snapshot = useMemo(
@@ -670,7 +688,7 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 							setPmPre(value >= 0.5);
 							break;
 						case P_L1_WAVEFORM: {
-							const waveform = IDX_TO_CZ_WAVEFORM[Math.round(value)];
+							const waveform = mapInboundWaveformIndex(value);
 							if (waveform) {
 								setLine1CzSlotAWaveform(waveform);
 								setLine1CzSlotBWaveform(waveform);
@@ -678,8 +696,7 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 							break;
 						}
 						case P_L1_WARP_ALGO: {
-							const algoName = (WARP_ALGO_FROM_ID[Math.round(value)] ?? "cz101") as Algo;
-							setWarpAAlgo(algoName);
+							setWarpAAlgo(mapInboundWarpAlgoId(value));
 							break;
 						}
 						case P_L1_DCW_BASE:
@@ -707,16 +724,11 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 							setAlgoBlendA(value);
 							break;
 						case P_L1_WARP_ALGO2: {
-							if (value < 0) {
-								setAlgo2A(null);
-							} else {
-								const algoName = (WARP_ALGO_FROM_ID[Math.round(value)] ?? "cz101") as Algo;
-								setAlgo2A(algoName);
-							}
+							setAlgo2A(mapInboundOptionalWarpAlgoId(value));
 							break;
 						}
 						case P_L2_WAVEFORM: {
-							const waveform = IDX_TO_CZ_WAVEFORM[Math.round(value)];
+							const waveform = mapInboundWaveformIndex(value);
 							if (waveform) {
 								setLine2CzSlotAWaveform(waveform);
 								setLine2CzSlotBWaveform(waveform);
@@ -724,8 +736,7 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 							break;
 						}
 						case P_L2_WARP_ALGO: {
-							const algoName = (WARP_ALGO_FROM_ID[Math.round(value)] ?? "cz101") as Algo;
-							setWarpBAlgo(algoName);
+							setWarpBAlgo(mapInboundWarpAlgoId(value));
 							break;
 						}
 						case P_L2_DCW_BASE:
@@ -753,12 +764,7 @@ export function usePluginParamBridge(synthState: UseSynthStateResult) {
 							setAlgoBlendB(value);
 							break;
 						case P_L2_WARP_ALGO2: {
-							if (value < 0) {
-								setAlgo2B(null);
-							} else {
-								const algoName = (WARP_ALGO_FROM_ID[Math.round(value)] ?? "cz101") as Algo;
-								setAlgo2B(algoName);
-							}
+							setAlgo2B(mapInboundOptionalWarpAlgoId(value));
 							break;
 						}
 						case P_VIB_ENABLED:

--- a/packages/cosmo-pd101/webview/src/lib/beamerLegacyBridge.test.ts
+++ b/packages/cosmo-pd101/webview/src/lib/beamerLegacyBridge.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	__resetBeamerLegacyBridgeForTests,
+	ensureBeamerLegacyBridge,
+} from "./beamerLegacyBridge";
+
+function createRuntime() {
+	const originalOnInit = vi.fn();
+	const originalOnParams = vi.fn();
+	const params = new Map([
+		[
+			"volume",
+			{
+				id: 0,
+				stringId: "volume",
+				name: "Volume",
+				min: 0,
+				max: 1,
+				defaultValue: 0.8,
+				value: 0.8,
+				plainValue: 0.8,
+				displayText: "80%",
+				format: "{:.0f}%",
+				units: "",
+				steps: 0,
+			},
+		],
+	]);
+
+	return {
+		_onInit: originalOnInit,
+		_onParams: originalOnParams,
+		invoke: vi.fn().mockResolvedValue({
+			samples: [],
+			sampleRate: 44_100,
+			hz: 220,
+		}),
+		params: {
+			info: (id: string) => params.get(id),
+			beginEdit: vi.fn(),
+			set: vi.fn(),
+			endEdit: vi.fn(),
+		},
+		originalOnInit,
+		originalOnParams,
+	};
+}
+
+beforeEach(() => {
+	__resetBeamerLegacyBridgeForTests();
+	window.__BEAMER__ = undefined;
+	vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+	vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	__resetBeamerLegacyBridgeForTests();
+	window.__BEAMER__ = undefined;
+});
+
+describe("ensureBeamerLegacyBridge", () => {
+	it("returns false until the runtime is available", () => {
+		expect(ensureBeamerLegacyBridge()).toBe(false);
+		expect(window.ipc).toBeUndefined();
+	});
+
+	it("replays synced params when the host handler is assigned later", async () => {
+		window.__BEAMER__ = createRuntime();
+
+		expect(ensureBeamerLegacyBridge()).toBe(true);
+
+		const handler = vi.fn();
+		window.__czOnParams = handler;
+		await Promise.resolve();
+
+		expect(handler).toHaveBeenCalledWith(JSON.stringify({ 0: 0.8 }));
+	});
+
+	it("installs only once and does not double-wrap param updates", async () => {
+		const runtime = createRuntime();
+		window.__BEAMER__ = runtime;
+
+		expect(ensureBeamerLegacyBridge()).toBe(true);
+
+		const handler = vi.fn();
+		window.__czOnParams = handler;
+		await Promise.resolve();
+		handler.mockClear();
+
+		expect(ensureBeamerLegacyBridge()).toBe(true);
+
+		runtime._onParams({ 0: [0.25, 0.25, "25%"] });
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(handler).toHaveBeenCalledWith(JSON.stringify({ 0: 0.25 }));
+		expect(runtime.originalOnParams).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/lib/beamerLegacyBridge.ts
+++ b/packages/cosmo-pd101/webview/src/lib/beamerLegacyBridge.ts
@@ -139,6 +139,19 @@ let latestLegacyParams: Record<number, number> = {};
 let currentParamHandler: ((json: string) => void) | undefined;
 const runtimeStringIdsByNumericId: Record<number, string> = {};
 
+export function __resetBeamerLegacyBridgeForTests() {
+	installed = false;
+	latestLegacyParams = {};
+	currentParamHandler = undefined;
+	for (const numericId of Object.keys(runtimeStringIdsByNumericId)) {
+		delete runtimeStringIdsByNumericId[Number(numericId)];
+	}
+	delete window.ipc;
+	delete window.__czGetEnvelopes;
+	delete window.__czGetModMatrix;
+	delete window.__czOnParams;
+}
+
 function clamp(value: number, min: number, max: number): number {
 	return Math.min(max, Math.max(min, value));
 }
@@ -274,12 +287,14 @@ function installLegacyIpc(runtime: BeamerRuntime) {
 			}
 
 			if ("mod_matrix" in payload) {
-				void runtime.invoke("setModMatrix", payload.mod_matrix).catch((error) => {
-					console.error(
-						"[beamerLegacyBridge] Failed to send mod matrix",
-						error,
-					);
-				});
+				void runtime
+					.invoke("setModMatrix", payload.mod_matrix)
+					.catch((error) => {
+						console.error(
+							"[beamerLegacyBridge] Failed to send mod matrix",
+							error,
+						);
+					});
 				return;
 			}
 

--- a/packages/cosmo-pd101/webview/src/test/mockPluginBridge.test.ts
+++ b/packages/cosmo-pd101/webview/src/test/mockPluginBridge.test.ts
@@ -140,6 +140,40 @@ describe("invoke", () => {
 		window.__MOCK_BRIDGE__?.rejectNextInvoke("something went wrong");
 		await expect(promise).rejects.toBe("something went wrong");
 	});
+
+	it("resolves queued custom invocations in order", async () => {
+		const firstPromise = window.__BEAMER__?.invoke("firstMethod");
+		const secondPromise = window.__BEAMER__?.invoke("secondMethod");
+
+		window.__MOCK_BRIDGE__?.resolveNextInvoke({ id: 1 });
+		window.__MOCK_BRIDGE__?.resolveNextInvoke({ id: 2 });
+
+		await expect(firstPromise).resolves.toEqual({ id: 1 });
+		await expect(secondPromise).resolves.toEqual({ id: 2 });
+	});
+
+	it("returns cloned mod matrix state", async () => {
+		await window.__BEAMER__?.invoke("setModMatrix", {
+			routes: [
+				{
+					source: "lfo1",
+					destination: "volume",
+					amount: 0.5,
+					enabled: true,
+				},
+			],
+		});
+
+		const firstRead = (await window.__BEAMER__?.invoke("getModMatrix")) as {
+			routes: Array<{ amount: number }>;
+		};
+		firstRead.routes[0].amount = 0;
+
+		const secondRead = (await window.__BEAMER__?.invoke("getModMatrix")) as {
+			routes: Array<{ amount: number }>;
+		};
+		expect(secondRead.routes[0].amount).toBe(0.5);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cosmo-pd101/webview/src/test/mockPluginBridge.ts
+++ b/packages/cosmo-pd101/webview/src/test/mockPluginBridge.ts
@@ -237,9 +237,19 @@ const DEFAULT_PARAMS: BeamerParamInfo[] = [
 export function installMockPluginBridge(): void {
 	const messages: MockBridgeMessage[] = [];
 	const messageListeners: Array<(msg: MockBridgeMessage) => void> = [];
-	let pendingInvokeResolve: ((result: unknown) => void) | null = null;
-	let pendingInvokeReject: ((error: string) => void) | null = null;
+	const pendingInvokes: Array<{
+		resolve: (result: unknown) => void;
+		reject: (error: string) => void;
+	}> = [];
 	let virtualModMatrix: { routes: unknown[] } = { routes: [] };
+
+	function cloneRoutes(routes: unknown[]) {
+		return routes.map((route) =>
+			route && typeof route === "object"
+				? { ...(route as Record<string, unknown>) }
+				: route,
+		);
+	}
 
 	// Virtual param state: Beamer numeric ID → normalized value
 	const virtualParamState: Record<number, number> = {};
@@ -339,12 +349,12 @@ export function installMockPluginBridge(): void {
 					const next = (args[0] ?? { routes: [] }) as {
 						routes?: unknown[];
 					};
-					virtualModMatrix = { routes: [...(next.routes ?? [])] };
+					virtualModMatrix = { routes: cloneRoutes(next.routes ?? []) };
 					resolve(null);
 					return;
 				}
 				if (method === "getModMatrix") {
-					resolve({ routes: [...virtualModMatrix.routes] });
+					resolve({ routes: cloneRoutes(virtualModMatrix.routes) });
 					return;
 				}
 				if (method === "getScopeData") {
@@ -354,8 +364,7 @@ export function installMockPluginBridge(): void {
 				}
 
 				// Unknown invocations queue so tests can drive the response.
-				pendingInvokeResolve = resolve;
-				pendingInvokeReject = reject;
+				pendingInvokes.push({ resolve, reject });
 			});
 		},
 
@@ -415,20 +424,17 @@ export function installMockPluginBridge(): void {
 		},
 
 		resolveNextInvoke(result: unknown): void {
-			pendingInvokeResolve?.(result);
-			pendingInvokeResolve = null;
+			pendingInvokes.shift()?.resolve(result);
 		},
 
 		rejectNextInvoke(error: string): void {
-			pendingInvokeReject?.(error);
-			pendingInvokeReject = null;
+			pendingInvokes.shift()?.reject(error);
 		},
 
 		reset(): void {
 			messages.length = 0;
 			messageListeners.length = 0;
-			pendingInvokeResolve = null;
-			pendingInvokeReject = null;
+			pendingInvokes.length = 0;
 		},
 	};
 


### PR DESCRIPTION
## Summary
- add direct unit coverage for delayed bridge startup, parameter replay, and bridge idempotence
- add regression tests around plugin waveform/algo mapping helpers and harden the mock bridge queue/clone behavior
- add Rust unit tests for wrapped and unwrapped plugin payload parsing plus DoubleSine -> MultiSine waveform normalization

## Testing
- `cd packages/cosmo-pd101/webview && bun run test:unit`
- `cd packages/cosmo-pd101/webview && bun run test:browser`
- `cd packages/cosmo-pd101/webview && bun run test:e2e`
- `cargo test -p cosmo-pd101`
- `cd packages/cosmo-pd101/webview && bun run build`