### PR TITLE
chore: run all workspace package tests from root test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"package:plugin:installer:macos": "bun run scripts/package-plugin-installers.mjs --platform macos",
 		"package:plugin:installer:windows": "bun run scripts/package-plugin-installers.mjs --platform windows",
 		"package:plugin:installer:linux": "bun run scripts/package-plugin-installers.mjs --platform linux",
-		"test": "bun --filter @cosmo/cz-explorer test:all && cargo test --workspace",
+		"test": "bun --filter '*' test && cargo test --workspace",
 		"lint": "bun --filter @cosmo/cz-explorer lint && cargo fmt --all --check && cargo clippy --workspace --all-targets",
 		"lint:fix": "bun --filter @cosmo/cz-explorer lint:fix && cargo fmt --all",
 		"clean": "rimraf --glob packages/*/dist packages/**/lib-dist packages/*/target src-tauri/target",

--- a/packages/cz-explorer/package.json
+++ b/packages/cz-explorer/package.json
@@ -11,7 +11,7 @@
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "drizzle-kit migrate",
 		"db:studio": "drizzle-kit studio",
-		"test": "bun --filter @cosmo/cosmo-pd101-webview build:lib && vitest --project unit",
+		"test": "bun --filter @cosmo/cosmo-pd101-webview build:lib && vitest --run",
 		"test:unit": "bun --filter @cosmo/cosmo-pd101-webview build:lib && vitest --project unit --run",
 		"test:browser": "bun --filter @cosmo/cosmo-pd101-webview build:lib && vitest --project browser --run",
 		"test:all": "bun --filter @cosmo/cosmo-pd101-webview build:lib && vitest --run",


### PR DESCRIPTION
## Summary

Fixes the root `test` script so that `bun run test` runs tests across **all** workspace packages automatically, without requiring changes to `package.json` when new packages are added.

## Changes

- **`package.json`**: Changed `bun --filter @cosmo/cz-explorer test:all` → `bun --filter '*' test`. This uses Bun's wildcard workspace filter so any package with a `test` script is included automatically. `cargo test --workspace` already auto-discovers all Rust crates.
- **`packages/cz-explorer/package.json`**: Fixed the `test` script to run all Vitest projects (`vitest --run`) instead of only the `unit` project — browser-mode tests are now included.

## Before / After

| | Before | After |
|---|---|---|
| `bun run test` covers | `cz-explorer` unit tests + Rust | All workspace `test` scripts + Rust |
| `cz-explorer` `test` script | unit project only | unit + browser projects |
| New package auto-discovered | No | Yes (add `"test"` script to package) |