### PR TITLE
test: add webview primitive and control component tests

### DIFF
--- a/packages/cosmo-pd101/webview/e2e/plugin-mod-matrix-management.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-mod-matrix-management.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+import { setupPluginPage, waitForMessageMatching } from "./helpers/pluginBridge";
+
+test.beforeEach(async ({ page }) => {
+	await setupPluginPage(page);
+});
+
+test.describe("Mod matrix route management", () => {
+	test("add, adjust, disable, and remove route emits setModMatrix payloads", async ({
+		page,
+	}) => {
+		const volumeKnob = page.getByRole("button", { name: /^volume$/i });
+		await expect(volumeKnob).toBeVisible();
+		await volumeKnob.hover();
+
+		const modulationButton = page.getByRole("button", {
+			name: /modulation for volume/i,
+		});
+		await expect(modulationButton).toBeVisible();
+		await modulationButton.click();
+
+		await page.evaluate(() => window.__MOCK_BRIDGE__?.clearMessages());
+		await page.getByRole("button", { name: /^lfo 1$/i }).click();
+		await waitForMessageMatching(page, (message) => {
+			if (message.type !== "invoke" || message.method !== "setModMatrix") {
+				return false;
+			}
+			if (!Array.isArray(message.args) || message.args.length < 1) {
+				return false;
+			}
+			const payload = message.args[0] as { routes?: Array<{ source?: string }> };
+			return Array.isArray(payload.routes) && payload.routes[0]?.source === "lfo1";
+		});
+
+		await page.evaluate(() => window.__MOCK_BRIDGE__?.clearMessages());
+		await page.getByRole("checkbox").first().click();
+		await waitForMessageMatching(page, (message) => {
+			if (message.type !== "invoke" || message.method !== "setModMatrix") {
+				return false;
+			}
+			if (!Array.isArray(message.args) || message.args.length < 1) {
+				return false;
+			}
+			const payload = message.args[0] as {
+				routes?: Array<{ enabled?: boolean }>;
+			};
+			return Array.isArray(payload.routes) && payload.routes[0]?.enabled === false;
+		});
+
+		await page.evaluate(() => window.__MOCK_BRIDGE__?.clearMessages());
+		const amountSlider = page.getByRole("slider").first();
+		await amountSlider.evaluate((element) => {
+			const input = element as HTMLInputElement;
+			input.value = "0.25";
+			input.dispatchEvent(new Event("input", { bubbles: true }));
+			input.dispatchEvent(new Event("change", { bubbles: true }));
+		});
+		await waitForMessageMatching(page, (message) => {
+			if (message.type !== "invoke" || message.method !== "setModMatrix") {
+				return false;
+			}
+			if (!Array.isArray(message.args) || message.args.length < 1) {
+				return false;
+			}
+			const payload = message.args[0] as { routes?: Array<{ amount?: number }> };
+			return (
+				Array.isArray(payload.routes) &&
+				typeof payload.routes[0]?.amount === "number" &&
+				Math.abs((payload.routes[0]?.amount ?? 0) - 0.25) < 0.000001
+			);
+		});
+
+		await page.evaluate(() => window.__MOCK_BRIDGE__?.clearMessages());
+		await page.getByRole("button", { name: "✕" }).click();
+		await waitForMessageMatching(page, (message) => {
+			if (message.type !== "invoke" || message.method !== "setModMatrix") {
+				return false;
+			}
+			if (!Array.isArray(message.args) || message.args.length < 1) {
+				return false;
+			}
+			const payload = message.args[0] as { routes?: unknown[] };
+			return Array.isArray(payload.routes) && payload.routes.length === 0;
+		});
+	});
+});

--- a/packages/cosmo-pd101/webview/e2e/plugin-mod-matrix-management.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-mod-matrix-management.spec.ts
@@ -32,8 +32,11 @@ test.describe("Mod matrix route management", () => {
 			return Array.isArray(payload.routes) && payload.routes[0]?.source === "lfo1";
 		});
 
+		const modulationMenu = page.locator("div").filter({
+			has: page.getByRole("button", { name: "Close" }),
+		}).last();
 		await page.evaluate(() => window.__MOCK_BRIDGE__?.clearMessages());
-		await page.getByRole("checkbox").first().click();
+		await modulationMenu.getByRole("checkbox").first().click();
 		await waitForMessageMatching(page, (message) => {
 			if (message.type !== "invoke" || message.method !== "setModMatrix") {
 				return false;
@@ -48,7 +51,7 @@ test.describe("Mod matrix route management", () => {
 		});
 
 		await page.evaluate(() => window.__MOCK_BRIDGE__?.clearMessages());
-		const amountSlider = page.getByRole("slider").first();
+		const amountSlider = modulationMenu.getByRole("slider").first();
 		await amountSlider.evaluate((element) => {
 			const input = element as HTMLInputElement;
 			input.value = "0.25";

--- a/packages/cosmo-pd101/webview/e2e/plugin-mod-matrix-management.spec.ts
+++ b/packages/cosmo-pd101/webview/e2e/plugin-mod-matrix-management.spec.ts
@@ -54,9 +54,12 @@ test.describe("Mod matrix route management", () => {
 		const amountSlider = modulationMenu.getByRole("slider").first();
 		await amountSlider.evaluate((element) => {
 			const input = element as HTMLInputElement;
-			input.value = "0.25";
+			const nativeSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLInputElement.prototype,
+				"value",
+			)?.set;
+			nativeSetter?.call(input, "0.25");
 			input.dispatchEvent(new Event("input", { bubbles: true }));
-			input.dispatchEvent(new Event("change", { bubbles: true }));
 		});
 		await waitForMessageMatching(page, (message) => {
 			if (message.type !== "invoke" || message.method !== "setModMatrix") {

--- a/packages/cosmo-pd101/webview/src/components/controls/ControlKnob.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/ControlKnob.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ControlKnob from "./ControlKnob";
+
+const useOptionalSynthControllerMock = vi.fn();
+
+vi.mock("@/features/synth/SynthParamController", () => ({
+	useOptionalSynthController: () => useOptionalSynthControllerMock(),
+}));
+
+vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
+	default: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="modulatable-wrapper">{children}</div>
+	),
+}));
+
+describe("ControlKnob", () => {
+	beforeEach(() => {
+		useOptionalSynthControllerMock.mockReset();
+		useOptionalSynthControllerMock.mockReturnValue(null);
+	});
+
+	it("renders label and formatted value", () => {
+		render(
+			<ControlKnob value={0.25} onChange={vi.fn()} label="Cutoff" min={0} max={1} />,
+		);
+
+		expect(screen.getByText("Cutoff")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Cutoff value" })).toHaveTextContent(
+			"0.25",
+		);
+	});
+
+	it("supports direct value editing and commits clamped values", () => {
+		const onChange = vi.fn();
+		render(
+			<ControlKnob value={0.25} onChange={onChange} label="Cutoff" min={0} max={1} />,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Cutoff value" }));
+		const input = screen.getByRole("textbox", { name: "Cutoff value" });
+		fireEvent.change(input, { target: { value: "2.5" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+
+		expect(onChange).toHaveBeenCalledWith(1);
+	});
+
+	it("resets to default value on double click", () => {
+		const onChange = vi.fn();
+		render(
+			<ControlKnob
+				value={0.4}
+				onChange={onChange}
+				label="Resonance"
+				defaultValue={0.1}
+			/>,
+		);
+
+		fireEvent.doubleClick(screen.getByRole("button", { name: "Resonance" }));
+		expect(onChange).toHaveBeenCalledWith(0.1);
+	});
+
+	it("hides value display when valueVisibility is never", () => {
+		render(
+			<ControlKnob
+				value={0.5}
+				onChange={vi.fn()}
+				label="Pitch"
+				valueVisibility="never"
+			/>,
+		);
+
+		expect(screen.queryByRole("button", { name: "Pitch value" })).toBeNull();
+	});
+
+	it("wraps knob with modulatable control when destination resolves", () => {
+		render(
+			<ControlKnob
+				value={0.5}
+				onChange={vi.fn()}
+				label="Level"
+				modDestination="volume"
+			/>,
+		);
+
+		expect(screen.getByTestId("modulatable-wrapper")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/ControlKnob.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/ControlKnob.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ControlKnob from "./ControlKnob";
 
@@ -9,7 +10,7 @@ vi.mock("@/features/synth/SynthParamController", () => ({
 }));
 
 vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
-	default: ({ children }: { children: React.ReactNode }) => (
+	default: ({ children }: { children: ReactNode }) => (
 		<div data-testid="modulatable-wrapper">{children}</div>
 	),
 }));

--- a/packages/cosmo-pd101/webview/src/components/controls/LineSelectControl.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/LineSelectControl.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LineSelectControl from "./LineSelectControl";
+
+const useSynthParamMock = vi.fn();
+
+vi.mock("@/features/synth/SynthParamController", () => ({
+	useSynthParam: (...args: unknown[]) => useSynthParamMock(...args),
+}));
+
+describe("LineSelectControl", () => {
+	beforeEach(() => {
+		useSynthParamMock.mockReset();
+	});
+
+	it("renders all line select buttons", () => {
+		useSynthParamMock.mockReturnValue({ value: "L1", setValue: vi.fn() });
+		render(<LineSelectControl />);
+
+		expect(screen.getByText("Line Select")).toBeInTheDocument();
+		expect(screen.getAllByRole("button")).toHaveLength(5);
+	});
+
+	it("calls setValue with selected line", () => {
+		const setValue = vi.fn();
+		useSynthParamMock.mockReturnValue({ value: "L1", setValue });
+		render(<LineSelectControl />);
+
+		fireEvent.click(screen.getAllByRole("button")[3]);
+		expect(setValue).toHaveBeenCalledWith("L1+L1'");
+	});
+
+	it("marks the active button", () => {
+		useSynthParamMock.mockReturnValue({ value: "L2", setValue: vi.fn() });
+		render(<LineSelectControl />);
+
+		expect(screen.getAllByRole("button")[2].className).toContain("text-cz-cream");
+		expect(screen.getAllByRole("button")[0].className).toContain(
+			"text-cz-cream-dim",
+		);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/ModModeControl.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/ModModeControl.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ModModeControl from "./ModModeControl";
+
+const useSynthParamMock = vi.fn();
+
+vi.mock("@/features/synth/SynthParamController", () => ({
+	useSynthParam: (...args: unknown[]) => useSynthParamMock(...args),
+}));
+
+describe("ModModeControl", () => {
+	beforeEach(() => {
+		useSynthParamMock.mockReset();
+	});
+
+	it("renders modulation mode buttons", () => {
+		useSynthParamMock.mockReturnValue({ value: "normal", setValue: vi.fn() });
+		render(<ModModeControl />);
+
+		expect(screen.getByText("Modulation")).toBeInTheDocument();
+		expect(screen.getAllByRole("button")).toHaveLength(3);
+	});
+
+	it("calls setValue when selecting a mode", () => {
+		const setValue = vi.fn();
+		useSynthParamMock.mockReturnValue({ value: "normal", setValue });
+		render(<ModModeControl />);
+
+		fireEvent.click(screen.getAllByRole("button")[2]);
+		expect(setValue).toHaveBeenCalledWith("noise");
+	});
+
+	it("marks active mode button", () => {
+		useSynthParamMock.mockReturnValue({ value: "ring", setValue: vi.fn() });
+		render(<ModModeControl />);
+
+		expect(screen.getAllByRole("button")[1].className).toContain("text-cz-cream");
+		expect(screen.getAllByRole("button")[0].className).toContain(
+			"text-cz-cream-dim",
+		);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlItem.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlItem.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AlgoControlItem from "./AlgoControlItem";
+
+vi.mock("./AlgoControlSelect", () => ({
+	default: () => <div data-testid="select-control" />,
+}));
+
+vi.mock("./AlgoControlNumber", () => ({
+	default: () => <div data-testid="number-control" />,
+}));
+
+vi.mock("./AlgoControlToggle", () => ({
+	default: () => <div data-testid="toggle-control" />,
+}));
+
+const baseProps = {
+	binding: {},
+	lineIndex: 1 as const,
+	algoParamSlotIndex: {},
+	getAlgoControlValue: () => 0,
+	setAlgoControlValue: () => {},
+	getActiveSelectOption: () => null,
+	applyOptionAssignments: () => {},
+};
+
+describe("AlgoControlItem", () => {
+	it("renders select control for select kind", () => {
+		render(<AlgoControlItem {...baseProps} control={{ id: "x", label: "X", kind: "select" }} />);
+		expect(screen.getByTestId("select-control")).toBeInTheDocument();
+	});
+
+	it("renders number control by default", () => {
+		render(<AlgoControlItem {...baseProps} control={{ id: "x", label: "X" }} />);
+		expect(screen.getByTestId("number-control")).toBeInTheDocument();
+	});
+
+	it("renders toggle control for toggle kind", () => {
+		render(<AlgoControlItem {...baseProps} control={{ id: "x", label: "X", kind: "toggle" }} />);
+		expect(screen.getByTestId("toggle-control")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlNumber.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlNumber.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AlgoControlNumber from "./AlgoControlNumber";
+
+const knobSpy = vi.fn();
+const algoParamTargetFromSlotMock = vi.fn();
+
+vi.mock("@/lib/synth/modDestination", () => ({
+	algoParamTargetFromSlot: (...args: unknown[]) => algoParamTargetFromSlotMock(...args),
+}));
+
+vi.mock("../ControlKnob", () => ({
+	default: (props: Record<string, unknown>) => {
+		knobSpy(props);
+		return <div data-testid="mock-knob">{String(props.label)}</div>;
+	},
+}));
+
+describe("AlgoControlNumber", () => {
+	it("renders knob with resolved value and forwards number changes to binding", () => {
+		const setNumber = vi.fn();
+		algoParamTargetFromSlotMock.mockReturnValue("algoParam2");
+
+		render(
+			<AlgoControlNumber
+				control={{ id: "depth", label: "Depth", min: 0, max: 2, default: 0.5 }}
+				binding={{ getNumber: () => 1.25, setNumber }}
+				lineIndex={1}
+				algoParamSlotIndex={{ depth: 2 }}
+				getAlgoControlValue={vi.fn()}
+				setAlgoControlValue={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByTestId("mock-knob")).toHaveTextContent("Depth");
+		const props = knobSpy.mock.calls[0][0] as { value: number; onChange: (value: number) => void; modulatable: string };
+		expect(props.value).toBe(1.25);
+		expect(props.modulatable).toBe("algoParam2");
+		props.onChange(0.77);
+		expect(setNumber).toHaveBeenCalledWith(0.77);
+	});
+
+	it("falls back to state getter and setAlgoControlValue", () => {
+		const setAlgoControlValue = vi.fn();
+		render(
+			<AlgoControlNumber
+				control={{ id: "res", label: "Res", min: 0, max: 1, default: 0.4 }}
+				lineIndex={2}
+				algoParamSlotIndex={{}}
+				getAlgoControlValue={() => 0.61}
+				setAlgoControlValue={setAlgoControlValue}
+			/>,
+		);
+
+		const props = knobSpy.mock.calls[0][0] as { onChange: (value: number) => void };
+		props.onChange(0.2);
+		expect(setAlgoControlValue).toHaveBeenCalledWith("res", 0.2);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlNumber.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlNumber.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import AlgoControlNumber from "./AlgoControlNumber";
 
 const knobSpy = vi.fn();
@@ -17,6 +17,11 @@ vi.mock("../ControlKnob", () => ({
 }));
 
 describe("AlgoControlNumber", () => {
+	beforeEach(() => {
+		knobSpy.mockClear();
+		algoParamTargetFromSlotMock.mockReset();
+	});
+
 	it("renders knob with resolved value and forwards number changes to binding", () => {
 		const setNumber = vi.fn();
 		algoParamTargetFromSlotMock.mockReturnValue("algoParam2");
@@ -33,7 +38,11 @@ describe("AlgoControlNumber", () => {
 		);
 
 		expect(screen.getByTestId("mock-knob")).toHaveTextContent("Depth");
-		const props = knobSpy.mock.calls[0][0] as { value: number; onChange: (value: number) => void; modulatable: string };
+		const props = knobSpy.mock.calls[0][0] as {
+			value: number;
+			onChange: (value: number) => void;
+			modulatable: string;
+		};
 		expect(props.value).toBe(1.25);
 		expect(props.modulatable).toBe("algoParam2");
 		props.onChange(0.77);
@@ -52,7 +61,9 @@ describe("AlgoControlNumber", () => {
 			/>,
 		);
 
-		const props = knobSpy.mock.calls[0][0] as { onChange: (value: number) => void };
+		const props = knobSpy.mock.calls.at(-1)?.[0] as {
+			onChange: (value: number) => void;
+		};
 		props.onChange(0.2);
 		expect(setAlgoControlValue).toHaveBeenCalledWith("res", 0.2);
 	});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlSelect.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlSelect.test.tsx
@@ -24,7 +24,7 @@ describe("AlgoControlSelect", () => {
 		);
 
 		expect(screen.getAllByRole("button")).toHaveLength(2);
-		expect(screen.getByRole("button").className).toContain("text-cz-cream");
+		expect(screen.getAllByRole("button")[0].className).toContain("text-cz-cream");
 	});
 
 	it("uses binding.setNumber for options without assignments", () => {

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlSelect.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlSelect.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AlgoControlSelect from "./AlgoControlSelect";
+
+const control = {
+	id: "shape",
+	label: "Shape",
+	description: "Select algorithm shape",
+	kind: "select" as const,
+	options: [
+		{ value: "a", label: "A", set: [] },
+		{ value: "b", label: "B", set: [{ controlId: "x", value: 1 }] },
+	],
+};
+
+describe("AlgoControlSelect", () => {
+	it("renders options and marks active option", () => {
+		render(
+			<AlgoControlSelect
+				control={control}
+				getActiveSelectOption={() => control.options[0]}
+				applyOptionAssignments={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getAllByRole("button")).toHaveLength(2);
+		expect(screen.getByRole("button").className).toContain("text-cz-cream");
+	});
+
+	it("uses binding.setNumber for options without assignments", () => {
+		const setNumber = vi.fn();
+		render(
+			<AlgoControlSelect
+				control={control}
+				binding={{ setNumber }}
+				getActiveSelectOption={() => null}
+				applyOptionAssignments={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getAllByRole("button")[0]);
+		expect(setNumber).toHaveBeenCalledWith(0);
+	});
+
+	it("applies assignments for options that define set payloads", () => {
+		const applyOptionAssignments = vi.fn();
+		render(
+			<AlgoControlSelect
+				control={control}
+				binding={{ setNumber: vi.fn() }}
+				getActiveSelectOption={() => null}
+				applyOptionAssignments={applyOptionAssignments}
+			/>,
+		);
+
+		fireEvent.click(screen.getAllByRole("button")[1]);
+		expect(applyOptionAssignments).toHaveBeenCalledWith(control.options[1]);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlToggle.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlToggle.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AlgoControlToggle from "./AlgoControlToggle";
+
+describe("AlgoControlToggle", () => {
+	it("uses binding value and toggles through binding", () => {
+		const setToggle = vi.fn();
+		render(
+			<AlgoControlToggle
+				control={{ id: "sync", label: "Sync", kind: "toggle" }}
+				binding={{ getToggle: () => true, setToggle }}
+			/>,
+		);
+
+		const checkbox = screen.getByRole("checkbox");
+		expect(checkbox).toBeChecked();
+		fireEvent.click(checkbox);
+		expect(setToggle).toHaveBeenCalledWith(false);
+	});
+
+	it("falls back to defaultToggle and disables when no setter", () => {
+		render(
+			<AlgoControlToggle
+				control={{ id: "sync", label: "Sync", kind: "toggle", defaultToggle: true }}
+			/>,
+		);
+
+		const checkbox = screen.getByRole("checkbox");
+		expect(checkbox).toBeChecked();
+		expect(checkbox).toBeDisabled();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlTooltip.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlTooltip.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AlgoControlTooltip from "./AlgoControlTooltip";
+
+describe("AlgoControlTooltip", () => {
+	it("renders nothing without description", () => {
+		const { container } = render(<AlgoControlTooltip description={undefined} />);
+		expect(container).toBeEmptyDOMElement();
+	});
+
+	it("renders tooltip trigger when description exists", () => {
+		render(<AlgoControlTooltip description="Fine tune harmonic spread" />);
+		expect(screen.getByRole("button", { name: "Show control description" })).toBeInTheDocument();
+		expect(screen.getByRole("button").closest("[data-tip='Fine tune harmonic spread']")).not.toBeNull();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlsGroup.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlsGroup.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AlgoControlsGroup from "./AlgoControlsGroup";
+
+vi.mock("@/components/primitives/Card", () => ({
+	default: ({ children }: { children: React.ReactNode }) => <div data-testid="card">{children}</div>,
+}));
+
+vi.mock("./AlgoControlItem", () => ({
+	default: ({ control }: { control: { id: string } }) => <div data-testid={`item-${control.id}`} />,
+}));
+
+const sharedProps = {
+	controlBindings: {},
+	lineIndex: 1 as const,
+	algoParamSlotIndex: {},
+	getAlgoControlValue: () => 0,
+	setAlgoControlValue: () => {},
+	getActiveSelectOption: () => null,
+	applyOptionAssignments: () => {},
+};
+
+describe("AlgoControlsGroup", () => {
+	it("renders empty-state message when no controls", () => {
+		render(<AlgoControlsGroup {...sharedProps} controls={[]} />);
+		expect(screen.getByText("No controls for this algo")).toBeInTheDocument();
+	});
+
+	it("renders control items when controls are present", () => {
+		render(
+			<AlgoControlsGroup
+				{...sharedProps}
+				controls={[
+					{ id: "a", label: "A" },
+					{ id: "b", label: "B" },
+				]}
+			/>,
+		);
+
+		expect(screen.getByTestId("item-a")).toBeInTheDocument();
+		expect(screen.getByTestId("item-b")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlsGroup.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoControlsGroup.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import AlgoControlsGroup from "./AlgoControlsGroup";
 
 vi.mock("@/components/primitives/Card", () => ({
-	default: ({ children }: { children: React.ReactNode }) => <div data-testid="card">{children}</div>,
+	default: ({ children }: { children: ReactNode }) => <div data-testid="card">{children}</div>,
 }));
 
 vi.mock("./AlgoControlItem", () => ({

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoIconGrid.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/AlgoIconGrid.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AlgoIconGrid from "./AlgoIconGrid";
+
+vi.mock("@/lib/synth/algoRef", () => ({
+	isAlgoRefEqual: (a: { id: number }, b: { id: number }) => a.id === b.id,
+}));
+
+vi.mock("@/lib/synth/pdAlgorithms", () => ({
+	PD_ALGOS: [
+		{ key: "algo-1", label: "Algo 1", value: { id: 1 }, icon: "M1 1L10 10" },
+		{ key: "algo-2", label: "Algo 2", value: { id: 2 }, icon: "M2 2L11 11" },
+	],
+}));
+
+describe("AlgoIconGrid", () => {
+	it("renders algorithm buttons and dispatches selection", () => {
+		const onChange = vi.fn();
+		render(<AlgoIconGrid value={{ id: 1 }} onChange={onChange} />);
+
+		const second = screen.getByRole("button", { name: "Algo 2" });
+		fireEvent.click(second);
+		expect(onChange).toHaveBeenCalledWith({ id: 2 });
+	});
+
+	it("disables interaction when disabled", () => {
+		const onChange = vi.fn();
+		render(<AlgoIconGrid value={{ id: 1 }} onChange={onChange} disabled />);
+
+		const first = screen.getByRole("button", { name: "Algo 1" });
+		expect(first).toBeDisabled();
+		fireEvent.click(first);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/algo/algoControls.browser.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/algo/algoControls.browser.test.tsx
@@ -1,0 +1,174 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AlgoControlItem from "./AlgoControlItem";
+import AlgoControlNumber from "./AlgoControlNumber";
+import AlgoControlSelect from "./AlgoControlSelect";
+import AlgoControlToggle from "./AlgoControlToggle";
+import AlgoControlTooltip from "./AlgoControlTooltip";
+import AlgoControlsGroup from "./AlgoControlsGroup";
+import AlgoIconGrid from "./AlgoIconGrid";
+
+const knobSpy = vi.fn();
+const algoParamTargetFromSlotMock = vi.fn();
+
+vi.mock("@/lib/synth/modDestination", () => ({
+	algoParamTargetFromSlot: (...args: unknown[]) => algoParamTargetFromSlotMock(...args),
+}));
+
+vi.mock("../ControlKnob", () => ({
+	default: (props: Record<string, unknown>) => {
+		knobSpy(props);
+		return <div data-testid="mock-knob">{String(props.label)}</div>;
+	},
+}));
+
+vi.mock("@/lib/synth/algoRef", () => ({
+	isAlgoRefEqual: (a: { id: number }, b: { id: number }) => a.id === b.id,
+}));
+
+vi.mock("@/lib/synth/pdAlgorithms", () => ({
+	PD_ALGOS: [
+		{ key: "algo-1", label: "Algo 1", value: { id: 1 }, icon: "M1 1L10 10" },
+		{ key: "algo-2", label: "Algo 2", value: { id: 2 }, icon: "M2 2L11 11" },
+	],
+}));
+
+const selectControl = {
+	id: "shape",
+	label: "Shape",
+	description: "Select algorithm shape",
+	kind: "select" as const,
+	options: [
+		{ value: "a", label: "A", set: [] },
+		{ value: "b", label: "B", set: [{ controlId: "x", value: 1 }] },
+	],
+};
+
+describe("algo controls (browser)", () => {
+	beforeEach(() => {
+		knobSpy.mockClear();
+		algoParamTargetFromSlotMock.mockReset();
+	});
+
+	it("renders tooltip only when description exists", () => {
+		const { rerender } = render(<AlgoControlTooltip description="Helpful info" />);
+		expect(screen.getByRole("button", { name: "Show control description" })).toBeInTheDocument();
+
+		rerender(<AlgoControlTooltip description={undefined} />);
+		expect(screen.queryByRole("button", { name: "Show control description" })).toBeNull();
+	});
+
+	it("renders and updates select controls", () => {
+		const setNumber = vi.fn();
+		const applyOptionAssignments = vi.fn();
+		render(
+			<AlgoControlSelect
+				control={selectControl}
+				binding={{ setNumber }}
+				getActiveSelectOption={() => selectControl.options[0]}
+				applyOptionAssignments={applyOptionAssignments}
+			/>,
+		);
+
+		expect(screen.getAllByRole("button")).toHaveLength(2);
+		fireEvent.click(screen.getAllByRole("button")[0]);
+		expect(setNumber).toHaveBeenCalledWith(0);
+		fireEvent.click(screen.getAllByRole("button")[1]);
+		expect(applyOptionAssignments).toHaveBeenCalledWith(selectControl.options[1]);
+	});
+
+	it("renders and updates toggle controls", () => {
+		const setToggle = vi.fn();
+		render(
+			<AlgoControlToggle
+				control={{ id: "sync", label: "Sync", kind: "toggle" }}
+				binding={{ getToggle: () => true, setToggle }}
+			/>,
+		);
+
+		const checkbox = screen.getByRole("checkbox");
+		expect(checkbox).toBeChecked();
+		fireEvent.click(checkbox);
+		expect(setToggle).toHaveBeenCalledWith(false);
+	});
+
+	it("renders AlgoControlNumber and forwards onChange", () => {
+		const setAlgoControlValue = vi.fn();
+		algoParamTargetFromSlotMock.mockReturnValue("algoParam2");
+		render(
+			<AlgoControlNumber
+				control={{ id: "depth", label: "Depth", min: 0, max: 2, default: 0.5 }}
+				lineIndex={1}
+				algoParamSlotIndex={{ depth: 2 }}
+				getAlgoControlValue={() => 1.25}
+				setAlgoControlValue={setAlgoControlValue}
+			/>,
+		);
+
+		expect(screen.getByTestId("mock-knob")).toHaveTextContent("Depth");
+		const props = knobSpy.mock.calls[0][0] as { onChange: (value: number) => void; modulatable: string };
+		expect(props.modulatable).toBe("algoParam2");
+		props.onChange(0.8);
+		expect(setAlgoControlValue).toHaveBeenCalledWith("depth", 0.8);
+	});
+
+	it("renders AlgoControlItem branches", () => {
+		const baseProps = {
+			binding: {},
+			lineIndex: 1 as const,
+			algoParamSlotIndex: {},
+			getAlgoControlValue: () => 0,
+			setAlgoControlValue: () => {},
+			getActiveSelectOption: () => null,
+			applyOptionAssignments: () => {},
+		};
+
+		const { rerender } = render(
+			<AlgoControlItem {...baseProps} control={{ id: "num", label: "Num" }} />,
+		);
+		expect(screen.getByTestId("mock-knob")).toBeInTheDocument();
+
+		rerender(
+			<AlgoControlItem {...baseProps} control={{ id: "toggle", label: "Toggle", kind: "toggle" }} />,
+		);
+		expect(screen.getByRole("checkbox")).toBeInTheDocument();
+
+		rerender(
+			<AlgoControlItem {...baseProps} control={selectControl} />,
+		);
+		expect(screen.getAllByRole("button")).toHaveLength(2);
+	});
+
+	it("renders AlgoControlsGroup empty and populated states", () => {
+		const sharedProps = {
+			controlBindings: {},
+			lineIndex: 1 as const,
+			algoParamSlotIndex: {},
+			getAlgoControlValue: () => 0,
+			setAlgoControlValue: () => {},
+			getActiveSelectOption: () => null,
+			applyOptionAssignments: () => {},
+		};
+		const { rerender } = render(
+			<AlgoControlsGroup {...sharedProps} controls={[]} />,
+		);
+		expect(screen.getByText("No controls for this algo")).toBeInTheDocument();
+
+		rerender(
+			<AlgoControlsGroup
+				{...sharedProps}
+				controls={[{ id: "depth", label: "Depth" }]}
+			/>,
+		);
+		expect(screen.getByText("Algo Controls")).toBeInTheDocument();
+		expect(screen.getByTestId("mock-knob")).toBeInTheDocument();
+	});
+
+	it("renders AlgoIconGrid and dispatches selection", () => {
+		const onChange = vi.fn();
+		render(<AlgoIconGrid value={{ id: 1 }} onChange={onChange} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Algo 2" }));
+		expect(onChange).toHaveBeenCalledWith({ id: 2 });
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/controls.browser.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/controls.browser.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ControlKnob from "./ControlKnob";
+import LineSelectControl from "./LineSelectControl";
+import ModModeControl from "./ModModeControl";
+import CzHorizontalSlider from "./sliders/CzHorizontalSlider";
+import CzVerticalSlider from "./sliders/CzVerticalSlider";
+
+const useSynthParamMock = vi.fn();
+const useOptionalSynthControllerMock = vi.fn();
+
+vi.mock("@/features/synth/SynthParamController", () => ({
+	useSynthParam: (...args: unknown[]) => useSynthParamMock(...args),
+	useOptionalSynthController: () => useOptionalSynthControllerMock(),
+}));
+
+vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
+	default: ({ children }: { children: ReactNode }) => (
+		<div data-testid="modulatable-wrapper">{children}</div>
+	),
+}));
+
+describe("core controls (browser)", () => {
+	beforeEach(() => {
+		useSynthParamMock.mockReset();
+		useOptionalSynthControllerMock.mockReset();
+		useOptionalSynthControllerMock.mockReturnValue(null);
+	});
+
+	it("renders and updates LineSelectControl", () => {
+		const setValue = vi.fn();
+		useSynthParamMock.mockReturnValue({ value: "L1", setValue });
+		render(<LineSelectControl />);
+
+		expect(screen.getAllByRole("button")).toHaveLength(5);
+		fireEvent.click(screen.getAllByRole("button")[2]);
+		expect(setValue).toHaveBeenCalledWith("L2");
+	});
+
+	it("renders and updates ModModeControl", () => {
+		const setValue = vi.fn();
+		useSynthParamMock.mockReturnValue({ value: "normal", setValue });
+		render(<ModModeControl />);
+
+		fireEvent.click(screen.getAllByRole("button")[1]);
+		expect(setValue).toHaveBeenCalledWith("ring");
+	});
+
+	it("supports ControlKnob value editing", () => {
+		const onChange = vi.fn();
+		render(
+			<ControlKnob value={0.25} onChange={onChange} label="Cutoff" min={0} max={1} />,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Cutoff value" }));
+		const input = screen.getByRole("textbox", { name: "Cutoff value" });
+		fireEvent.change(input, { target: { value: "0.75" } });
+		fireEvent.keyDown(input, { key: "Enter" });
+		expect(onChange).toHaveBeenCalledWith(0.75);
+	});
+
+	it("renders horizontal slider inside modulation wrapper when destination exists", () => {
+		const onChange = vi.fn();
+		render(
+			<CzHorizontalSlider
+				value={0.2}
+				min={0}
+				max={1}
+				onChange={onChange}
+				modDestination="volume"
+			/>,
+		);
+
+		fireEvent.change(screen.getByRole("slider"), { target: { value: "0.4" } });
+		expect(onChange).toHaveBeenCalledWith(0.4);
+		expect(screen.getByTestId("modulatable-wrapper")).toBeInTheDocument();
+	});
+
+	it("supports CzVerticalSlider keyboard interaction", () => {
+		const onChange = vi.fn();
+		render(
+			<CzVerticalSlider
+				value={0.5}
+				min={0}
+				max={1}
+				step={0.1}
+				onChange={onChange}
+				ariaLabel="Level"
+			/>,
+		);
+
+		const slider = screen.getByRole("slider", { name: "Level" });
+		fireEvent.keyDown(slider, { key: "ArrowUp" });
+		fireEvent.keyDown(slider, { key: "ArrowDown" });
+		const values = onChange.mock.calls.map(([value]) => value as number);
+		expect(values[0]).toBeCloseTo(0.6, 10);
+		expect(values[1]).toBeCloseTo(0.4, 10);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulatableControl.browser.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulatableControl.browser.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { ModMatrixProvider } from "@/context/ModMatrixContext";
+import type { ModMatrix } from "@/lib/synth/bindings/synth";
+import ControlKnob from "../ControlKnob";
+
+function ModulationHarness() {
+	const [modMatrix, setModMatrix] = useState<ModMatrix>({ routes: [] });
+	const [value, setValue] = useState(0.5);
+
+	return (
+		<ModMatrixProvider modMatrix={modMatrix} setModMatrix={setModMatrix}>
+			<ControlKnob
+				label="Volume"
+				value={value}
+				onChange={setValue}
+				min={0}
+				max={1}
+				modDestination="volume"
+			/>
+		</ModMatrixProvider>
+	);
+}
+
+describe("ModulatableControl browser integration", () => {
+	it("adds, edits, and removes routes through the modulation menu", () => {
+		render(<ModulationHarness />);
+
+		const modulationButton = screen.getByRole("button", {
+			name: /modulation for volume/i,
+		});
+
+		fireEvent.click(modulationButton);
+		fireEvent.click(screen.getByRole("button", { name: /^LFO 1$/i }));
+		expect(modulationButton).toHaveTextContent("1");
+
+		fireEvent.change(screen.getByRole("slider"), {
+			target: { value: "0.25" },
+		});
+		expect(screen.getByText("0.25")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "✕" }));
+		expect(modulationButton).toHaveTextContent("+");
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulatableControl.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulatableControl.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ModulatableControl from "./ModulatableControl";
+
+const useModMatrixMock = vi.fn();
+const modulationIconPropsSpy = vi.fn();
+const modulationMenuPropsSpy = vi.fn();
+
+vi.mock("@/context/ModMatrixContext", () => ({
+	useModMatrix: () => useModMatrixMock(),
+}));
+
+vi.mock("./ModulationIconButton", () => ({
+	default: (props: Record<string, unknown>) => {
+		modulationIconPropsSpy(props);
+		return (
+			<button type="button" onClick={props.onClick as () => void}>
+				icon
+			</button>
+		);
+	},
+}));
+
+vi.mock("./ModulationMenu", () => ({
+	default: (props: Record<string, unknown>) => {
+		modulationMenuPropsSpy(props);
+		return (
+			<div data-testid="modulation-menu">
+				<button type="button" onClick={props.onClose as () => void}>
+					close menu
+				</button>
+			</div>
+		);
+	},
+}));
+
+describe("ModulatableControl", () => {
+	beforeEach(() => {
+		useModMatrixMock.mockReset();
+		modulationIconPropsSpy.mockReset();
+		modulationMenuPropsSpy.mockReset();
+	});
+
+	it("passes active route count for destination to icon", () => {
+		useModMatrixMock.mockReturnValue({
+			modMatrix: {
+				routes: [
+					{ source: "lfo1", destination: "volume", amount: 0.4, enabled: true },
+					{ source: "velocity", destination: "volume", amount: 0.2, enabled: true },
+					{ source: "modWheel", destination: "line1Level", amount: 0.3, enabled: true },
+				],
+			},
+			setModMatrix: vi.fn(),
+		});
+
+		render(
+			<ModulatableControl destinationId="volume" label="Volume">
+				<div>child</div>
+			</ModulatableControl>,
+		);
+
+		const props = modulationIconPropsSpy.mock.calls[0][0] as {
+			hasActiveRoutes: boolean;
+			routeCount: number;
+			label: string;
+		};
+		expect(props.hasActiveRoutes).toBe(true);
+		expect(props.routeCount).toBe(2);
+		expect(props.label).toBe("Modulation for Volume");
+	});
+
+	it("opens menu and supports route mutations", () => {
+		const setModMatrix = vi.fn();
+		useModMatrixMock.mockReturnValue({
+			modMatrix: {
+				routes: [
+					{ source: "lfo1", destination: "volume", amount: 0.4, enabled: true },
+					{ source: "modWheel", destination: "line1Level", amount: 0.3, enabled: true },
+				],
+			},
+			setModMatrix,
+		});
+
+		render(
+			<ModulatableControl destinationId="volume" label="Volume">
+				<div>child</div>
+			</ModulatableControl>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "icon" }));
+		expect(screen.getByTestId("modulation-menu")).toBeInTheDocument();
+
+		const menuProps = modulationMenuPropsSpy.mock.calls[0][0] as {
+			onAddRoute: (source: "velocity") => void;
+			onToggleEnabled: (index: number) => void;
+			onAmountChange: (index: number, amount: number) => void;
+			onRemoveRoute: (index: number) => void;
+		};
+		menuProps.onAddRoute("velocity");
+		menuProps.onToggleEnabled(0);
+		menuProps.onAmountChange(0, 0.9);
+		menuProps.onRemoveRoute(0);
+
+		expect(setModMatrix).toHaveBeenCalledTimes(4);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationIconButton.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationIconButton.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ModulationIconButton from "./ModulationIconButton";
+
+describe("ModulationIconButton", () => {
+	it("shows plus indicator when no routes", () => {
+		render(
+			<ModulationIconButton
+				hasActiveRoutes={false}
+				routeCount={0}
+				label="Modulation"
+				onClick={vi.fn()}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Modulation" })).toHaveTextContent("+");
+	});
+
+	it("shows route count and handles click", () => {
+		const onClick = vi.fn();
+		render(
+			<ModulationIconButton
+				hasActiveRoutes
+				routeCount={3}
+				label="Modulation"
+				onClick={onClick}
+			/>,
+		);
+
+		const button = screen.getByRole("button", { name: "Modulation" });
+		expect(button).toHaveTextContent("3");
+		fireEvent.click(button);
+		expect(onClick).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationMenu.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationMenu.test.tsx
@@ -1,11 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { ModRoute } from "@/lib/synth/bindings/synth";
 import ModulationMenu from "./ModulationMenu";
 
-const routes = [
+const routes: ModRoute[] = [
 	{ source: "lfo1", destination: "volume", amount: 0.5, enabled: true },
 	{ source: "modWheel", destination: "volume", amount: -0.2, enabled: false },
-] as const;
+];
 
 describe("ModulationMenu", () => {
 	it("renders routes with labels and values", () => {

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationMenu.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationMenu.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ModulationMenu from "./ModulationMenu";
+
+const routes = [
+	{ source: "lfo1", destination: "volume", amount: 0.5, enabled: true },
+	{ source: "modWheel", destination: "volume", amount: -0.2, enabled: false },
+] as const;
+
+describe("ModulationMenu", () => {
+	it("renders routes with labels and values", () => {
+		render(
+			<ModulationMenu
+				title="Volume"
+				routes={[...routes]}
+				onToggleEnabled={vi.fn()}
+				onRemoveRoute={vi.fn()}
+				onAmountChange={vi.fn()}
+				onAddRoute={vi.fn()}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("Volume")).toBeInTheDocument();
+		expect(screen.getByText("LFO 1")).toBeInTheDocument();
+		expect(screen.getByText("Mod Wheel")).toBeInTheDocument();
+		expect(screen.getByText("0.50")).toBeInTheDocument();
+	});
+
+	it("dispatches route actions", () => {
+		const onToggleEnabled = vi.fn();
+		const onRemoveRoute = vi.fn();
+		const onAmountChange = vi.fn();
+		const onClose = vi.fn();
+		render(
+			<ModulationMenu
+				title="Volume"
+				routes={[...routes]}
+				onToggleEnabled={onToggleEnabled}
+				onRemoveRoute={onRemoveRoute}
+				onAmountChange={onAmountChange}
+				onAddRoute={vi.fn()}
+				onClose={onClose}
+			/>,
+		);
+
+		fireEvent.click(screen.getAllByRole("checkbox")[0]);
+		fireEvent.click(screen.getAllByRole("button", { name: "✕" })[1]);
+		fireEvent.change(screen.getAllByRole("slider")[0], {
+			target: { value: "0.25" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+		expect(onToggleEnabled).toHaveBeenCalledWith(0);
+		expect(onRemoveRoute).toHaveBeenCalledWith(1);
+		expect(onAmountChange).toHaveBeenCalledWith(0, 0.25);
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it("dispatches add source actions", () => {
+		const onAddRoute = vi.fn();
+		render(
+			<ModulationMenu
+				title="Volume"
+				routes={[]}
+				onToggleEnabled={vi.fn()}
+				onRemoveRoute={vi.fn()}
+				onAmountChange={vi.fn()}
+				onAddRoute={onAddRoute}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Velocity" }));
+		expect(onAddRoute).toHaveBeenCalledWith("velocity");
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationMenu.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/ModulationMenu.test.tsx
@@ -22,8 +22,8 @@ describe("ModulationMenu", () => {
 		);
 
 		expect(screen.getByText("Volume")).toBeInTheDocument();
-		expect(screen.getByText("LFO 1")).toBeInTheDocument();
-		expect(screen.getByText("Mod Wheel")).toBeInTheDocument();
+		expect(screen.getAllByText("LFO 1")).toHaveLength(2);
+		expect(screen.getAllByText("Mod Wheel")).toHaveLength(2);
 		expect(screen.getByText("0.50")).toBeInTheDocument();
 	});
 

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/modulation.browser.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/modulation.browser.test.tsx
@@ -1,12 +1,13 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { ModRoute } from "@/lib/synth/bindings/synth";
 import ModulationIconButton from "./ModulationIconButton";
 import ModulationMenu from "./ModulationMenu";
 
-const routes = [
+const routes: ModRoute[] = [
 	{ source: "lfo1", destination: "volume", amount: 0.5, enabled: true },
 	{ source: "modWheel", destination: "volume", amount: -0.2, enabled: false },
-] as const;
+];
 
 describe("modulation controls (browser)", () => {
 	it("renders ModulationIconButton states", () => {

--- a/packages/cosmo-pd101/webview/src/components/controls/modulation/modulation.browser.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/modulation/modulation.browser.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import ModulationIconButton from "./ModulationIconButton";
+import ModulationMenu from "./ModulationMenu";
+
+const routes = [
+	{ source: "lfo1", destination: "volume", amount: 0.5, enabled: true },
+	{ source: "modWheel", destination: "volume", amount: -0.2, enabled: false },
+] as const;
+
+describe("modulation controls (browser)", () => {
+	it("renders ModulationIconButton states", () => {
+		const onClick = vi.fn();
+		const { rerender } = render(
+			<ModulationIconButton
+				hasActiveRoutes={false}
+				routeCount={0}
+				label="Modulation"
+				onClick={onClick}
+			/>,
+		);
+
+		const button = screen.getByRole("button", { name: "Modulation" });
+		expect(button).toHaveTextContent("+");
+		fireEvent.click(button);
+		expect(onClick).toHaveBeenCalledTimes(1);
+
+		rerender(
+			<ModulationIconButton
+				hasActiveRoutes
+				routeCount={2}
+				label="Modulation"
+				onClick={onClick}
+			/>,
+		);
+		expect(screen.getByRole("button", { name: "Modulation" })).toHaveTextContent("2");
+	});
+
+	it("renders ModulationMenu route management actions", () => {
+		const onToggleEnabled = vi.fn();
+		const onRemoveRoute = vi.fn();
+		const onAmountChange = vi.fn();
+		const onAddRoute = vi.fn();
+		const onClose = vi.fn();
+		render(
+			<ModulationMenu
+				title="Volume"
+				routes={[...routes]}
+				onToggleEnabled={onToggleEnabled}
+				onRemoveRoute={onRemoveRoute}
+				onAmountChange={onAmountChange}
+				onAddRoute={onAddRoute}
+				onClose={onClose}
+			/>,
+		);
+
+		expect(screen.getAllByText("LFO 1")).toHaveLength(2);
+		fireEvent.click(screen.getAllByRole("checkbox")[0]);
+		fireEvent.click(screen.getAllByRole("button", { name: "✕" })[0]);
+		fireEvent.change(screen.getAllByRole("slider")[0], {
+			target: { value: "0.25" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Velocity" }));
+		fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+		expect(onToggleEnabled).toHaveBeenCalledWith(0);
+		expect(onRemoveRoute).toHaveBeenCalledWith(0);
+		expect(onAmountChange).toHaveBeenCalledWith(0, 0.25);
+		expect(onAddRoute).toHaveBeenCalledWith("velocity");
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/sliders/CzHorizontalSlider.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/sliders/CzHorizontalSlider.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import CzHorizontalSlider from "./CzHorizontalSlider";
 
 vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
-	default: ({ children }: { children: React.ReactNode }) => (
+	default: ({ children }: { children: ReactNode }) => (
 		<div data-testid="modulatable-wrapper">{children}</div>
 	),
 }));

--- a/packages/cosmo-pd101/webview/src/components/controls/sliders/CzHorizontalSlider.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/sliders/CzHorizontalSlider.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CzHorizontalSlider from "./CzHorizontalSlider";
+
+vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
+	default: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="modulatable-wrapper">{children}</div>
+	),
+}));
+
+describe("CzHorizontalSlider", () => {
+	it("renders a range input and emits numeric changes", () => {
+		const onChange = vi.fn();
+		render(<CzHorizontalSlider value={0.2} min={0} max={1} onChange={onChange} />);
+
+		const slider = screen.getByRole("slider");
+		fireEvent.change(slider, { target: { value: "0.75" } });
+		expect(onChange).toHaveBeenCalledWith(0.75);
+	});
+
+	it("supports disabled state", () => {
+		render(<CzHorizontalSlider value={0.2} min={0} max={1} onChange={vi.fn()} disabled />);
+		expect(screen.getByRole("slider")).toBeDisabled();
+	});
+
+	it("wraps in modulatable control when destination is provided", () => {
+		render(
+			<CzHorizontalSlider
+				value={0.2}
+				min={0}
+				max={1}
+				onChange={vi.fn()}
+				modDestination="volume"
+			/>,
+		);
+		expect(screen.getByTestId("modulatable-wrapper")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/sliders/CzVerticalSlider.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/sliders/CzVerticalSlider.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CzVerticalSlider from "./CzVerticalSlider";
+
+vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
+	default: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="modulatable-wrapper">{children}</div>
+	),
+}));
+
+describe("CzVerticalSlider", () => {
+	it("renders slider semantics with current value", () => {
+		render(
+			<CzVerticalSlider
+				value={0.4}
+				min={0}
+				max={1}
+				onChange={vi.fn()}
+				ariaLabel="Volume"
+			/>,
+		);
+
+		const slider = screen.getByRole("slider", { name: "Volume" });
+		expect(slider).toHaveAttribute("aria-valuenow", "0.4");
+	});
+
+	it("handles keyboard and wheel adjustments", () => {
+		const onChange = vi.fn();
+		render(
+			<CzVerticalSlider
+				value={0.5}
+				min={0}
+				max={1}
+				step={0.1}
+				onChange={onChange}
+				ariaLabel="Level"
+			/>,
+		);
+
+		const slider = screen.getByRole("slider", { name: "Level" });
+		fireEvent.keyDown(slider, { key: "ArrowUp" });
+		fireEvent.keyDown(slider, { key: "ArrowDown" });
+		fireEvent.wheel(slider, { deltaY: -100 });
+
+		expect(onChange).toHaveBeenNthCalledWith(1, 0.6);
+		expect(onChange).toHaveBeenNthCalledWith(2, 0.4);
+		expect(onChange).toHaveBeenNthCalledWith(3, 0.6);
+	});
+
+	it("wraps in modulatable control when destination is provided", () => {
+		render(
+			<CzVerticalSlider
+				value={0.5}
+				min={0}
+				max={1}
+				onChange={vi.fn()}
+				modDestination="volume"
+			/>,
+		);
+		expect(screen.getByTestId("modulatable-wrapper")).toBeInTheDocument();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/controls/sliders/CzVerticalSlider.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/sliders/CzVerticalSlider.test.tsx
@@ -43,9 +43,10 @@ describe("CzVerticalSlider", () => {
 		fireEvent.keyDown(slider, { key: "ArrowDown" });
 		fireEvent.wheel(slider, { deltaY: -100 });
 
-		expect(onChange).toHaveBeenNthCalledWith(1, 0.6);
-		expect(onChange).toHaveBeenNthCalledWith(2, 0.4);
-		expect(onChange).toHaveBeenNthCalledWith(3, 0.6);
+		const values = onChange.mock.calls.map(([v]) => v as number);
+		expect(values[0]).toBeCloseTo(0.6, 10);
+		expect(values[1]).toBeCloseTo(0.4, 10);
+		expect(values[2]).toBeCloseTo(0.6, 10);
 	});
 
 	it("wraps in modulatable control when destination is provided", () => {

--- a/packages/cosmo-pd101/webview/src/components/controls/sliders/CzVerticalSlider.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/controls/sliders/CzVerticalSlider.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import CzVerticalSlider from "./CzVerticalSlider";
 
 vi.mock("@/components/controls/modulation/ModulatableControl", () => ({
-	default: ({ children }: { children: React.ReactNode }) => (
+	default: ({ children }: { children: ReactNode }) => (
 		<div data-testid="modulatable-wrapper">{children}</div>
 	),
 }));

--- a/packages/cosmo-pd101/webview/src/components/primitives/Card.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/primitives/Card.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Card, {
+	CARD_BASE_CLASSES,
+	getCardClassName,
+	joinClasses,
+} from "./Card";
+
+describe("Card", () => {
+	it("joinClasses omits falsey values", () => {
+		expect(joinClasses("a", undefined, "", false, "b", null)).toBe("a b");
+	});
+
+	it("getCardClassName composes base, variant, padding and custom classes", () => {
+		expect(
+			getCardClassName({
+				variant: "hero",
+				padding: "lg",
+				className: "extra",
+			}),
+		).toContain(`${CARD_BASE_CLASSES} rounded-2xl bg-cz-surface p-6 extra`);
+	});
+
+	it("renders as the provided element type", () => {
+		render(
+			<Card as="section" variant="panel-gold" padding="sm" data-testid="card">
+				content
+			</Card>,
+		);
+
+		const card = screen.getByTestId("card");
+		expect(card.tagName).toBe("SECTION");
+		expect(card).toHaveClass("card", "text-cz-cream", "cz-section-gold", "p-3");
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/primitives/CzButton.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/primitives/CzButton.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CzButton from "./CzButton";
+
+describe("CzButton", () => {
+	it("renders label and handles click", () => {
+		const onClick = vi.fn();
+		render(<CzButton onClick={onClick}>L1</CzButton>);
+
+		fireEvent.click(screen.getByRole("button"));
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(screen.getByText("L1")).toBeInTheDocument();
+	});
+
+	it("shows inactive LED class by default and active class when active", () => {
+		const { rerender, container } = render(<CzButton>Test</CzButton>);
+		expect(container.querySelector("span[aria-hidden='true']")).toHaveClass(
+			"bg-cz-led-off",
+		);
+
+		rerender(<CzButton active>Test</CzButton>);
+		expect(container.querySelector("span[aria-hidden='true']")).toHaveClass(
+			"bg-cz-led-on",
+		);
+	});
+
+	it("renders tooltip wrapper and supports disabled", () => {
+		render(
+			<CzButton tooltip="Helpful" disabled>
+				Disabled
+			</CzButton>,
+		);
+
+		const button = screen.getByRole("button");
+		expect(button).toBeDisabled();
+		expect(button.closest("[data-tip='Helpful']")).not.toBeNull();
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/primitives/CzTabButton.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/primitives/CzTabButton.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import CzTabButton from "./CzTabButton";
+
+describe("CzTabButton", () => {
+	it("renders two-line labels and click handler", () => {
+		const onClick = vi.fn();
+		render(
+			<CzTabButton topLabel="DCO" bottomLabel="ENV" onClick={onClick} />,
+		);
+
+		fireEvent.click(screen.getByRole("button"));
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(screen.getByText("DCO")).toBeInTheDocument();
+		expect(screen.getByText("ENV")).toBeInTheDocument();
+	});
+
+	it("sets pressed state and LED color based on active", () => {
+		const { rerender, container } = render(
+			<CzTabButton topLabel="A" bottomLabel="B" active />,
+		);
+
+		expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+		expect(container.querySelector("span[aria-hidden='true']")).toHaveClass(
+			"bg-cz-led-on",
+		);
+
+		rerender(<CzTabButton topLabel="A" bottomLabel="B" active={false} />);
+		expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+		expect(container.querySelector("span[aria-hidden='true']")).toHaveClass(
+			"bg-cz-led-off",
+		);
+	});
+
+	it("can hide LED and apply color palette", () => {
+		const { container } = render(
+			<CzTabButton topLabel="X" bottomLabel="Y" showLed={false} color="cyan" />,
+		);
+
+		expect(container.querySelector("span[aria-hidden='true']")).toBeNull();
+		expect(screen.getByRole("button").className).toContain("border-[#3a838c]");
+	});
+});

--- a/packages/cosmo-pd101/webview/src/components/primitives/primitives.browser.test.tsx
+++ b/packages/cosmo-pd101/webview/src/components/primitives/primitives.browser.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Card from "./Card";
+import CzButton from "./CzButton";
+import CzTabButton from "./CzTabButton";
+
+describe("primitive components (browser)", () => {
+	it("renders Card as a custom element with expected classes", () => {
+		render(
+			<Card as="section" variant="hero" padding="lg" data-testid="card">
+				content
+			</Card>,
+		);
+
+		const card = screen.getByTestId("card");
+		expect(card.tagName).toBe("SECTION");
+		expect(card).toHaveClass("card", "bg-cz-surface", "p-6");
+	});
+
+	it("renders CzButton with tooltip and click behavior", () => {
+		const onClick = vi.fn();
+		render(
+			<CzButton onClick={onClick} tooltip="Choose line" active>
+				L1
+			</CzButton>,
+		);
+
+		fireEvent.click(screen.getByRole("button"));
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(screen.getByRole("button").closest("[data-tip='Choose line']")).not.toBeNull();
+		expect(screen.getByText("L1")).toBeInTheDocument();
+	});
+
+	it("renders CzTabButton labels and pressed state", () => {
+		const onClick = vi.fn();
+		render(
+			<CzTabButton
+				topLabel="PHASE"
+				bottomLabel="MOD"
+				active
+				onClick={onClick}
+			/>,
+		);
+
+		const button = screen.getByRole("button");
+		fireEvent.click(button);
+		expect(onClick).toHaveBeenCalledTimes(1);
+		expect(button).toHaveAttribute("aria-pressed", "true");
+		expect(screen.getByText("PHASE")).toBeInTheDocument();
+		expect(screen.getByText("MOD")).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary
Adds comprehensive unit tests for all components under:
- `packages/cosmo-pd101/webview/src/components/primitives`
- `packages/cosmo-pd101/webview/src/components/controls`

## What was added
1. Primitive component tests:
   - `Card`
   - `CzButton`
   - `CzTabButton`

2. Core control and slider tests:
   - `ControlKnob`
   - `LineSelectControl`
   - `ModModeControl`
   - `sliders/CzHorizontalSlider`
   - `sliders/CzVerticalSlider`

3. Algo control tests:
   - `algo/AlgoControlItem`
   - `algo/AlgoControlNumber`
   - `algo/AlgoControlSelect`
   - `algo/AlgoControlToggle`
   - `algo/AlgoControlTooltip`
   - `algo/AlgoControlsGroup`
   - `algo/AlgoIconGrid`

4. Modulation control tests:
   - `modulation/ModulatableControl`
   - `modulation/ModulationIconButton`
   - `modulation/ModulationMenu`

## Notes
- Tests focus on rendering, interaction behavior, branching paths, and callback wiring.
- Mocks are used where appropriate to isolate each component's behavior.