### PR TITLE
feat: persist synth UI state

### DIFF
--- a/packages/cosmo-pd101-plugin/webview/e2e/plugin-shell-visual.spec.ts
+++ b/packages/cosmo-pd101-plugin/webview/e2e/plugin-shell-visual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { setupPluginPage } from "./helpers/pluginBridge";
+import { setupPluginPage, waitForBridge } from "./helpers/pluginBridge";
 
 test.beforeEach(async ({ page }) => {
 	await page.setViewportSize({ width: 1440, height: 980 });
@@ -37,5 +37,42 @@ test.describe("Plugin shell visual smoke", () => {
 			path: testInfo.outputPath("plugin-shell-mini-keyboard.png"),
 			fullPage: true,
 		});
+	});
+
+	test("persists synth shell UI state across reloads", async ({ page }) => {
+		await expect(page.getByTestId("test-harness")).toBeVisible();
+
+		const scopeButton = page.getByRole("button", { name: /Scope\s+View/i });
+		await scopeButton.click();
+		await expect(scopeButton).toHaveAttribute("aria-pressed", "true");
+
+		await page.getByRole("button", { name: "ENV" }).nth(1).click();
+		await page.getByText(/^DCA$/).locator("..").locator("button").click();
+		await expect(page.getByText("Line 2 DCA")).toBeVisible();
+
+		await page.getByRole("button", { name: /Hide Keys/i }).click();
+		await expect(page.getByTestId("mini-keyboard-overlay")).not.toBeVisible();
+
+		await page.getByText(/^FX$/).last().locator("..").locator("button").click();
+		await expect(page.getByText("Chorus").first()).toBeVisible();
+
+		await page.reload();
+		await page.waitForLoadState("networkidle");
+		await waitForBridge(page);
+
+		await expect(page.getByText("Chorus").first()).toBeVisible();
+		await expect(scopeButton).toHaveAttribute("aria-pressed", "true");
+		await expect(page.getByTestId("mini-keyboard-overlay")).not.toBeVisible();
+		await expect(
+			page.getByRole("button", { name: /Show Keys/i }),
+		).toBeVisible();
+
+		await page
+			.getByText(/^Main$/)
+			.last()
+			.locator("..")
+			.locator("button")
+			.click();
+		await expect(page.getByText("Line 2 DCA")).toBeVisible();
 	});
 });

--- a/packages/cosmo-pd101-plugin/webview/playwright.config.ts
+++ b/packages/cosmo-pd101-plugin/webview/playwright.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import { defineConfig, devices } from "@playwright/test";
 
 /**
@@ -17,7 +19,7 @@ export default defineConfig({
 	reporter: process.env.CI ? "github" : "list",
 
 	use: {
-		baseURL: "http://localhost:5175",
+		baseURL: "http://127.0.0.1:5175",
 		trace: "on-first-retry",
 		screenshot: "only-on-failure",
 	},
@@ -30,9 +32,10 @@ export default defineConfig({
 	],
 
 	webServer: {
-		command: "bunx --bun vite --port 5175",
-		url: "http://localhost:5175",
-		reuseExistingServer: !process.env.CI,
+		command:
+			"bun --filter @cosmo/cosmo-pd101 build:lib && bunx --bun vite --host 127.0.0.1 --port 5175 --strictPort",
+		url: "http://127.0.0.1:5175",
+		reuseExistingServer: false,
 		env: {
 			VITE_TEST_HARNESS: "1",
 			VITE_DEBUG_PANEL: "0",

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
@@ -1,5 +1,4 @@
 import {
-	type AsidePanelTab,
 	DEFAULT_SYNTH_PRESETS,
 	getSynthRuntimeCapabilities,
 	SynthRenderer,
@@ -7,6 +6,7 @@ import {
 	useNoteHandling,
 	useSynthPresetManager,
 	useSynthStore,
+	useSynthUiStore,
 } from "@cosmo/cosmo-pd101";
 import {
 	type ReactNode,
@@ -44,8 +44,8 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 	const [scopeActiveHz, setScopeActiveHz] = useState(220);
 	const analyserNodeRef = useRef<AnalyserNode | null>(null);
 	const audioCtxRef = useRef<AudioContext | null>(null);
-	const [activeAsidePanel, setActiveAsidePanel] =
-		useState<AsidePanelTab>("global");
+	const activeAsidePanel = useSynthUiStore((s) => s.activeAsidePanel);
+	const setActiveAsidePanel = useSynthUiStore((s) => s.setActiveAsidePanel);
 	const { lcdControlReadout, pushLcdControlReadout } = useLcdControlReadout();
 	const { activeNotes, sendNoteOn, sendNoteOff } = useNoteHandling({
 		velocityTarget,

--- a/packages/cosmo-pd101/package.json
+++ b/packages/cosmo-pd101/package.json
@@ -14,7 +14,7 @@
 	"scripts": {
 		"build": "bun run build:lib",
 		"build:lib": "bunx tsdown src/index.ts --format esm --dts --out-dir lib-dist --clean --no-bundle",
-		"build:lib:watch": "bunx tsdown src/index.ts --format esm --dts --out-dir lib-dist --clean --no-bundle --watch",
+		"build:lib:watch": "bunx tsdown src/index.ts --format esm --dts --out-dir lib-dist --no-bundle --watch",
 		"gen:bindings": "SPECTA_TS_EXPORT_PATH=./src/lib/synth/bindings/synth.ts cargo run --features specta-bindings --bin export-specta-bindings --manifest-path ../cosmo-synth-engine/Cargo.toml",
 		"test": "bunx vitest --project unit --run",
 		"test:unit": "bunx vitest --project unit --run",

--- a/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect } from "react";
 import type {
 	AlgoControlBinding,
 	AlgoControlOptionRuntime,
@@ -9,6 +9,8 @@ import ControlKnob from "@/components/controls/ControlKnob";
 import AlgoSectionCard from "@/components/editor/AlgoSectionCard";
 import Card from "@/components/primitives/Card";
 import CzButton from "@/components/primitives/CzButton";
+import type { EnvTab } from "@/features/synth/synthUiStore";
+import { useSynthUiStore } from "@/features/synth/synthUiStore";
 import { getCzPresetDefaults } from "@/lib/synth/algoRef";
 import type {
 	AlgoControlValueV1,
@@ -62,7 +64,6 @@ interface PerLineWarpBlockProps {
 	activeSection?: SectionTab;
 }
 
-type EnvTab = "dco" | "dcw" | "dca";
 type SectionTab = "algos" | "envelopes";
 type AlgoDefinitionRuntime = {
 	id: PdAlgo;
@@ -107,7 +108,8 @@ export const PerLineWarpBlock = memo(function PerLineWarpBlock({
 	lineIndex = 1,
 	activeSection: activeSectionProp,
 }: PerLineWarpBlockProps) {
-	const [activeEnvTab, setActiveEnvTab] = useState<EnvTab>("dcw");
+	const activeEnvTab = useSynthUiStore((s) => s.activeEnvTab);
+	const setActiveEnvTab = useSynthUiStore((s) => s.setActiveEnvTab);
 	const activeSection = activeSectionProp;
 	const algoBEnabled = algoBlend > 0.001;
 

--- a/packages/cosmo-pd101/src/components/editor/PhaseLinesSection.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PhaseLinesSection.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import Card, { joinClasses } from "@/components/primitives/Card";
 import CzTabButton from "@/components/primitives/CzTabButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import type { PhaseLinePanelTab } from "@/features/synth/synthUiStore";
+import { useSynthUiStore } from "@/features/synth/synthUiStore";
 import type { Algo, StepEnvData } from "@/lib/synth/bindings/synth";
 import { PerLineWarpBlock } from "./PerLineWarpBlock";
 
@@ -22,18 +24,11 @@ export type PhaseLinesSectionProps = {
 	envOverrideHandlers?: EnvOverrideHandlers;
 };
 
-type SidePanelTab =
-	| "line1-algos"
-	| "line2-algos"
-	| "line1-envelopes"
-	| "line2-envelopes";
-
 export default function PhaseLinesSection({
 	onActiveTabChange,
 	className,
 	envOverrideHandlers,
 }: PhaseLinesSectionProps) {
-	const { value: lineSelect } = useSynthParam("lineSelect");
 	const { value: warpAAmount, setValue: setWarpAAmount } =
 		useSynthParam("warpAAmount");
 	const { value: warpBAmount, setValue: setWarpBAmount } =
@@ -167,10 +162,8 @@ export default function PhaseLinesSection({
 		setKeyFollow: setLine2DcwKeyFollow,
 	};
 
-	const showLineA = lineSelect !== "L2";
-	const [activeTab, setActiveTab] = useState<SidePanelTab>(
-		showLineA ? "line1-algos" : "line2-algos",
-	);
+	const activeTab = useSynthUiStore((s) => s.phaseLinePanelTab);
+	const setActiveTab = useSynthUiStore((s) => s.setPhaseLinePanelTab);
 
 	const activeLine: "line1" | "line2" = activeTab.startsWith("line1")
 		? "line1"
@@ -190,7 +183,7 @@ export default function PhaseLinesSection({
 		label: "L1" | "L2";
 		color: "red" | "blue";
 		tabs: Array<{
-			id: SidePanelTab;
+			id: PhaseLinePanelTab;
 			bottomLabel: string;
 		}>;
 	}> = [

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -1,10 +1,5 @@
 import { AnimatePresence, motion } from "motion/react";
-import {
-	type CSSProperties,
-	type ReactNode,
-	type RefObject,
-	useState,
-} from "react";
+import type { CSSProperties, ReactNode, RefObject } from "react";
 import LineSelectControl from "@/components/controls/LineSelectControl";
 import ModModeControl from "@/components/controls/ModModeControl";
 import type { EnvOverrideHandlers } from "@/components/editor/PhaseLinesSection";
@@ -32,6 +27,7 @@ import CzButton from "@/components/primitives/CzButton";
 import { ModMatrixProvider } from "@/context/ModMatrixContext";
 import { SynthParamControllerProvider } from "@/features/synth/SynthParamController";
 import { useSynthStore } from "@/features/synth/synthStore";
+import { useSynthUiStore } from "@/features/synth/synthUiStore";
 import { HoverInfoProvider, useHoverInfo } from "../layout/HoverInfo";
 import MiniKeyboardOverlay from "../layout/MiniKeyboardOverlay";
 
@@ -67,8 +63,6 @@ type SynthRendererProps = {
 		onNoteOff: (note: number) => void;
 	};
 };
-
-type MainPanelMode = "phase" | "fx" | "mod";
 
 export default function SynthRenderer({
 	headerProps,
@@ -135,8 +129,10 @@ function SynthRendererContent({
 }: SynthRendererProps) {
 	const modMatrix = useSynthStore((s) => s.modMatrix);
 	const setModMatrix = useSynthStore((s) => s.setModMatrix);
-	const [mainPanelMode, setMainPanelMode] = useState<MainPanelMode>("phase");
-	const [keyboardVisible, setKeyboardVisible] = useState(true);
+	const mainPanelMode = useSynthUiStore((s) => s.mainPanelMode);
+	const setMainPanelMode = useSynthUiStore((s) => s.setMainPanelMode);
+	const keyboardVisible = useSynthUiStore((s) => s.keyboardVisible);
+	const setKeyboardVisible = useSynthUiStore((s) => s.setKeyboardVisible);
 	const { hoverInfo } = useHoverInfo();
 	const infoText = hoverInfo
 		? hoverInfo
@@ -206,8 +202,8 @@ function SynthRendererContent({
 											<CzButton
 												active={mainPanelMode === "fx"}
 												onClick={() =>
-													setMainPanelMode((current) =>
-														current === "fx" ? "phase" : "fx",
+													setMainPanelMode(
+														mainPanelMode === "fx" ? "phase" : "fx",
 													)
 												}
 												className="[&_button]:w-18"
@@ -217,8 +213,8 @@ function SynthRendererContent({
 											<CzButton
 												active={mainPanelMode === "mod"}
 												onClick={() =>
-													setMainPanelMode((current) =>
-														current === "mod" ? "phase" : "mod",
+													setMainPanelMode(
+														mainPanelMode === "mod" ? "phase" : "mod",
 													)
 												}
 												className="[&_button]:w-18"
@@ -288,7 +284,7 @@ function SynthRendererContent({
 						{miniKeyboard ? (
 							<button
 								type="button"
-								onClick={() => setKeyboardVisible((current) => !current)}
+								onClick={() => setKeyboardVisible(!keyboardVisible)}
 								className={`rounded-sm border px-2 py-1 text-[0.56rem] uppercase tracking-[0.24em] transition-colors ${
 									keyboardVisible
 										? "border-cz-gold bg-cz-gold/10 text-cz-gold"

--- a/packages/cosmo-pd101/src/features/synth/synthUiStore.test.ts
+++ b/packages/cosmo-pd101/src/features/synth/synthUiStore.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	SYNTH_UI_STATE_STORAGE_KEY,
+	useSynthUiStore,
+} from "@/features/synth/synthUiStore";
+
+describe("synthUiStore", () => {
+	beforeEach(() => {
+		localStorage.clear();
+		useSynthUiStore.persist.clearStorage();
+		useSynthUiStore.setState({
+			activeAsidePanel: "global",
+			mainPanelMode: "phase",
+			phaseLinePanelTab: "line1-algos",
+			activeEnvTab: "dcw",
+			keyboardVisible: true,
+		});
+	});
+
+	it("persists the current synth UI state", async () => {
+		useSynthUiStore.getState().setActiveAsidePanel("reverb");
+		useSynthUiStore.getState().setMainPanelMode("fx");
+		useSynthUiStore.getState().setPhaseLinePanelTab("line2-envelopes");
+		useSynthUiStore.getState().setActiveEnvTab("dca");
+		useSynthUiStore.getState().setKeyboardVisible(false);
+		const savedState = localStorage.getItem(SYNTH_UI_STATE_STORAGE_KEY);
+
+		useSynthUiStore.setState({
+			activeAsidePanel: "global",
+			mainPanelMode: "phase",
+			phaseLinePanelTab: "line1-algos",
+			activeEnvTab: "dcw",
+			keyboardVisible: true,
+		});
+		expect(savedState).not.toBeNull();
+		localStorage.setItem(SYNTH_UI_STATE_STORAGE_KEY, savedState ?? "");
+
+		await useSynthUiStore.persist.rehydrate();
+
+		expect(useSynthUiStore.getState()).toMatchObject({
+			activeAsidePanel: "reverb",
+			mainPanelMode: "fx",
+			phaseLinePanelTab: "line2-envelopes",
+			activeEnvTab: "dca",
+			keyboardVisible: false,
+		});
+	});
+
+	it("falls back to defaults when stored values are invalid", async () => {
+		localStorage.setItem(
+			SYNTH_UI_STATE_STORAGE_KEY,
+			JSON.stringify({
+				state: {
+					activeAsidePanel: "missing",
+					mainPanelMode: "drawer",
+					phaseLinePanelTab: "line3-algos",
+					activeEnvTab: "pitch",
+					keyboardVisible: "nope",
+				},
+				version: 0,
+			}),
+		);
+
+		await useSynthUiStore.persist.rehydrate();
+
+		expect(useSynthUiStore.getState()).toMatchObject({
+			activeAsidePanel: "global",
+			mainPanelMode: "phase",
+			phaseLinePanelTab: "line1-algos",
+			activeEnvTab: "dcw",
+			keyboardVisible: true,
+		});
+	});
+});

--- a/packages/cosmo-pd101/src/features/synth/synthUiStore.ts
+++ b/packages/cosmo-pd101/src/features/synth/synthUiStore.ts
@@ -1,0 +1,128 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { AsidePanelTab } from "@/components/layout/AsidePanelSwitcher";
+
+export const SYNTH_UI_STATE_STORAGE_KEY = "cosmo-pd101-ui-state";
+
+export type MainPanelMode = "phase" | "fx" | "mod";
+export type PhaseLinePanelTab =
+	| "line1-algos"
+	| "line2-algos"
+	| "line1-envelopes"
+	| "line2-envelopes";
+export type EnvTab = "dco" | "dcw" | "dca";
+
+type SynthUiState = {
+	activeAsidePanel: AsidePanelTab;
+	mainPanelMode: MainPanelMode;
+	phaseLinePanelTab: PhaseLinePanelTab;
+	activeEnvTab: EnvTab;
+	keyboardVisible: boolean;
+};
+
+type SynthUiActions = {
+	setActiveAsidePanel: (tab: AsidePanelTab) => void;
+	setMainPanelMode: (mode: MainPanelMode) => void;
+	setPhaseLinePanelTab: (tab: PhaseLinePanelTab) => void;
+	setActiveEnvTab: (tab: EnvTab) => void;
+	setKeyboardVisible: (visible: boolean) => void;
+};
+
+export type SynthUiStore = SynthUiState & SynthUiActions;
+
+const ASIDE_PANEL_TABS = new Set<AsidePanelTab>([
+	"scope",
+	"global",
+	"phaseMod",
+	"vibrato",
+	"portamento",
+	"lfo",
+	"filter",
+	"chorus",
+	"delay",
+	"reverb",
+]);
+const MAIN_PANEL_MODES = new Set<MainPanelMode>(["phase", "fx", "mod"]);
+const PHASE_LINE_PANEL_TABS = new Set<PhaseLinePanelTab>([
+	"line1-algos",
+	"line2-algos",
+	"line1-envelopes",
+	"line2-envelopes",
+]);
+const ENV_TABS = new Set<EnvTab>(["dco", "dcw", "dca"]);
+
+const DEFAULT_UI_STATE: SynthUiState = {
+	activeAsidePanel: "global",
+	mainPanelMode: "phase",
+	phaseLinePanelTab: "line1-algos",
+	activeEnvTab: "dcw",
+	keyboardVisible: true,
+};
+
+const getStringValue = (value: unknown): string | null =>
+	typeof value === "string" ? value : null;
+
+const normalizeSynthUiState = (value: unknown): SynthUiState => {
+	if (typeof value !== "object" || value === null) {
+		return DEFAULT_UI_STATE;
+	}
+
+	const candidate = value as Partial<Record<keyof SynthUiState, unknown>>;
+	const activeAsidePanel = getStringValue(candidate.activeAsidePanel);
+	const mainPanelMode = getStringValue(candidate.mainPanelMode);
+	const phaseLinePanelTab = getStringValue(candidate.phaseLinePanelTab);
+	const activeEnvTab = getStringValue(candidate.activeEnvTab);
+
+	return {
+		activeAsidePanel:
+			activeAsidePanel &&
+			ASIDE_PANEL_TABS.has(activeAsidePanel as AsidePanelTab)
+				? (activeAsidePanel as AsidePanelTab)
+				: DEFAULT_UI_STATE.activeAsidePanel,
+		mainPanelMode:
+			mainPanelMode && MAIN_PANEL_MODES.has(mainPanelMode as MainPanelMode)
+				? (mainPanelMode as MainPanelMode)
+				: DEFAULT_UI_STATE.mainPanelMode,
+		phaseLinePanelTab:
+			phaseLinePanelTab &&
+			PHASE_LINE_PANEL_TABS.has(phaseLinePanelTab as PhaseLinePanelTab)
+				? (phaseLinePanelTab as PhaseLinePanelTab)
+				: DEFAULT_UI_STATE.phaseLinePanelTab,
+		activeEnvTab:
+			activeEnvTab && ENV_TABS.has(activeEnvTab as EnvTab)
+				? (activeEnvTab as EnvTab)
+				: DEFAULT_UI_STATE.activeEnvTab,
+		keyboardVisible:
+			typeof candidate.keyboardVisible === "boolean"
+				? candidate.keyboardVisible
+				: DEFAULT_UI_STATE.keyboardVisible,
+	};
+};
+
+export const useSynthUiStore = create<SynthUiStore>()(
+	persist(
+		(set) => ({
+			...DEFAULT_UI_STATE,
+			setActiveAsidePanel: (tab) => set({ activeAsidePanel: tab }),
+			setMainPanelMode: (mode) => set({ mainPanelMode: mode }),
+			setPhaseLinePanelTab: (tab) => set({ phaseLinePanelTab: tab }),
+			setActiveEnvTab: (tab) => set({ activeEnvTab: tab }),
+			setKeyboardVisible: (visible) => set({ keyboardVisible: visible }),
+		}),
+		{
+			name: SYNTH_UI_STATE_STORAGE_KEY,
+			storage: createJSONStorage(() => localStorage),
+			partialize: (state) => ({
+				activeAsidePanel: state.activeAsidePanel,
+				mainPanelMode: state.mainPanelMode,
+				phaseLinePanelTab: state.phaseLinePanelTab,
+				activeEnvTab: state.activeEnvTab,
+				keyboardVisible: state.keyboardVisible,
+			}),
+			merge: (persistedState, currentState) => ({
+				...currentState,
+				...normalizeSynthUiState(persistedState),
+			}),
+		},
+	),
+);

--- a/packages/cosmo-pd101/src/index.ts
+++ b/packages/cosmo-pd101/src/index.ts
@@ -7,6 +7,16 @@ export { useNoteHandling } from "./features/synth/hooks/useNoteHandling";
 export { useSynthParamsToWorklet } from "./features/synth/hooks/useSynthParamsToWorklet";
 export { getSynthRuntimeCapabilities } from "./features/synth/runtimeCapabilities";
 export { useSynthStore } from "./features/synth/synthStore";
+export type {
+	EnvTab,
+	MainPanelMode,
+	PhaseLinePanelTab,
+	SynthUiStore,
+} from "./features/synth/synthUiStore";
+export {
+	SYNTH_UI_STATE_STORAGE_KEY,
+	useSynthUiStore,
+} from "./features/synth/synthUiStore";
 export type { LibraryPreset } from "./features/synth/types/libraryPreset";
 export { useSynthPresetManager } from "./features/synth/useSynthPresetManager";
 export { useSynthState } from "./features/synth/useSynthState";

--- a/packages/cz-explorer/src/components/PhaseDistortionVisualizer.tsx
+++ b/packages/cz-explorer/src/components/PhaseDistortionVisualizer.tsx
@@ -1,5 +1,4 @@
 import {
-	type AsidePanelTab,
 	convertDecodedPatchToSynthPreset,
 	DEFAULT_SYNTH_PRESETS,
 	decodeCzPatch,
@@ -7,6 +6,7 @@ import {
 	noteToFreq,
 	pdVisualizerWorkletUrl,
 	type StepEnvData,
+	SYNTH_UI_STATE_STORAGE_KEY,
 	SynthRenderer,
 	synthBindingsUrl,
 	synthWasmUrl,
@@ -16,12 +16,14 @@ import {
 	useSynthParamsToWorklet,
 	useSynthPresetManager,
 	useSynthStore,
+	useSynthUiStore,
 } from "@cosmo/cosmo-pd101";
 import { useQuery } from "@tanstack/react-query";
 import {
 	type CSSProperties,
 	type ReactNode,
 	useCallback,
+	useEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -64,8 +66,20 @@ export function SharedPhaseDistortionVisualizer({
 	const applyPreset = useSynthStore((s) => s.applyPreset);
 
 	const [extPmAmount] = useState(0);
-	const [activeAsidePanel, setActiveAsidePanel] =
-		useState<AsidePanelTab>("scope");
+	const activeAsidePanel = useSynthUiStore((s) => s.activeAsidePanel);
+	const setActiveAsidePanel = useSynthUiStore((s) => s.setActiveAsidePanel);
+
+	useEffect(() => {
+		try {
+			if (localStorage.getItem(SYNTH_UI_STATE_STORAGE_KEY) !== null) {
+				return;
+			}
+		} catch {
+			return;
+		}
+
+		setActiveAsidePanel("scope");
+	}, [setActiveAsidePanel]);
 
 	const { audioCtxRef, analyserNodeRef, workletNodeRef, paramsRef } =
 		useAudioEngine({


### PR DESCRIPTION
Fixes #99

## Summary
- Add a persisted Zustand store for synth UI shell state, including active side panel, main panel mode, phase line panel tab, envelope tab, and mini keyboard visibility.
- Wire the shared renderer, plugin webview, and cz-explorer visualizer to the persisted store while preserving each host's fresh default panel behavior.
- Stabilize plugin webview Playwright startup so tests use a fresh harness server and rebuild the shared library before serving.
