### PR TITLE
feat(cosmo-pd101): unify infobar tooltips and live control readouts

### DIFF
--- a/packages/cosmo-pd101/src/components/controls/ControlKnob.tsx
+++ b/packages/cosmo-pd101/src/components/controls/ControlKnob.tsx
@@ -196,7 +196,6 @@ export function ControlKnob({
 	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip, {
 		useCapture: true,
 	});
-	const infoButtonHandlers = useHoverInfoHandlers(resolvedTooltip);
 
 	const inner = (
 		<div
@@ -206,20 +205,8 @@ export function ControlKnob({
 		>
 			{label && (
 				<div className="space-y-0.5">
-					<div className="flex items-center justify-center gap-1 text-3xs uppercase tracking-[0.24em] text-base-content/55">
+					<div className="flex items-center justify-center text-3xs uppercase tracking-[0.24em] text-base-content/55">
 						<span>{label}</span>
-						{resolvedTooltip ? (
-							<button
-								type="button"
-								className="btn btn-ghost btn-circle btn-xs h-4 min-h-4 w-4 border border-cz-border p-0 text-2xs font-semibold leading-none text-cz-cream/70 hover:border-cz-light-blue hover:text-cz-light-blue"
-								aria-label="Show control description"
-								data-hover-info={resolvedTooltip}
-								tabIndex={-1}
-								{...infoButtonHandlers}
-							>
-								?
-							</button>
-						) : null}
 					</div>
 				</div>
 			)}

--- a/packages/cosmo-pd101/src/components/controls/ControlKnob.tsx
+++ b/packages/cosmo-pd101/src/components/controls/ControlKnob.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useRef, useState } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import ModulatableControl from "@/components/controls/modulation/ModulatableControl";
 import { useOptionalSynthController } from "@/features/synth/SynthParamController";
 import type { ModDestination } from "@/lib/synth/bindings/synth";
@@ -6,7 +6,7 @@ import {
 	type ModTarget,
 	resolveModDestination,
 } from "@/lib/synth/modDestination";
-import { useHoverInfo } from "../layout/HoverInfo";
+import { useHoverInfo, useHoverInfoHandlers } from "../layout/HoverInfo";
 import { type KnobVariant, KnobView } from "./knob/KnobView";
 import {
 	bipolarCenterNorm,
@@ -104,7 +104,30 @@ export function ControlKnob({
 	const svgRef = useRef<SVGSVGElement | null>(null);
 	const buttonRef = useRef<HTMLButtonElement | null>(null);
 	const [hovered, setHovered] = useState(false);
-	const { setHoverInfo, clearHoverInfo } = useHoverInfo();
+	const { setControlReadout } = useHoverInfo();
+	const resolvedTooltip = tooltip?.trim() ? tooltip : label?.trim();
+	const formatDisplayValue = useCallback(
+		(nextValue: number) => {
+			if (valueFormatter) {
+				return valueFormatter(nextValue);
+			}
+
+			return Number.isInteger(nextValue)
+				? `${nextValue}`
+				: nextValue.toFixed(2);
+		},
+		[valueFormatter],
+	);
+	const emitChange = useCallback(
+		(nextValue: number) => {
+			onChange(nextValue);
+			setControlReadout({
+				label: label ?? "Value",
+				value: formatDisplayValue(nextValue),
+			});
+		},
+		[formatDisplayValue, label, onChange, setControlReadout],
+	);
 
 	const arcGeometry =
 		arcStartAngle !== undefined || arcSweepAngle !== undefined
@@ -138,7 +161,7 @@ export function ControlKnob({
 		wheelStep,
 		fineWheelStep,
 		disabled,
-		onChange,
+		onChange: emitChange,
 		arcGeometry,
 		svgRef,
 		buttonRef,
@@ -170,39 +193,27 @@ export function ControlKnob({
 		? valueFormatter(value)
 		: value.toFixed(2);
 	const valueControlLabel = label ? `${label} value` : "knob value";
-	const hoverHandlers = tooltip
-		? {
-				onPointerEnter: () => setHoverInfo(tooltip),
-				onPointerLeave: clearHoverInfo,
-				onFocusCapture: () => setHoverInfo(tooltip),
-				onBlurCapture: clearHoverInfo,
-			}
-		: undefined;
-	const infoButtonHandlers = tooltip
-		? {
-				onPointerEnter: () => setHoverInfo(tooltip),
-				onPointerLeave: clearHoverInfo,
-				onFocus: () => setHoverInfo(tooltip),
-				onBlur: clearHoverInfo,
-			}
-		: undefined;
+	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip, {
+		useCapture: true,
+	});
+	const infoButtonHandlers = useHoverInfoHandlers(resolvedTooltip);
 
 	const inner = (
 		<div
 			className={`group flex flex-col items-center gap-0.5 text-center ${className ?? ""}`}
-			data-hover-info={tooltip}
+			data-hover-info={resolvedTooltip}
 			{...hoverHandlers}
 		>
 			{label && (
 				<div className="space-y-0.5">
 					<div className="flex items-center justify-center gap-1 text-3xs uppercase tracking-[0.24em] text-base-content/55">
 						<span>{label}</span>
-						{tooltip ? (
+						{resolvedTooltip ? (
 							<button
 								type="button"
 								className="btn btn-ghost btn-circle btn-xs h-4 min-h-4 w-4 border border-cz-border p-0 text-2xs font-semibold leading-none text-cz-cream/70 hover:border-cz-light-blue hover:text-cz-light-blue"
 								aria-label="Show control description"
-								data-hover-info={tooltip}
+								data-hover-info={resolvedTooltip}
 								tabIndex={-1}
 								{...infoButtonHandlers}
 							>

--- a/packages/cosmo-pd101/src/components/controls/LineSelectControl.tsx
+++ b/packages/cosmo-pd101/src/components/controls/LineSelectControl.tsx
@@ -4,6 +4,13 @@ import { useSynthParam } from "@/features/synth/SynthParamController";
 export default function LineSelectControl() {
 	const { value: lineSelect, setValue: setLineSelect } =
 		useSynthParam("lineSelect");
+	const lineSelectTooltips: Record<string, string> = {
+		L1: "Play oscillator line 1 only.",
+		"L1+L2": "Layer oscillator lines 1 and 2.",
+		L2: "Play oscillator line 2 only.",
+		"L1+L1'": "Stack line 1 with a detuned variant.",
+		"L1+L2'": "Layer line 1 with a detuned line 2 variant.",
+	};
 
 	return (
 		<div className="shrink-0">
@@ -13,6 +20,7 @@ export default function LineSelectControl() {
 					<CzButton
 						key={ls}
 						active={lineSelect === ls}
+						tooltip={lineSelectTooltips[ls]}
 						onClick={() => setLineSelect(ls)}
 					>
 						{ls}

--- a/packages/cosmo-pd101/src/components/controls/LineSelectControl.tsx
+++ b/packages/cosmo-pd101/src/components/controls/LineSelectControl.tsx
@@ -1,16 +1,10 @@
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { LINE_SELECT_TOOLTIPS } from "@/lib/synth/paramMeta";
 
 export default function LineSelectControl() {
 	const { value: lineSelect, setValue: setLineSelect } =
 		useSynthParam("lineSelect");
-	const lineSelectTooltips: Record<string, string> = {
-		L1: "Play oscillator line 1 only.",
-		"L1+L2": "Layer oscillator lines 1 and 2.",
-		L2: "Play oscillator line 2 only.",
-		"L1+L1'": "Stack line 1 with a detuned variant.",
-		"L1+L2'": "Layer line 1 with a detuned line 2 variant.",
-	};
 
 	return (
 		<div className="shrink-0">
@@ -20,7 +14,7 @@ export default function LineSelectControl() {
 					<CzButton
 						key={ls}
 						active={lineSelect === ls}
-						tooltip={lineSelectTooltips[ls]}
+						tooltip={LINE_SELECT_TOOLTIPS[ls]}
 						onClick={() => setLineSelect(ls)}
 					>
 						{ls}

--- a/packages/cosmo-pd101/src/components/controls/ModModeControl.tsx
+++ b/packages/cosmo-pd101/src/components/controls/ModModeControl.tsx
@@ -10,21 +10,9 @@ export default function ModModeControl() {
 			<div className="flex gap-1">
 				{(
 					[
-						[
-							"normal",
-							"Normal",
-							"Standard phase modulation behavior.",
-						],
-						[
-							"ring",
-							"Ring",
-							"Enable ring modulation between lines.",
-						],
-						[
-							"noise",
-							"Noise",
-							"Mix noise source into modulation path.",
-						],
+						["normal", "Normal", "Standard phase modulation behavior."],
+						["ring", "Ring", "Enable ring modulation between lines."],
+						["noise", "Noise", "Mix noise source into modulation path."],
 					] as const
 				).map(([mode, label, tooltip]) => (
 					<CzButton

--- a/packages/cosmo-pd101/src/components/controls/ModModeControl.tsx
+++ b/packages/cosmo-pd101/src/components/controls/ModModeControl.tsx
@@ -10,15 +10,28 @@ export default function ModModeControl() {
 			<div className="flex gap-1">
 				{(
 					[
-						["normal", "Normal"],
-						["ring", "Ring"],
-						["noise", "Noise"],
+						[
+							"normal",
+							"Normal",
+							"Standard phase modulation behavior.",
+						],
+						[
+							"ring",
+							"Ring",
+							"Enable ring modulation between lines.",
+						],
+						[
+							"noise",
+							"Noise",
+							"Mix noise source into modulation path.",
+						],
 					] as const
-				).map(([mode, label]) => (
+				).map(([mode, label, tooltip]) => (
 					<CzButton
 						key={mode}
 						active={modMode === mode}
 						onClick={() => setModMode(mode)}
+						tooltip={tooltip}
 						className="flex-1"
 					>
 						{label}

--- a/packages/cosmo-pd101/src/components/controls/ModModeControl.tsx
+++ b/packages/cosmo-pd101/src/components/controls/ModModeControl.tsx
@@ -1,5 +1,6 @@
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { MOD_MODE_TOOLTIPS } from "@/lib/synth/paramMeta";
 
 export default function ModModeControl() {
 	const { value: modMode, setValue: setModMode } = useSynthParam("modMode");
@@ -10,16 +11,16 @@ export default function ModModeControl() {
 			<div className="flex gap-1">
 				{(
 					[
-						["normal", "Normal", "Standard phase modulation behavior."],
-						["ring", "Ring", "Enable ring modulation between lines."],
-						["noise", "Noise", "Mix noise source into modulation path."],
+						["normal", "Normal"],
+						["ring", "Ring"],
+						["noise", "Noise"],
 					] as const
-				).map(([mode, label, tooltip]) => (
+				).map(([mode, label]) => (
 					<CzButton
 						key={mode}
 						active={modMode === mode}
 						onClick={() => setModMode(mode)}
-						tooltip={tooltip}
+						tooltip={MOD_MODE_TOOLTIPS[mode]}
 						className="flex-1"
 					>
 						{label}

--- a/packages/cosmo-pd101/src/components/controls/algo/AlgoControlDropdown.tsx
+++ b/packages/cosmo-pd101/src/components/controls/algo/AlgoControlDropdown.tsx
@@ -1,4 +1,8 @@
 import { memo } from "react";
+import {
+	useHoverInfo,
+	useHoverInfoHandlers,
+} from "@/components/layout/HoverInfo";
 import type {
 	AlgoControlBinding,
 	AlgoControlOptionRuntime,
@@ -22,9 +26,13 @@ function AlgoControlDropdownInner({
 	getActiveSelectOption,
 	applyOptionAssignments,
 }: AlgoControlDropdownProps) {
+	const { setControlReadout } = useHoverInfo();
 	const options = control.options ?? [];
 	const activeOption = getActiveSelectOption(control);
 	const selectedValue = activeOption?.value ?? options[0]?.value ?? "";
+	const hoverHandlers = useHoverInfoHandlers(
+		control.description ?? control.label,
+	);
 
 	return (
 		<div className="grid grid-rows-[2.15rem_auto] gap-1.5">
@@ -35,6 +43,8 @@ function AlgoControlDropdownInner({
 				className="select select-bordered select-xs w-full"
 				disabled={disabled}
 				value={selectedValue}
+				data-hover-info={control.description ?? control.label}
+				{...hoverHandlers}
 				onChange={(event) => {
 					if (disabled) {
 						return;
@@ -48,6 +58,10 @@ function AlgoControlDropdownInner({
 					}
 
 					if (nextOption.set.length > 0) {
+						setControlReadout({
+							label: control.label,
+							value: nextOption.label,
+						});
 						applyOptionAssignments(nextOption);
 						return;
 					}
@@ -56,6 +70,10 @@ function AlgoControlDropdownInner({
 						(option) => option.value === nextOption.value,
 					);
 					if (selectedIndex >= 0) {
+						setControlReadout({
+							label: control.label,
+							value: nextOption.label,
+						});
 						binding?.setNumber?.(selectedIndex);
 					}
 				}}

--- a/packages/cosmo-pd101/src/components/controls/algo/AlgoControlSelect.tsx
+++ b/packages/cosmo-pd101/src/components/controls/algo/AlgoControlSelect.tsx
@@ -25,35 +25,38 @@ function AlgoControlSelectInner({
 }: AlgoControlSelectProps) {
 	const options = control.options ?? [];
 	const activeOption = getActiveSelectOption(control);
-	const buttonTooltip = control.description
-		? `${control.label}: ${control.description}`
-		: control.label;
 
 	return (
 		<div className="space-y-1.5">
 			<div className="grid grid-cols-4 gap-1.5">
-				{options.map((option, index) => (
-					<CzButton
-						key={option.value}
-						active={activeOption?.value === option.value}
-						disabled={disabled}
-						led={false}
-						tooltip={buttonTooltip}
-						onClick={() => {
-							if (disabled) {
-								return;
-							}
-							if (option.set.length > 0) {
-								applyOptionAssignments(option);
-								return;
-							}
-							binding?.setNumber?.(index);
-						}}
-						className="[&_button]:w-full"
-					>
-						{option.label}
-					</CzButton>
-				))}
+				{options.map((option, index) => {
+					const buttonTooltip = control.description
+						? `${control.label} ${option.label}: ${control.description}`
+						: `${control.label} ${option.label}`;
+
+					return (
+						<CzButton
+							key={option.value}
+							active={activeOption?.value === option.value}
+							disabled={disabled}
+							led={false}
+							tooltip={buttonTooltip}
+							onClick={() => {
+								if (disabled) {
+									return;
+								}
+								if (option.set.length > 0) {
+									applyOptionAssignments(option);
+									return;
+								}
+								binding?.setNumber?.(index);
+							}}
+							className="[&_button]:w-full"
+						>
+							{option.label}
+						</CzButton>
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/packages/cosmo-pd101/src/components/controls/algo/AlgoControlToggle.tsx
+++ b/packages/cosmo-pd101/src/components/controls/algo/AlgoControlToggle.tsx
@@ -1,4 +1,8 @@
 import { memo } from "react";
+import {
+	useHoverInfo,
+	useHoverInfoHandlers,
+} from "@/components/layout/HoverInfo";
 import AlgoControlTooltip from "./AlgoControlTooltip";
 import type {
 	AlgoControlBinding,
@@ -16,7 +20,11 @@ function AlgoControlToggleInner({
 	disabled = false,
 	binding,
 }: AlgoControlToggleProps) {
+	const { setControlReadout } = useHoverInfo();
 	const toggleValue = binding?.getToggle?.() ?? control.defaultToggle ?? false;
+	const hoverHandlers = useHoverInfoHandlers(
+		control.description ?? control.label,
+	);
 
 	return (
 		<div className="flex items-center justify-between rounded-md bg-cz-inset/70 px-2 py-1.5">
@@ -29,7 +37,16 @@ function AlgoControlToggleInner({
 			<input
 				type="checkbox"
 				checked={toggleValue}
-				onChange={(event) => binding?.setToggle?.(event.target.checked)}
+				onChange={(event) => {
+					const nextValue = event.target.checked;
+					setControlReadout({
+						label: control.label,
+						value: nextValue ? "ON" : "OFF",
+					});
+					binding?.setToggle?.(nextValue);
+				}}
+				data-hover-info={control.description ?? control.label}
+				{...hoverHandlers}
 				disabled={disabled || !binding?.setToggle}
 				className="checkbox checkbox-xs"
 			/>

--- a/packages/cosmo-pd101/src/components/controls/algo/AlgoControlTooltip.tsx
+++ b/packages/cosmo-pd101/src/components/controls/algo/AlgoControlTooltip.tsx
@@ -1,11 +1,11 @@
-import { useHoverInfo } from "../../layout/HoverInfo";
+import { useHoverInfoHandlers } from "../../layout/HoverInfo";
 
 export default function AlgoControlTooltip({
 	description,
 }: {
 	description?: string | null;
 }) {
-	const { setHoverInfo, clearHoverInfo } = useHoverInfo();
+	const hoverHandlers = useHoverInfoHandlers(description);
 
 	if (!description) {
 		return null;
@@ -17,10 +17,7 @@ export default function AlgoControlTooltip({
 			className="btn btn-ghost btn-circle btn-xs h-4 min-h-4 w-4 border border-cz-border p-0 text-2xs font-semibold leading-none text-cz-cream/70 hover:border-cz-light-blue hover:text-cz-light-blue"
 			aria-label="Show control description"
 			data-hover-info={description}
-			onPointerEnter={() => setHoverInfo(description)}
-			onPointerLeave={clearHoverInfo}
-			onFocus={() => setHoverInfo(description)}
-			onBlur={clearHoverInfo}
+			{...hoverHandlers}
 		>
 			?
 		</button>

--- a/packages/cosmo-pd101/src/components/controls/algo/AlgoIconGrid.tsx
+++ b/packages/cosmo-pd101/src/components/controls/algo/AlgoIconGrid.tsx
@@ -1,5 +1,9 @@
 import { isAlgoRefEqual } from "@/lib/synth/algoRef";
-import { PD_ALGOS, type PdAlgo } from "@/lib/synth/pdAlgorithms";
+import {
+	getPdAlgoBehaviorDescription,
+	PD_ALGOS,
+	type PdAlgo,
+} from "@/lib/synth/pdAlgorithms";
 import { HoverInfoTrigger } from "../../layout/HoverInfo";
 
 export default function AlgoIconGrid({
@@ -23,7 +27,7 @@ export default function AlgoIconGrid({
 			style={{ pointerEvents: disabled ? "none" : undefined }}
 		>
 			{PD_ALGOS.map((algo) => {
-				const tooltipText = `Algorithm ${algo.label}`;
+				const tooltipText = `Algorithm ${algo.label}: ${getPdAlgoBehaviorDescription(algo.value)}`;
 
 				return (
 					<HoverInfoTrigger key={algo.key} message={tooltipText}>

--- a/packages/cosmo-pd101/src/components/controls/algo/AlgoIconGrid.tsx
+++ b/packages/cosmo-pd101/src/components/controls/algo/AlgoIconGrid.tsx
@@ -1,5 +1,6 @@
 import { isAlgoRefEqual } from "@/lib/synth/algoRef";
 import { PD_ALGOS, type PdAlgo } from "@/lib/synth/pdAlgorithms";
+import { HoverInfoTrigger } from "../../layout/HoverInfo";
 
 export default function AlgoIconGrid({
 	value,
@@ -21,37 +22,46 @@ export default function AlgoIconGrid({
 			].join(" ")}
 			style={{ pointerEvents: disabled ? "none" : undefined }}
 		>
-			{PD_ALGOS.map((algo) => (
-				<button
-					key={algo.key}
-					type="button"
-					title={algo.label}
-					onClick={() => !disabled && onChange(algo.value)}
-					disabled={disabled}
-					className={[
-						"flex  items-center justify-center transition-colors focus:outline-none border-t-0 border-b border-l border-r text-cz-gold border-cz-light-blue",
-						isAlgoRefEqual(value, algo.value)
-							? "border-cz-light-blue bg-cz-inset text-white shadow-sm"
-							: "border-cz-border bg-cz-surface  hover:border-cz-light-blue hover:text-white",
-					].join(" ")}
-					style={{ height: size, width: size + 4 }}
-				>
-					<svg
-						viewBox="0 0 24 24"
-						width={iconSize}
-						height={iconSize}
-						stroke="currentColor"
-						strokeWidth="1.5"
-						fill="none"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						aria-hidden="true"
-					>
-						<title>{algo.label}</title>
-						<path d={algo.icon} />
-					</svg>
-				</button>
-			))}
+			{PD_ALGOS.map((algo) => {
+				const tooltipText = `Algorithm ${algo.label}`;
+
+				return (
+					<HoverInfoTrigger key={algo.key} message={tooltipText}>
+						{(hoverHandlers) => (
+							<button
+								type="button"
+								title={algo.label}
+								data-hover-info={tooltipText}
+								{...hoverHandlers}
+								onClick={() => !disabled && onChange(algo.value)}
+								disabled={disabled}
+								className={[
+									"flex  items-center justify-center transition-colors focus:outline-none border-t-0 border-b border-l border-r text-cz-gold border-cz-light-blue",
+									isAlgoRefEqual(value, algo.value)
+										? "border-cz-light-blue bg-cz-inset text-white shadow-sm"
+										: "border-cz-border bg-cz-surface  hover:border-cz-light-blue hover:text-white",
+								].join(" ")}
+								style={{ height: size, width: size + 4 }}
+							>
+								<svg
+									viewBox="0 0 24 24"
+									width={iconSize}
+									height={iconSize}
+									stroke="currentColor"
+									strokeWidth="1.5"
+									fill="none"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									aria-hidden="true"
+								>
+									<title>{algo.label}</title>
+									<path d={algo.icon} />
+								</svg>
+							</button>
+						)}
+					</HoverInfoTrigger>
+				);
+			})}
 		</div>
 	);
 }

--- a/packages/cosmo-pd101/src/components/controls/modulation/ModRouteRow.tsx
+++ b/packages/cosmo-pd101/src/components/controls/modulation/ModRouteRow.tsx
@@ -111,6 +111,7 @@ const ModRouteRow = memo(function ModRouteRow({
 					size={32}
 					color="#7f9de4"
 					label="Amount"
+					tooltip="Sets modulation depth and direction from source to destination."
 					valueFormatter={(v) => v.toFixed(2)}
 					valueVisibility="hover"
 				/>

--- a/packages/cosmo-pd101/src/components/controls/sliders/CzHorizontalSlider.tsx
+++ b/packages/cosmo-pd101/src/components/controls/sliders/CzHorizontalSlider.tsx
@@ -1,4 +1,9 @@
+import { useCallback } from "react";
 import ModulatableControl from "@/components/controls/modulation/ModulatableControl";
+import {
+	useHoverInfo,
+	useHoverInfoHandlers,
+} from "@/components/layout/HoverInfo";
 import type { ModDestination } from "@/lib/synth/bindings/synth";
 import {
 	type ModTarget,
@@ -13,6 +18,9 @@ interface CzHorizontalSliderProps {
 	onChange: (v: number) => void;
 	disabled?: boolean;
 	className?: string;
+	label?: string;
+	tooltip?: string;
+	valueFormatter?: (value: number) => string;
 	/** Simple modulation opt-in with auto destination resolution. */
 	modulatable?: ModTarget;
 	/** Line context for line-scoped targets (defaults to line 1). */
@@ -34,10 +42,31 @@ export default function CzHorizontalSlider({
 	onChange,
 	disabled = false,
 	className = "",
+	label,
+	tooltip,
+	valueFormatter,
 	modulatable,
 	lineIndex = 1,
 	modDestination,
 }: CzHorizontalSliderProps) {
+	const { setControlReadout } = useHoverInfo();
+	const resolvedTooltip = tooltip?.trim() ? tooltip : label?.trim();
+	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip);
+	const emitChange = useCallback(
+		(nextValue: number) => {
+			onChange(nextValue);
+			setControlReadout({
+				label: label ?? "Value",
+				value: valueFormatter
+					? valueFormatter(nextValue)
+					: Number.isInteger(nextValue)
+						? `${nextValue}`
+						: nextValue.toFixed(2),
+			});
+		},
+		[label, onChange, setControlReadout, valueFormatter],
+	);
+
 	const input = (
 		<input
 			type="range"
@@ -45,8 +74,11 @@ export default function CzHorizontalSlider({
 			max={max}
 			step={step}
 			value={value}
-			onChange={(e) => onChange(Number(e.target.value))}
+			onChange={(e) => emitChange(Number(e.target.value))}
 			className={`range range-xs w-full ${className}`.trim()}
+			aria-label={label}
+			data-hover-info={resolvedTooltip}
+			{...hoverHandlers}
 			disabled={disabled}
 		/>
 	);

--- a/packages/cosmo-pd101/src/components/controls/sliders/CzVerticalSlider.tsx
+++ b/packages/cosmo-pd101/src/components/controls/sliders/CzVerticalSlider.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useRef } from "react";
 import ModulatableControl from "@/components/controls/modulation/ModulatableControl";
+import {
+	useHoverInfo,
+	useHoverInfoHandlers,
+} from "@/components/layout/HoverInfo";
 import type { ModDestination } from "@/lib/synth/bindings/synth";
 import {
 	type ModTarget,
@@ -14,6 +18,8 @@ interface CzVerticalSliderProps {
 	onChange: (v: number) => void;
 	color?: string;
 	ariaLabel?: string;
+	tooltip?: string;
+	valueFormatter?: (value: number) => string;
 	/** Optional fixed height for the slider in px. When omitted, it fills parent height. */
 	trackHeight?: number;
 	/** Simple modulation opt-in with auto destination resolution. */
@@ -36,12 +42,32 @@ export default function CzVerticalSlider({
 	onChange,
 	color = "#9cb937",
 	ariaLabel,
+	tooltip,
+	valueFormatter,
 	trackHeight,
 	modulatable,
 	lineIndex = 1,
 	modDestination,
 }: CzVerticalSliderProps) {
+	const { setControlReadout } = useHoverInfo();
 	const trackRef = useRef<HTMLDivElement>(null);
+	const resolvedLabel = ariaLabel?.trim() ? ariaLabel : "Value";
+	const resolvedTooltip = tooltip?.trim() ? tooltip : resolvedLabel;
+	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip);
+	const emitChange = useCallback(
+		(nextValue: number) => {
+			onChange(nextValue);
+			setControlReadout({
+				label: resolvedLabel,
+				value: valueFormatter
+					? valueFormatter(nextValue)
+					: Number.isInteger(nextValue)
+						? `${nextValue}`
+						: nextValue.toFixed(2),
+			});
+		},
+		[onChange, resolvedLabel, setControlReadout, valueFormatter],
+	);
 
 	const capH = 30; // height of the fader cap in px
 	const trackW = 30; // overall control width in px
@@ -75,11 +101,11 @@ export default function CzVerticalSlider({
 			if (!el) return;
 			el.setPointerCapture(e.pointerId);
 			const rect = el.getBoundingClientRect();
-			onChange(posToValue(e.clientY, rect));
+			emitChange(posToValue(e.clientY, rect));
 
 			const onMove = (ev: PointerEvent) => {
 				const r = el.getBoundingClientRect();
-				onChange(posToValue(ev.clientY, r));
+				emitChange(posToValue(ev.clientY, r));
 			};
 			const onUp = () => {
 				el.removeEventListener("pointermove", onMove);
@@ -88,7 +114,7 @@ export default function CzVerticalSlider({
 			el.addEventListener("pointermove", onMove);
 			el.addEventListener("pointerup", onUp);
 		},
-		[onChange, posToValue],
+		[emitChange, posToValue],
 	);
 
 	const handleWheel = useCallback(
@@ -96,9 +122,9 @@ export default function CzVerticalSlider({
 			e.preventDefault();
 			const delta = -e.deltaY / 100;
 			const range = max - min;
-			onChange(clampToStep(value + delta * range * 0.05));
+			emitChange(clampToStep(value + delta * range * 0.05));
 		},
-		[value, min, max, clampToStep, onChange],
+		[value, min, max, clampToStep, emitChange],
 	);
 
 	const inner = (
@@ -106,6 +132,8 @@ export default function CzVerticalSlider({
 			ref={trackRef}
 			onPointerDown={handlePointerDown}
 			onWheel={handleWheel}
+			data-hover-info={resolvedTooltip}
+			{...hoverHandlers}
 			className="relative h-full min-h-64 select-none cursor-ns-resize"
 			style={{
 				width: trackW,
@@ -120,8 +148,8 @@ export default function CzVerticalSlider({
 			tabIndex={0}
 			onKeyDown={(e) => {
 				const inc = step || (max - min) / 100;
-				if (e.key === "ArrowUp") onChange(clampToStep(value + inc));
-				if (e.key === "ArrowDown") onChange(clampToStep(value - inc));
+				if (e.key === "ArrowUp") emitChange(clampToStep(value + inc));
+				if (e.key === "ArrowDown") emitChange(clampToStep(value - inc));
 			}}
 		>
 			{/* Track channel */}

--- a/packages/cosmo-pd101/src/components/editor/PerLineParametersCard.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PerLineParametersCard.tsx
@@ -30,6 +30,7 @@ function PerLineParametersCardInner({
 	const controls = [
 		{
 			label: "DCW Amt",
+			tooltip: "Sets base harmonic warp amount for this line.",
 			value: warpAmount,
 			min: 0,
 			max: 1,
@@ -42,6 +43,7 @@ function PerLineParametersCardInner({
 		},
 		{
 			label: "Level",
+			tooltip: "Sets base output level for this line.",
 			value: level,
 			min: 0,
 			max: 1,
@@ -54,6 +56,7 @@ function PerLineParametersCardInner({
 		},
 		{
 			label: "Oct",
+			tooltip: "Transposes this line by octave steps.",
 			value: octave,
 			min: -2,
 			max: 2,
@@ -66,6 +69,7 @@ function PerLineParametersCardInner({
 		},
 		{
 			label: "Fine",
+			tooltip: "Fine tunes this line in cents.",
 			value: fineDetune,
 			min: -50,
 			max: 50,
@@ -87,6 +91,7 @@ function PerLineParametersCardInner({
 				{controls.map(
 					({
 						label,
+						tooltip,
 						value,
 						min,
 						max,
@@ -100,6 +105,7 @@ function PerLineParametersCardInner({
 						<ControlKnob
 							key={label}
 							label={label}
+							tooltip={tooltip}
 							value={value}
 							min={min}
 							max={max}

--- a/packages/cosmo-pd101/src/components/editor/PerLineParametersCard.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PerLineParametersCard.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import ControlKnob from "@/components/controls/ControlKnob";
 import Card from "@/components/primitives/Card";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 interface PerLineParametersCardProps {
 	color: string;
@@ -27,10 +28,27 @@ function PerLineParametersCardInner({
 	setFineDetune,
 	lineIndex,
 }: PerLineParametersCardProps) {
+	const dcwTooltip =
+		lineIndex === 1
+			? PARAM_META.warpAAmount?.tooltip
+			: PARAM_META.warpBAmount?.tooltip;
+	const levelTooltip =
+		lineIndex === 1
+			? PARAM_META.line1Level?.tooltip
+			: PARAM_META.line2Level?.tooltip;
+	const octaveTooltip =
+		lineIndex === 1
+			? PARAM_META.line1Octave?.tooltip
+			: PARAM_META.line2Octave?.tooltip;
+	const detuneTooltip =
+		lineIndex === 1
+			? PARAM_META.line1Detune?.tooltip
+			: PARAM_META.line2Detune?.tooltip;
+
 	const controls = [
 		{
 			label: "DCW Amt",
-			tooltip: "Sets base harmonic warp amount for this line.",
+			tooltip: dcwTooltip,
 			value: warpAmount,
 			min: 0,
 			max: 1,
@@ -43,7 +61,7 @@ function PerLineParametersCardInner({
 		},
 		{
 			label: "Level",
-			tooltip: "Sets base output level for this line.",
+			tooltip: levelTooltip,
 			value: level,
 			min: 0,
 			max: 1,
@@ -56,7 +74,7 @@ function PerLineParametersCardInner({
 		},
 		{
 			label: "Oct",
-			tooltip: "Transposes this line by octave steps.",
+			tooltip: octaveTooltip,
 			value: octave,
 			min: -2,
 			max: 2,
@@ -69,7 +87,7 @@ function PerLineParametersCardInner({
 		},
 		{
 			label: "Fine",
-			tooltip: "Fine tunes this line in cents.",
+			tooltip: detuneTooltip,
 			value: fineDetune,
 			min: -50,
 			max: 50,

--- a/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
@@ -414,6 +414,7 @@ export const PerLineWarpBlock = memo(function PerLineWarpBlock({
 										</div>
 										<ControlKnob
 											label="Blend"
+											tooltip="Crossfades between Algo A and Algo B outputs."
 											value={algoBlend}
 											onChange={setAlgoBlend}
 											min={0}

--- a/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
@@ -19,6 +19,7 @@ import type {
 	WindowType,
 } from "@/lib/synth/bindings/synth";
 import { ALGO_DEFINITIONS_V1 } from "@/lib/synth/bindings/synth";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import type { PdAlgo } from "@/lib/synth/pdAlgorithms";
 import { getPdAlgoDef, PD_ALGOS } from "@/lib/synth/pdAlgorithms";
 import PerLineParametersCard from "./PerLineParametersCard";
@@ -414,7 +415,11 @@ export const PerLineWarpBlock = memo(function PerLineWarpBlock({
 										</div>
 										<ControlKnob
 											label="Blend"
-											tooltip="Crossfades between Algo A and Algo B outputs."
+											tooltip={
+												PARAM_META[
+													lineIndex === 2 ? "algoBlendB" : "algoBlendA"
+												]?.tooltip
+											}
 											value={algoBlend}
 											onChange={setAlgoBlend}
 											min={0}

--- a/packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.tsx
+++ b/packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.tsx
@@ -476,6 +476,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 									min={0}
 									max={99}
 									label="Lvl"
+									tooltip={`Sets envelope level for step ${i + 1}.`}
 									// CZ behaviour: last step always outputs 0; show effective
 									// value as 0 but the stored value is still editable so it
 									// is preserved when the step count is increased.
@@ -491,6 +492,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 									min={0}
 									max={99}
 									label="Rate"
+									tooltip={`Sets envelope transition speed for step ${i + 1}.`}
 									valueFormatter={(v) => `${Math.round(v)}`}
 									color="#a3a3a3"
 									size={compact ? 26 : 30}

--- a/packages/cosmo-pd101/src/components/layout/HoverInfo.tsx
+++ b/packages/cosmo-pd101/src/components/layout/HoverInfo.tsx
@@ -7,16 +7,54 @@ import {
 	useState,
 } from "react";
 
+type InfoReadout = {
+	label: string;
+	value: string;
+};
+
 type HoverInfoContextValue = {
 	hoverInfo: string | null;
+	infoText: string;
 	setHoverInfo: (message: string | null | undefined) => void;
 	clearHoverInfo: () => void;
+	setControlReadout: (readout: InfoReadout | null | undefined) => void;
+	clearControlReadout: () => void;
 };
 
 const HoverInfoContext = createContext<HoverInfoContextValue | null>(null);
 
-export function HoverInfoProvider({ children }: PropsWithChildren) {
+type HoverInfoProviderProps = PropsWithChildren<{
+	defaultInfoText?: string;
+	externalReadout?: InfoReadout | null;
+}>;
+
+function formatInfoText(
+	hoverInfo: string | null,
+	readout: InfoReadout | null,
+	defaultInfoText: string,
+): string {
+	if (hoverInfo && readout) {
+		return `${hoverInfo} | ${readout.label}: ${readout.value}`;
+	}
+
+	if (hoverInfo) {
+		return hoverInfo;
+	}
+
+	if (readout) {
+		return `${readout.label}: ${readout.value}`;
+	}
+
+	return defaultInfoText;
+}
+
+export function HoverInfoProvider({
+	children,
+	defaultInfoText = "Hover any control for context.",
+	externalReadout = null,
+}: HoverInfoProviderProps) {
 	const [hoverInfo, setHoverInfoState] = useState<string | null>(null);
+	const [localReadout, setLocalReadout] = useState<InfoReadout | null>(null);
 
 	const setHoverInfo = useCallback((message: string | null | undefined) => {
 		setHoverInfoState(message?.trim() ? message : null);
@@ -26,9 +64,50 @@ export function HoverInfoProvider({ children }: PropsWithChildren) {
 		setHoverInfoState(null);
 	}, []);
 
+	const setControlReadout = useCallback(
+		(readout: InfoReadout | null | undefined) => {
+			if (!readout) {
+				setLocalReadout(null);
+				return;
+			}
+
+			if (!readout.label.trim() || !readout.value.trim()) {
+				setLocalReadout(null);
+				return;
+			}
+
+			setLocalReadout({
+				label: readout.label,
+				value: readout.value,
+			});
+		},
+		[],
+	);
+
+	const clearControlReadout = useCallback(() => {
+		setLocalReadout(null);
+	}, []);
+
+	const resolvedReadout = localReadout ?? externalReadout;
+	const infoText = formatInfoText(hoverInfo, resolvedReadout, defaultInfoText);
+
 	const value = useMemo(
-		() => ({ hoverInfo, setHoverInfo, clearHoverInfo }),
-		[hoverInfo, setHoverInfo, clearHoverInfo],
+		() => ({
+			hoverInfo,
+			infoText,
+			setHoverInfo,
+			clearHoverInfo,
+			setControlReadout,
+			clearControlReadout,
+		}),
+		[
+			hoverInfo,
+			infoText,
+			setHoverInfo,
+			clearHoverInfo,
+			setControlReadout,
+			clearControlReadout,
+		],
 	);
 
 	return (
@@ -44,8 +123,11 @@ export function useHoverInfo() {
 	if (!context) {
 		return {
 			hoverInfo: null,
+			infoText: "Hover any control for context.",
 			setHoverInfo: (_message: string | null | undefined) => {},
 			clearHoverInfo: () => {},
+			setControlReadout: (_readout: InfoReadout | null | undefined) => {},
+			clearControlReadout: () => {},
 		};
 	}
 

--- a/packages/cosmo-pd101/src/components/layout/HoverInfo.tsx
+++ b/packages/cosmo-pd101/src/components/layout/HoverInfo.tsx
@@ -1,9 +1,13 @@
 import {
 	createContext,
+	type HTMLAttributes,
 	type PropsWithChildren,
+	type ReactNode,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from "react";
 
@@ -55,6 +59,7 @@ export function HoverInfoProvider({
 }: HoverInfoProviderProps) {
 	const [hoverInfo, setHoverInfoState] = useState<string | null>(null);
 	const [localReadout, setLocalReadout] = useState<InfoReadout | null>(null);
+	const localReadoutTimeoutRef = useRef<number | null>(null);
 
 	const setHoverInfo = useCallback((message: string | null | undefined) => {
 		setHoverInfoState(message?.trim() ? message : null);
@@ -66,6 +71,11 @@ export function HoverInfoProvider({
 
 	const setControlReadout = useCallback(
 		(readout: InfoReadout | null | undefined) => {
+			if (localReadoutTimeoutRef.current != null) {
+				window.clearTimeout(localReadoutTimeoutRef.current);
+				localReadoutTimeoutRef.current = null;
+			}
+
 			if (!readout) {
 				setLocalReadout(null);
 				return;
@@ -80,12 +90,27 @@ export function HoverInfoProvider({
 				label: readout.label,
 				value: readout.value,
 			});
+			localReadoutTimeoutRef.current = window.setTimeout(() => {
+				setLocalReadout(null);
+			}, 1200);
 		},
 		[],
 	);
 
 	const clearControlReadout = useCallback(() => {
+		if (localReadoutTimeoutRef.current != null) {
+			window.clearTimeout(localReadoutTimeoutRef.current);
+			localReadoutTimeoutRef.current = null;
+		}
 		setLocalReadout(null);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (localReadoutTimeoutRef.current != null) {
+				window.clearTimeout(localReadoutTimeoutRef.current);
+			}
+		};
 	}, []);
 
 	const resolvedReadout = localReadout ?? externalReadout;
@@ -132,4 +157,60 @@ export function useHoverInfo() {
 	}
 
 	return context;
+}
+
+type HoverInfoHandlersOptions = {
+	useCapture?: boolean;
+};
+
+type HoverInfoHandlers = Pick<
+	HTMLAttributes<HTMLElement>,
+	| "onPointerEnter"
+	| "onPointerLeave"
+	| "onFocus"
+	| "onBlur"
+	| "onFocusCapture"
+	| "onBlurCapture"
+>;
+
+export function useHoverInfoHandlers(
+	message: string | null | undefined,
+	{ useCapture = false }: HoverInfoHandlersOptions = {},
+): HoverInfoHandlers {
+	const { setHoverInfo, clearHoverInfo } = useHoverInfo();
+
+	return useMemo(() => {
+		if (!message?.trim()) {
+			return {};
+		}
+
+		if (useCapture) {
+			return {
+				onPointerEnter: () => setHoverInfo(message),
+				onPointerLeave: clearHoverInfo,
+				onFocusCapture: () => setHoverInfo(message),
+				onBlurCapture: clearHoverInfo,
+			};
+		}
+
+		return {
+			onPointerEnter: () => setHoverInfo(message),
+			onPointerLeave: clearHoverInfo,
+			onFocus: () => setHoverInfo(message),
+			onBlur: clearHoverInfo,
+		};
+	}, [clearHoverInfo, message, setHoverInfo, useCapture]);
+}
+
+export function HoverInfoTrigger({
+	message,
+	children,
+	useCapture,
+}: {
+	message: string;
+	children: (handlers: HoverInfoHandlers) => ReactNode;
+	useCapture?: boolean;
+}) {
+	const handlers = useHoverInfoHandlers(message, { useCapture });
+	return <>{children(handlers)}</>;
 }

--- a/packages/cosmo-pd101/src/components/layout/SynthInfoBar.tsx
+++ b/packages/cosmo-pd101/src/components/layout/SynthInfoBar.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+
+type SynthInfoBarProps = {
+	infoText: string;
+	bottomBarExtra?: ReactNode;
+	showKeyboardToggle: boolean;
+	keyboardVisible: boolean;
+	onKeyboardToggle: () => void;
+};
+
+export default function SynthInfoBar({
+	infoText,
+	bottomBarExtra,
+	showKeyboardToggle,
+	keyboardVisible,
+	onKeyboardToggle,
+}: SynthInfoBarProps) {
+	return (
+		<div className="relative z-20 mt-1 flex min-h-8 flex-wrap items-center gap-x-3 gap-y-1 rounded-t-sm border border-cz-border/80 bg-cz-body px-3 py-1 font-mono text-[0.62rem] uppercase tracking-[0.22em] text-cz-cream/80 shadow-inner">
+			<span className="text-cz-light-blue/80">Info</span>
+			<span className="min-w-0 flex-1 truncate">{infoText}</span>
+			{bottomBarExtra ? (
+				<div className="flex items-center gap-2 text-[0.54rem] tracking-[0.18em]">
+					{bottomBarExtra}
+				</div>
+			) : null}
+			{showKeyboardToggle ? (
+				<button
+					type="button"
+					onClick={onKeyboardToggle}
+					className={`rounded-sm border px-2 py-1 text-[0.56rem] uppercase tracking-[0.24em] transition-colors ${
+						keyboardVisible
+							? "border-cz-gold bg-cz-gold/10 text-cz-gold"
+							: "border-cz-border bg-black/10 text-cz-cream/70 hover:text-cz-cream"
+					}`}
+				>
+					{keyboardVisible ? "Hide Keys" : "Show Keys"}
+				</button>
+			) : null}
+		</div>
+	);
+}

--- a/packages/cosmo-pd101/src/components/panels/analysis/ScopePanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/ScopePanel.tsx
@@ -235,6 +235,7 @@ function ScopePanel() {
 					size={48}
 					color="#3dff3d"
 					label="Cycles"
+					tooltip="Sets how many waveform cycles are shown in scope view."
 					valueFormatter={(value) => value.toFixed(1)}
 				/>
 				<ControlKnob
@@ -245,6 +246,7 @@ function ScopePanel() {
 					size={48}
 					color="#9cb937"
 					label="Zoom"
+					tooltip="Sets vertical waveform magnification."
 					valueFormatter={(value) => `${value.toFixed(1)}x`}
 				/>
 				<ControlKnob
@@ -255,6 +257,7 @@ function ScopePanel() {
 					size={48}
 					color="#7f9de4"
 					label="Trig"
+					tooltip="Sets trigger threshold used to stabilize waveform display."
 					valueFormatter={(value) => `${Math.round(value)}`}
 				/>
 			</div>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/DelayModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/DelayModule.tsx
@@ -5,6 +5,7 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthStore } from "@/features/synth/synthStore";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import { DELAY_PRESETS } from "@/lib/synth/modulePresets";
 
 export default function DelayModule({ slot }: { slot: number }) {
@@ -31,8 +32,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 		});
 	};
 
-	const tapeModeTooltip = "Toggle tape echo coloration for delay repeats.";
-	const tapeModeHoverHandlers = useHoverInfoHandlers(tapeModeTooltip);
+	const tapeModeHoverHandlers = useHoverInfoHandlers(PARAM_META.delayTapeMode?.tooltip);
 	return (
 		<ModuleFrame
 			title="Delay"
@@ -53,7 +53,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 			<button
 				type="button"
 				onClick={() => setFxSlotParams(slot, { tapeMode: !delay.tapeMode })}
-				data-hover-info={tapeModeTooltip}
+				data-hover-info={PARAM_META.delayTapeMode?.tooltip}
 				{...tapeModeHoverHandlers}
 				className={`rounded px-2 py-0.5 text-[0.6rem] font-medium tracking-wider border transition-colors w-fit justify-self-center grow col-span-${delay.tapeMode ? 4 : 3} ${
 					delay.tapeMode
@@ -72,7 +72,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Time"
-				tooltip="Sets the delay repeat interval."
+				tooltip={PARAM_META.delayTime?.tooltip}
 				valueFormatter={(value) => `${Math.round(value * 1000)}ms`}
 			/>
 			<ControlKnob
@@ -84,7 +84,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Fdbk"
-				tooltip="Controls how much delayed signal feeds back into the delay."
+				tooltip={PARAM_META.delayFeedback?.tooltip}
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 			/>
 			{delay.tapeMode && (
@@ -97,7 +97,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 					size={52}
 					color="#f59e0b"
 					label="Warmth"
-					tooltip="Adds tape-style saturation and tone darkening."
+					tooltip={PARAM_META.delayWarmth?.tooltip}
 					valueFormatter={(value) => `${Math.round(value * 100)}%`}
 				/>
 			)}
@@ -110,7 +110,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Mix"
-				tooltip="Blends dry signal with delayed repeats."
+			tooltip={PARAM_META.delayMix?.tooltip}
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/DelayModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/DelayModule.tsx
@@ -5,8 +5,8 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthStore } from "@/features/synth/synthStore";
-import { PARAM_META } from "@/lib/synth/paramMeta";
 import { DELAY_PRESETS } from "@/lib/synth/modulePresets";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 export default function DelayModule({ slot }: { slot: number }) {
 	const [selectedPreset, setSelectedPreset] = useState<string>("");
@@ -32,7 +32,9 @@ export default function DelayModule({ slot }: { slot: number }) {
 		});
 	};
 
-	const tapeModeHoverHandlers = useHoverInfoHandlers(PARAM_META.delayTapeMode?.tooltip);
+	const tapeModeHoverHandlers = useHoverInfoHandlers(
+		PARAM_META.delayTapeMode?.tooltip,
+	);
 	return (
 		<ModuleFrame
 			title="Delay"
@@ -110,7 +112,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Mix"
-			tooltip={PARAM_META.delayMix?.tooltip}
+				tooltip={PARAM_META.delayMix?.tooltip}
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/DelayModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/DelayModule.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import ControlKnob from "@/components/controls/ControlKnob";
+import { useHoverInfoHandlers } from "@/components/layout/HoverInfo";
 import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
@@ -30,6 +31,8 @@ export default function DelayModule({ slot }: { slot: number }) {
 		});
 	};
 
+	const tapeModeTooltip = "Toggle tape echo coloration for delay repeats.";
+	const tapeModeHoverHandlers = useHoverInfoHandlers(tapeModeTooltip);
 	return (
 		<ModuleFrame
 			title="Delay"
@@ -50,6 +53,8 @@ export default function DelayModule({ slot }: { slot: number }) {
 			<button
 				type="button"
 				onClick={() => setFxSlotParams(slot, { tapeMode: !delay.tapeMode })}
+				data-hover-info={tapeModeTooltip}
+				{...tapeModeHoverHandlers}
 				className={`rounded px-2 py-0.5 text-[0.6rem] font-medium tracking-wider border transition-colors w-fit justify-self-center grow col-span-${delay.tapeMode ? 4 : 3} ${
 					delay.tapeMode
 						? "border-amber-500/60 bg-amber-500/20 text-amber-300"
@@ -67,6 +72,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Time"
+				tooltip="Sets the delay repeat interval."
 				valueFormatter={(value) => `${Math.round(value * 1000)}ms`}
 			/>
 			<ControlKnob
@@ -78,6 +84,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Fdbk"
+				tooltip="Controls how much delayed signal feeds back into the delay."
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 			/>
 			{delay.tapeMode && (
@@ -90,6 +97,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 					size={52}
 					color="#f59e0b"
 					label="Warmth"
+					tooltip="Adds tape-style saturation and tone darkening."
 					valueFormatter={(value) => `${Math.round(value * 100)}%`}
 				/>
 			)}
@@ -102,6 +110,7 @@ export default function DelayModule({ slot }: { slot: number }) {
 				size={52}
 				color="#fbbf24"
 				label="Mix"
+				tooltip="Blends dry signal with delayed repeats."
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/LFOModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/LFOModule.tsx
@@ -5,7 +5,9 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import type { SynthParamKey } from "@/features/synth/SynthParamController";
 import { getLfoModulePatch, LFO_PRESETS } from "@/lib/synth/modulePresets";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 interface LfoModuleProps {
 	id: 1 | 2;
@@ -16,6 +18,8 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 	const [selectedPreset, setSelectedPreset] = useState<string>("");
 	// Dynamically resolve the parameter names based on the LFO id
 	const prefix = id === 1 ? "lfo" : "lfo2";
+	const lfoParamTooltip = (suffix: string) =>
+		PARAM_META[`${prefix}${suffix}` as SynthParamKey]?.tooltip;
 
 	const { value: lfoWaveform, setValue: setLfoWaveform } = useSynthParam(
 		`${prefix}Waveform`,
@@ -103,7 +107,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Rate"
-				tooltip={`Sets LFO ${id} speed.`}
+				tooltip={lfoParamTooltip('Rate')}
 				valueFormatter={(v) => `${v.toFixed(1)}Hz`}
 			/>
 			<ControlKnob
@@ -115,7 +119,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Depth"
-				tooltip={`Sets modulation depth for LFO ${id}.`}
+				tooltip={lfoParamTooltip('Depth')}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -127,7 +131,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Offset"
-				tooltip={`Offsets LFO ${id} output around zero.`}
+				tooltip={lfoParamTooltip('Offset')}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -139,13 +143,13 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Sym."
-				tooltip={`Adjusts waveform symmetry for LFO ${id}.`}
+				tooltip={lfoParamTooltip('Symmetry')}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<CompactButton
 				active={lfoRetrigger}
 				onClick={() => setLfoRetrigger(!lfoRetrigger)}
-				tooltip={`Restart LFO ${id} phase on each new note.`}
+				tooltip={lfoParamTooltip('Retrigger')}
 				className="px-2 col-span-4 w-fit justify-self-center"
 			>
 				Retrig

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/LFOModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/LFOModule.tsx
@@ -4,8 +4,8 @@ import CompactButton from "@/components/primitives/CompactButton";
 import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
-import { useSynthParam } from "@/features/synth/SynthParamController";
 import type { SynthParamKey } from "@/features/synth/SynthParamController";
+import { useSynthParam } from "@/features/synth/SynthParamController";
 import { getLfoModulePatch, LFO_PRESETS } from "@/lib/synth/modulePresets";
 import { PARAM_META } from "@/lib/synth/paramMeta";
 
@@ -107,7 +107,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Rate"
-				tooltip={lfoParamTooltip('Rate')}
+				tooltip={lfoParamTooltip("Rate")}
 				valueFormatter={(v) => `${v.toFixed(1)}Hz`}
 			/>
 			<ControlKnob
@@ -119,7 +119,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Depth"
-				tooltip={lfoParamTooltip('Depth')}
+				tooltip={lfoParamTooltip("Depth")}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -131,7 +131,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Offset"
-				tooltip={lfoParamTooltip('Offset')}
+				tooltip={lfoParamTooltip("Offset")}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -143,13 +143,13 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Sym."
-				tooltip={lfoParamTooltip('Symmetry')}
+				tooltip={lfoParamTooltip("Symmetry")}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<CompactButton
 				active={lfoRetrigger}
 				onClick={() => setLfoRetrigger(!lfoRetrigger)}
-				tooltip={lfoParamTooltip('Retrigger')}
+				tooltip={lfoParamTooltip("Retrigger")}
 				className="px-2 col-span-4 w-fit justify-self-center"
 			>
 				Retrig

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/LFOModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/LFOModule.tsx
@@ -88,6 +88,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 						className="grow"
 						active={lfoWaveform === w}
 						onClick={() => setLfoWaveform(w)}
+						tooltip={`Select ${label} waveform for LFO ${id}.`}
 					>
 						{label}
 					</CompactButton>
@@ -102,6 +103,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Rate"
+				tooltip={`Sets LFO ${id} speed.`}
 				valueFormatter={(v) => `${v.toFixed(1)}Hz`}
 			/>
 			<ControlKnob
@@ -113,6 +115,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Depth"
+				tooltip={`Sets modulation depth for LFO ${id}.`}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -124,6 +127,7 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Offset"
+				tooltip={`Offsets LFO ${id} output around zero.`}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -135,11 +139,13 @@ export default function LfoModule({ id, color }: LfoModuleProps) {
 				size={40}
 				color="#27588f"
 				label="Sym."
+				tooltip={`Adjusts waveform symmetry for LFO ${id}.`}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<CompactButton
 				active={lfoRetrigger}
 				onClick={() => setLfoRetrigger(!lfoRetrigger)}
+				tooltip={`Restart LFO ${id} phase on each new note.`}
 				className="px-2 col-span-4 w-fit justify-self-center"
 			>
 				Retrig

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/ModEnveloppeModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/ModEnveloppeModule.tsx
@@ -4,6 +4,7 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import { MOD_ENV_PRESETS } from "@/lib/synth/modulePresets";
 
 export default function ModEnveloppeModule() {
@@ -84,7 +85,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Sus"
-				tooltip="Sets sustained modulation level while note is held."
+							tooltip={PARAM_META.modEnvSustain?.tooltip}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -96,7 +97,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Rel"
-				tooltip="Sets modulation envelope release time after note off."
+							tooltip={PARAM_META.modEnvRelease?.tooltip}
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/ModEnveloppeModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/ModEnveloppeModule.tsx
@@ -60,6 +60,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Atk"
+				tooltip="Sets modulation envelope attack time."
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 			<ControlKnob
@@ -71,6 +72,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Dec"
+				tooltip="Sets modulation envelope decay time."
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 			<ControlKnob
@@ -82,6 +84,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Sus"
+				tooltip="Sets sustained modulation level while note is held."
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -93,6 +96,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Rel"
+				tooltip="Sets modulation envelope release time after note off."
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/ModEnveloppeModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/ModEnveloppeModule.tsx
@@ -4,8 +4,8 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
-import { PARAM_META } from "@/lib/synth/paramMeta";
 import { MOD_ENV_PRESETS } from "@/lib/synth/modulePresets";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 export default function ModEnveloppeModule() {
 	const [selectedPreset, setSelectedPreset] = useState<string>("");
@@ -61,7 +61,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Atk"
-				tooltip="Sets modulation envelope attack time."
+				tooltip={PARAM_META.modEnvAttack?.tooltip}
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 			<ControlKnob
@@ -73,7 +73,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Dec"
-				tooltip="Sets modulation envelope decay time."
+				tooltip={PARAM_META.modEnvDecay?.tooltip}
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 			<ControlKnob
@@ -85,7 +85,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Sus"
-							tooltip={PARAM_META.modEnvSustain?.tooltip}
+				tooltip={PARAM_META.modEnvSustain?.tooltip}
 				valueFormatter={(v) => `${Math.round(v * 100)}%`}
 			/>
 			<ControlKnob
@@ -97,7 +97,7 @@ export default function ModEnveloppeModule() {
 				size={52}
 				color="#c24587"
 				label="Rel"
-							tooltip={PARAM_META.modEnvRelease?.tooltip}
+				tooltip={PARAM_META.modEnvRelease?.tooltip}
 				valueFormatter={(v) => `${v.toFixed(2)}s`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/PhaseModModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/PhaseModModule.tsx
@@ -5,6 +5,7 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import { PHASE_MOD_PRESETS } from "@/lib/synth/modulePresets";
 
 export default function PhaseModModule() {
@@ -55,7 +56,7 @@ export default function PhaseModModule() {
 			<CzButton
 				active={pmPre}
 				onClick={() => setPmPre(!pmPre)}
-				tooltip="Apply phase modulation before warp shaping."
+			tooltip={PARAM_META.pmPre?.tooltip}
 				className="h-16 px-2 col-span-2"
 			>
 				Pre
@@ -70,7 +71,7 @@ export default function PhaseModModule() {
 				size={52}
 				color="#be3330"
 				label="Amount"
-				tooltip="Sets internal phase modulation depth."
+			tooltip={PARAM_META.intPmAmount?.tooltip}
 				valueFormatter={(value) => value.toFixed(2)}
 			/>
 			<ControlKnob
@@ -82,7 +83,7 @@ export default function PhaseModModule() {
 				size={52}
 				color="#be3330"
 				label="Ratio"
-				tooltip="Sets modulator-to-carrier frequency ratio."
+			tooltip={PARAM_META.intPmRatio?.tooltip}
 				valueFormatter={(value) => value.toFixed(1)}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/PhaseModModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/PhaseModModule.tsx
@@ -55,6 +55,7 @@ export default function PhaseModModule() {
 			<CzButton
 				active={pmPre}
 				onClick={() => setPmPre(!pmPre)}
+				tooltip="Apply phase modulation before warp shaping."
 				className="h-16 px-2 col-span-2"
 			>
 				Pre
@@ -69,6 +70,7 @@ export default function PhaseModModule() {
 				size={52}
 				color="#be3330"
 				label="Amount"
+				tooltip="Sets internal phase modulation depth."
 				valueFormatter={(value) => value.toFixed(2)}
 			/>
 			<ControlKnob
@@ -80,6 +82,7 @@ export default function PhaseModModule() {
 				size={52}
 				color="#be3330"
 				label="Ratio"
+				tooltip="Sets modulator-to-carrier frequency ratio."
 				valueFormatter={(value) => value.toFixed(1)}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/PhaseModModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/PhaseModModule.tsx
@@ -5,8 +5,8 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
-import { PARAM_META } from "@/lib/synth/paramMeta";
 import { PHASE_MOD_PRESETS } from "@/lib/synth/modulePresets";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 export default function PhaseModModule() {
 	const [selectedPreset, setSelectedPreset] = useState<string>("");
@@ -56,7 +56,7 @@ export default function PhaseModModule() {
 			<CzButton
 				active={pmPre}
 				onClick={() => setPmPre(!pmPre)}
-			tooltip={PARAM_META.pmPre?.tooltip}
+				tooltip={PARAM_META.pmPre?.tooltip}
 				className="h-16 px-2 col-span-2"
 			>
 				Pre
@@ -71,7 +71,7 @@ export default function PhaseModModule() {
 				size={52}
 				color="#be3330"
 				label="Amount"
-			tooltip={PARAM_META.intPmAmount?.tooltip}
+				tooltip={PARAM_META.intPmAmount?.tooltip}
 				valueFormatter={(value) => value.toFixed(2)}
 			/>
 			<ControlKnob
@@ -83,7 +83,7 @@ export default function PhaseModModule() {
 				size={52}
 				color="#be3330"
 				label="Ratio"
-			tooltip={PARAM_META.intPmRatio?.tooltip}
+				tooltip={PARAM_META.intPmRatio?.tooltip}
 				valueFormatter={(value) => value.toFixed(1)}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/RandomModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/RandomModule.tsx
@@ -1,6 +1,7 @@
 import ControlKnob from "@/components/controls/ControlKnob";
 import ModuleFrame from "@/components/primitives/ModuleFrame";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 export default function RandomModule() {
 	const { value: randomRate, setValue: setRandomRate } =
@@ -16,7 +17,7 @@ export default function RandomModule() {
 				size={52}
 				color="#c2571a"
 				label="Rate"
-				tooltip="Sets sample-and-hold random modulation refresh rate."
+				tooltip={PARAM_META.randomRate?.tooltip}
 				valueFormatter={(v) => `${v.toFixed(2)}Hz`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/RandomModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/RandomModule.tsx
@@ -16,6 +16,7 @@ export default function RandomModule() {
 				size={52}
 				color="#c2571a"
 				label="Rate"
+				tooltip="Sets sample-and-hold random modulation refresh rate."
 				valueFormatter={(v) => `${v.toFixed(2)}Hz`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/VibratoModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/VibratoModule.tsx
@@ -5,6 +5,7 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import { VIBRATO_PRESETS } from "@/lib/synth/modulePresets";
 
 export default function VibratoModule() {
@@ -77,7 +78,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Rate"
-				tooltip="Sets vibrato speed."
+			tooltip={PARAM_META.vibratoRate?.tooltip}
 				valueFormatter={(v) => `${Math.round(v)}`}
 			/>
 			<ControlKnob
@@ -89,7 +90,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Depth"
-				tooltip="Sets vibrato pitch modulation depth."
+			tooltip={PARAM_META.vibratoDepth?.tooltip}
 				valueFormatter={(v) => `${Math.round(v)}`}
 			/>
 			<ControlKnob
@@ -101,7 +102,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Delay"
-				tooltip="Delays vibrato onset after note start."
+			tooltip={PARAM_META.vibratoDelay?.tooltip}
 				valueFormatter={(v) => `${Math.round(v)}ms`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/VibratoModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/VibratoModule.tsx
@@ -62,6 +62,7 @@ export default function VibratoModule() {
 						key={w}
 						active={vibratoWave === i + 1}
 						onClick={() => setVibratoWave(i + 1)}
+						tooltip={`Select ${w} vibrato waveform.`}
 					>
 						{w}
 					</CompactButton>
@@ -76,6 +77,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Rate"
+				tooltip="Sets vibrato speed."
 				valueFormatter={(v) => `${Math.round(v)}`}
 			/>
 			<ControlKnob
@@ -87,6 +89,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Depth"
+				tooltip="Sets vibrato pitch modulation depth."
 				valueFormatter={(v) => `${Math.round(v)}`}
 			/>
 			<ControlKnob
@@ -98,6 +101,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Delay"
+				tooltip="Delays vibrato onset after note start."
 				valueFormatter={(v) => `${Math.round(v)}ms`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/VibratoModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/VibratoModule.tsx
@@ -5,8 +5,8 @@ import ModuleFrame from "@/components/primitives/ModuleFrame";
 import ModulePresetPopover from "@/components/primitives/ModulePresetPopover";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthParam } from "@/features/synth/SynthParamController";
-import { PARAM_META } from "@/lib/synth/paramMeta";
 import { VIBRATO_PRESETS } from "@/lib/synth/modulePresets";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 export default function VibratoModule() {
 	const [selectedPreset, setSelectedPreset] = useState<string>("");
@@ -78,7 +78,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Rate"
-			tooltip={PARAM_META.vibratoRate?.tooltip}
+				tooltip={PARAM_META.vibratoRate?.tooltip}
 				valueFormatter={(v) => `${Math.round(v)}`}
 			/>
 			<ControlKnob
@@ -90,7 +90,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Depth"
-			tooltip={PARAM_META.vibratoDepth?.tooltip}
+				tooltip={PARAM_META.vibratoDepth?.tooltip}
 				valueFormatter={(v) => `${Math.round(v)}`}
 			/>
 			<ControlKnob
@@ -102,7 +102,7 @@ export default function VibratoModule() {
 				size={52}
 				color="#307948"
 				label="Delay"
-			tooltip={PARAM_META.vibratoDelay?.tooltip}
+				tooltip={PARAM_META.vibratoDelay?.tooltip}
 				valueFormatter={(v) => `${Math.round(v)}ms`}
 			/>
 		</ModuleFrame>

--- a/packages/cosmo-pd101/src/components/panels/fx/BaseFxSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/BaseFxSection.tsx
@@ -3,6 +3,7 @@ import type { KnobVariant } from "@/components/controls/knob/KnobView";
 
 export interface FxKnobConfig {
 	label: string;
+	tooltip?: string;
 	value: number;
 	setValue: (v: number) => void;
 	min: number;
@@ -36,6 +37,7 @@ export function BaseFxSection({ title, knobs }: BaseFxSectionProps) {
 						variant={knob.variant}
 						color={knob.color}
 						label={knob.label}
+						tooltip={knob.tooltip}
 						valueFormatter={knob.valueFormatter}
 					/>
 				))}

--- a/packages/cosmo-pd101/src/components/panels/fx/ChorusSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/ChorusSection.tsx
@@ -20,6 +20,7 @@ export function ChorusSection({
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Rate",
+			tooltip: "Sets chorus modulation speed.",
 			value: rate,
 			setValue: setRate,
 			min: 0.1,
@@ -30,6 +31,7 @@ export function ChorusSection({
 		},
 		{
 			label: "Depth",
+			tooltip: "Sets how wide the chorus pitch modulation swings.",
 			value: depth,
 			setValue: setDepth,
 			min: 0,
@@ -40,6 +42,7 @@ export function ChorusSection({
 		},
 		{
 			label: "Mix",
+			tooltip: "Blends dry signal with the chorus effect.",
 			value: mix,
 			setValue: setMix,
 			min: 0,

--- a/packages/cosmo-pd101/src/components/panels/fx/ChorusSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/ChorusSection.tsx
@@ -1,5 +1,5 @@
-import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 import { PARAM_META } from "@/lib/synth/paramMeta";
+import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 
 interface ChorusSectionProps {
 	rate: number;

--- a/packages/cosmo-pd101/src/components/panels/fx/ChorusSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/ChorusSection.tsx
@@ -1,4 +1,5 @@
 import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 interface ChorusSectionProps {
 	rate: number;
@@ -20,7 +21,7 @@ export function ChorusSection({
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Rate",
-			tooltip: "Sets chorus modulation speed.",
+			tooltip: PARAM_META.chorusRate?.tooltip,
 			value: rate,
 			setValue: setRate,
 			min: 0.1,
@@ -31,7 +32,7 @@ export function ChorusSection({
 		},
 		{
 			label: "Depth",
-			tooltip: "Sets how wide the chorus pitch modulation swings.",
+			tooltip: PARAM_META.chorusDepth?.tooltip,
 			value: depth,
 			setValue: setDepth,
 			min: 0,
@@ -42,7 +43,7 @@ export function ChorusSection({
 		},
 		{
 			label: "Mix",
-			tooltip: "Blends dry signal with the chorus effect.",
+			tooltip: PARAM_META.chorusMix?.tooltip,
 			value: mix,
 			setValue: setMix,
 			min: 0,

--- a/packages/cosmo-pd101/src/components/panels/fx/DelaySection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/DelaySection.tsx
@@ -1,3 +1,4 @@
+import { useHoverInfoHandlers } from "@/components/layout/HoverInfo";
 import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 
 interface DelaySectionProps {
@@ -25,9 +26,12 @@ export function DelaySection({
 	warmth,
 	setWarmth,
 }: DelaySectionProps) {
+	const tapeModeTooltip = "Toggle tape echo coloration for delay repeats.";
+	const tapeModeHoverHandlers = useHoverInfoHandlers(tapeModeTooltip);
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Time",
+			tooltip: "Sets the delay repeat interval.",
 			value: time,
 			setValue: setTime,
 			min: 0.01,
@@ -38,6 +42,7 @@ export function DelaySection({
 		},
 		{
 			label: "Dly Fdbk",
+			tooltip: "Feeds delayed signal back for additional repeats.",
 			value: feedback,
 			setValue: setFeedback,
 			min: 0,
@@ -50,6 +55,7 @@ export function DelaySection({
 			? ([
 					{
 						label: "Warmth",
+						tooltip: "Adds tape-style saturation and high-frequency rolloff.",
 						value: warmth,
 						setValue: setWarmth,
 						min: 0,
@@ -62,6 +68,7 @@ export function DelaySection({
 			: []),
 		{
 			label: "Mix",
+			tooltip: "Blends dry signal with delayed signal.",
 			value: mix,
 			setValue: setMix,
 			min: 0,
@@ -81,6 +88,8 @@ export function DelaySection({
 				<button
 					type="button"
 					onClick={() => setTapeMode(!tapeMode)}
+					data-hover-info={tapeModeTooltip}
+					{...tapeModeHoverHandlers}
 					className={`rounded px-3 py-1 text-xs font-medium tracking-wide border transition-colors ${
 						tapeMode
 							? "border-amber-500/60 bg-amber-500/20 text-amber-300"

--- a/packages/cosmo-pd101/src/components/panels/fx/DelaySection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/DelaySection.tsx
@@ -1,4 +1,5 @@
 import { useHoverInfoHandlers } from "@/components/layout/HoverInfo";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 
 interface DelaySectionProps {
@@ -26,12 +27,11 @@ export function DelaySection({
 	warmth,
 	setWarmth,
 }: DelaySectionProps) {
-	const tapeModeTooltip = "Toggle tape echo coloration for delay repeats.";
-	const tapeModeHoverHandlers = useHoverInfoHandlers(tapeModeTooltip);
+	const tapeModeHoverHandlers = useHoverInfoHandlers(PARAM_META.delayTapeMode?.tooltip);
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Time",
-			tooltip: "Sets the delay repeat interval.",
+			tooltip: PARAM_META.delayTime?.tooltip,
 			value: time,
 			setValue: setTime,
 			min: 0.01,
@@ -42,7 +42,7 @@ export function DelaySection({
 		},
 		{
 			label: "Dly Fdbk",
-			tooltip: "Feeds delayed signal back for additional repeats.",
+			tooltip: PARAM_META.delayFeedback?.tooltip,
 			value: feedback,
 			setValue: setFeedback,
 			min: 0,
@@ -55,7 +55,7 @@ export function DelaySection({
 			? ([
 					{
 						label: "Warmth",
-						tooltip: "Adds tape-style saturation and high-frequency rolloff.",
+						tooltip: PARAM_META.delayWarmth?.tooltip,
 						value: warmth,
 						setValue: setWarmth,
 						min: 0,
@@ -68,7 +68,7 @@ export function DelaySection({
 			: []),
 		{
 			label: "Mix",
-			tooltip: "Blends dry signal with delayed signal.",
+			tooltip: PARAM_META.delayMix?.tooltip,
 			value: mix,
 			setValue: setMix,
 			min: 0,
@@ -88,7 +88,7 @@ export function DelaySection({
 				<button
 					type="button"
 					onClick={() => setTapeMode(!tapeMode)}
-					data-hover-info={tapeModeTooltip}
+					data-hover-info={PARAM_META.delayTapeMode?.tooltip}
 					{...tapeModeHoverHandlers}
 					className={`rounded px-3 py-1 text-xs font-medium tracking-wide border transition-colors ${
 						tapeMode

--- a/packages/cosmo-pd101/src/components/panels/fx/DelaySection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/DelaySection.tsx
@@ -27,7 +27,9 @@ export function DelaySection({
 	warmth,
 	setWarmth,
 }: DelaySectionProps) {
-	const tapeModeHoverHandlers = useHoverInfoHandlers(PARAM_META.delayTapeMode?.tooltip);
+	const tapeModeHoverHandlers = useHoverInfoHandlers(
+		PARAM_META.delayTapeMode?.tooltip,
+	);
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Time",

--- a/packages/cosmo-pd101/src/components/panels/fx/PhaserSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/PhaserSection.tsx
@@ -1,5 +1,5 @@
-import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 import { PARAM_META } from "@/lib/synth/paramMeta";
+import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 
 interface PhaserSectionProps {
 	rate: number;

--- a/packages/cosmo-pd101/src/components/panels/fx/PhaserSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/PhaserSection.tsx
@@ -1,4 +1,5 @@
 import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 interface PhaserSectionProps {
 	rate: number;
@@ -30,6 +31,7 @@ export function PhaserSection({
 			max: 10,
 			size: 44,
 			color: "#a78bfa",
+			tooltip: PARAM_META.phaserRate?.tooltip,
 			valueFormatter: (value) => `${value.toFixed(1)}Hz`,
 		},
 		{
@@ -40,6 +42,7 @@ export function PhaserSection({
 			max: 1,
 			size: 44,
 			color: "#a78bfa",
+			tooltip: PARAM_META.phaserDepth?.tooltip,
 			valueFormatter: (value) => `${Math.round(value * 100)}%`,
 		},
 		{
@@ -50,6 +53,7 @@ export function PhaserSection({
 			max: 0.9,
 			size: 42,
 			color: "#a78bfa",
+			tooltip: PARAM_META.phaserFeedback?.tooltip,
 			valueFormatter: (value) =>
 				value >= 0
 					? `+${Math.round(value * 100)}%`
@@ -63,6 +67,7 @@ export function PhaserSection({
 			max: 1,
 			size: 44,
 			color: "#9cb937",
+			tooltip: PARAM_META.phaserMix?.tooltip,
 			valueFormatter: (value) => `${Math.round(value * 100)}%`,
 		},
 	];

--- a/packages/cosmo-pd101/src/components/panels/fx/ReverbSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/ReverbSection.tsx
@@ -28,6 +28,7 @@ export function ReverbSection({
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Space",
+			tooltip: "Sets the virtual room size of the reverb.",
 			value: space,
 			setValue: setSpace,
 			min: 0,
@@ -38,6 +39,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Pre-Dly",
+			tooltip: "Adds a short delay before reverb reflections begin.",
 			value: predelay,
 			setValue: setPredelay,
 			min: 0,
@@ -48,6 +50,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Char",
+			tooltip: "Shapes reverb tone between darker and brighter tails.",
 			value: character,
 			setValue: setCharacter,
 			min: 0,
@@ -58,6 +61,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Dist",
+			tooltip: "Moves the source closer or farther inside the virtual space.",
 			value: distance,
 			setValue: setDistance,
 			min: 0,
@@ -68,6 +72,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Mix",
+			tooltip: "Blends dry signal with reverb output.",
 			value: mix,
 			setValue: setMix,
 			min: 0,

--- a/packages/cosmo-pd101/src/components/panels/fx/ReverbSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/ReverbSection.tsx
@@ -1,5 +1,5 @@
-import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 import { PARAM_META } from "@/lib/synth/paramMeta";
+import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
 
 interface ReverbSectionProps {
 	space: number;

--- a/packages/cosmo-pd101/src/components/panels/fx/ReverbSection.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/ReverbSection.tsx
@@ -1,4 +1,5 @@
 import { BaseFxSection, type FxKnobConfig } from "./BaseFxSection";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 interface ReverbSectionProps {
 	space: number;
@@ -28,7 +29,7 @@ export function ReverbSection({
 	const knobs: FxKnobConfig[] = [
 		{
 			label: "Space",
-			tooltip: "Sets the virtual room size of the reverb.",
+			tooltip: PARAM_META.reverbSpace?.tooltip,
 			value: space,
 			setValue: setSpace,
 			min: 0,
@@ -39,7 +40,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Pre-Dly",
-			tooltip: "Adds a short delay before reverb reflections begin.",
+			tooltip: PARAM_META.reverbPredelay?.tooltip,
 			value: predelay,
 			setValue: setPredelay,
 			min: 0,
@@ -50,7 +51,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Char",
-			tooltip: "Shapes reverb tone between darker and brighter tails.",
+			tooltip: PARAM_META.reverbCharacter?.tooltip,
 			value: character,
 			setValue: setCharacter,
 			min: 0,
@@ -61,7 +62,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Dist",
-			tooltip: "Moves the source closer or farther inside the virtual space.",
+			tooltip: PARAM_META.reverbDistance?.tooltip,
 			value: distance,
 			setValue: setDistance,
 			min: 0,
@@ -72,7 +73,7 @@ export function ReverbSection({
 		},
 		{
 			label: "Mix",
-			tooltip: "Blends dry signal with reverb output.",
+			tooltip: PARAM_META.reverbMix?.tooltip,
 			value: mix,
 			setValue: setMix,
 			min: 0,

--- a/packages/cosmo-pd101/src/components/panels/fx/SynthFilterPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/SynthFilterPanel.tsx
@@ -96,6 +96,13 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 							key={t}
 							active={filterType === t}
 							onClick={() => setFilterType(t)}
+							tooltip={
+								t === "lp"
+									? "Low-pass mode: attenuates frequencies above cutoff."
+									: t === "hp"
+										? "High-pass mode: attenuates frequencies below cutoff."
+										: "Band-pass mode: emphasizes a narrow band around cutoff."
+							}
 							className="flex-1"
 						>
 							{t.toUpperCase()}
@@ -111,6 +118,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 						size={44}
 						color="#3dff3d"
 						label="Cutoff"
+						tooltip="Sets the filter cutoff frequency."
 						valueFormatter={(v) => `${Math.round(v)}Hz`}
 						modDestination="filterCutoff"
 					/>
@@ -122,6 +130,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 						size={44}
 						color="#3dff3d"
 						label="Res"
+						tooltip="Boosts frequencies around the cutoff point."
 						valueFormatter={(v) => `${Math.round(v * 100)}%`}
 						modDestination="filterResonance"
 					/>
@@ -133,6 +142,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 						size={44}
 						color="#3dff3d"
 						label="Env"
+						tooltip="Applies envelope modulation amount to the cutoff."
 						valueFormatter={(v) => `${Math.round(v * 100)}%`}
 						modDestination="filterEnvAmount"
 					/>

--- a/packages/cosmo-pd101/src/components/panels/fx/SynthFilterPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/SynthFilterPanel.tsx
@@ -97,13 +97,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 							key={t}
 							active={filterType === t}
 							onClick={() => setFilterType(t)}
-							tooltip={
-								t === "lp"
-									? "Low-pass mode: attenuates frequencies above cutoff."
-									: t === "hp"
-										? "High-pass mode: attenuates frequencies below cutoff."
-										: "Band-pass mode: emphasizes a narrow band around cutoff."
-							}
+							tooltip={FILTER_TYPE_TOOLTIPS[t]}
 							className="flex-1"
 						>
 							{t.toUpperCase()}

--- a/packages/cosmo-pd101/src/components/panels/fx/SynthFilterPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/fx/SynthFilterPanel.tsx
@@ -4,6 +4,7 @@ import type { AsidePanelComponent } from "@/components/layout/AsidePanelSwitcher
 import SynthPanelContainer from "@/components/layout/SynthPanelContainer";
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { FILTER_TYPE_TOOLTIPS, PARAM_META } from "@/lib/synth/paramMeta";
 
 const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 	function SynthFilterPanel() {
@@ -118,7 +119,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 						size={44}
 						color="#3dff3d"
 						label="Cutoff"
-						tooltip="Sets the filter cutoff frequency."
+						tooltip={PARAM_META.filterCutoff?.tooltip}
 						valueFormatter={(v) => `${Math.round(v)}Hz`}
 						modDestination="filterCutoff"
 					/>
@@ -130,7 +131,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 						size={44}
 						color="#3dff3d"
 						label="Res"
-						tooltip="Boosts frequencies around the cutoff point."
+						tooltip={PARAM_META.filterResonance?.tooltip}
 						valueFormatter={(v) => `${Math.round(v * 100)}%`}
 						modDestination="filterResonance"
 					/>
@@ -142,7 +143,7 @@ const SynthFilterPanel: AsidePanelComponent<"filter"> = Object.assign(
 						size={44}
 						color="#3dff3d"
 						label="Env"
-						tooltip="Applies envelope modulation amount to the cutoff."
+						tooltip={PARAM_META.filterEnvAmount?.tooltip}
 						valueFormatter={(v) => `${Math.round(v * 100)}%`}
 						modDestination="filterEnvAmount"
 					/>

--- a/packages/cosmo-pd101/src/components/panels/voice/GlobalVoicePanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/GlobalVoicePanel.tsx
@@ -96,12 +96,14 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 							<CzButton
 								active={portamentoMode === "rate"}
 								onClick={() => setPortamentoMode("rate")}
+								tooltip="Portamento time scales with note interval distance."
 							>
 								Rate
 							</CzButton>
 							<CzButton
 								active={portamentoMode === "time"}
 								onClick={() => setPortamentoMode("time")}
+								tooltip="Portamento uses a fixed glide time between notes."
 							>
 								Time
 							</CzButton>
@@ -116,6 +118,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 									size={32}
 									color="#7f9de4"
 									label="Rate"
+									tooltip="Sets glide speed when portamento mode is Rate."
 									valueFormatter={(v) => `${Math.round(v)}`}
 								/>
 							) : (
@@ -127,6 +130,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 									size={32}
 									color="#7f9de4"
 									label="Time"
+									tooltip="Sets glide duration when portamento mode is Time."
 									valueFormatter={(v) => `${v.toFixed(2)}s`}
 								/>
 							)}
@@ -143,6 +147,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 								size={30}
 								color="#5bc8d4"
 								label="Bend"
+								tooltip="Sets maximum pitch bend range in semitones."
 								valueFormatter={(v) => `${Math.round(v)} st`}
 							/>
 						</div>
@@ -158,6 +163,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 								size={28}
 								color="#c46eb4"
 								label="Vel Curve"
+								tooltip="Shapes how keyboard velocity maps to output level."
 								valueFormatter={(v) => (v === 0 ? "Linear" : v.toFixed(2))}
 							/>
 						</div>

--- a/packages/cosmo-pd101/src/components/panels/voice/GlobalVoicePanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/GlobalVoicePanel.tsx
@@ -4,8 +4,8 @@ import type { AsidePanelComponent } from "@/components/layout/AsidePanelSwitcher
 import SynthPanelContainer from "@/components/layout/SynthPanelContainer";
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
-import { applyVelocityCurve } from "@/lib/synth/velocityCurve";
 import { PARAM_META, PORTAMENTO_MODE_TOOLTIPS } from "@/lib/synth/paramMeta";
+import { applyVelocityCurve } from "@/lib/synth/velocityCurve";
 
 const W = 72;
 const H = 42;

--- a/packages/cosmo-pd101/src/components/panels/voice/GlobalVoicePanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/GlobalVoicePanel.tsx
@@ -5,6 +5,7 @@ import SynthPanelContainer from "@/components/layout/SynthPanelContainer";
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
 import { applyVelocityCurve } from "@/lib/synth/velocityCurve";
+import { PARAM_META, PORTAMENTO_MODE_TOOLTIPS } from "@/lib/synth/paramMeta";
 
 const W = 72;
 const H = 42;
@@ -96,14 +97,14 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 							<CzButton
 								active={portamentoMode === "rate"}
 								onClick={() => setPortamentoMode("rate")}
-								tooltip="Portamento time scales with note interval distance."
+								tooltip={PORTAMENTO_MODE_TOOLTIPS["rate"]}
 							>
 								Rate
 							</CzButton>
 							<CzButton
 								active={portamentoMode === "time"}
 								onClick={() => setPortamentoMode("time")}
-								tooltip="Portamento uses a fixed glide time between notes."
+								tooltip={PORTAMENTO_MODE_TOOLTIPS["time"]}
 							>
 								Time
 							</CzButton>
@@ -118,7 +119,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 									size={32}
 									color="#7f9de4"
 									label="Rate"
-									tooltip="Sets glide speed when portamento mode is Rate."
+									tooltip={PARAM_META.portamentoRate?.tooltip}
 									valueFormatter={(v) => `${Math.round(v)}`}
 								/>
 							) : (
@@ -130,7 +131,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 									size={32}
 									color="#7f9de4"
 									label="Time"
-									tooltip="Sets glide duration when portamento mode is Time."
+									tooltip={PARAM_META.portamentoTime?.tooltip}
 									valueFormatter={(v) => `${v.toFixed(2)}s`}
 								/>
 							)}
@@ -147,7 +148,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 								size={30}
 								color="#5bc8d4"
 								label="Bend"
-								tooltip="Sets maximum pitch bend range in semitones."
+								tooltip={PARAM_META.pitchBendRange?.tooltip}
 								valueFormatter={(v) => `${Math.round(v)} st`}
 							/>
 						</div>
@@ -163,7 +164,7 @@ const GlobalVoicePanel: AsidePanelComponent<"global"> = Object.assign(
 								size={28}
 								color="#c46eb4"
 								label="Vel Curve"
-								tooltip="Shapes how keyboard velocity maps to output level."
+								tooltip={PARAM_META.velocityCurve?.tooltip}
 								valueFormatter={(v) => (v === 0 ? "Linear" : v.toFixed(2))}
 							/>
 						</div>

--- a/packages/cosmo-pd101/src/components/panels/voice/PhaseModPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/PhaseModPanel.tsx
@@ -28,6 +28,7 @@ const PhaseModPanel: AsidePanelComponent<"phaseMod"> = Object.assign(
 						size={52}
 						color="#7f9de4"
 						label="Amount"
+						tooltip="Sets internal phase modulation depth."
 						valueFormatter={(value) => value.toFixed(2)}
 						modDestination="intPmAmount"
 					/>
@@ -39,12 +40,14 @@ const PhaseModPanel: AsidePanelComponent<"phaseMod"> = Object.assign(
 						size={52}
 						color="#9cb937"
 						label="Ratio"
+						tooltip="Sets modulator-to-carrier frequency ratio."
 						valueFormatter={(value) => value.toFixed(1)}
 					/>
 				</div>
 				<CzButton
 					active={pmPre}
 					onClick={() => setPmPre(!pmPre)}
+					tooltip="Apply phase modulation before warp shaping."
 					className="mt-3 [&_button]:bg-cz-inset [&_button]:border-cz-border"
 				>
 					Pre-warp PM

--- a/packages/cosmo-pd101/src/components/panels/voice/PhaseModPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/PhaseModPanel.tsx
@@ -3,6 +3,7 @@ import type { AsidePanelComponent } from "@/components/layout/AsidePanelSwitcher
 import SynthPanelContainer from "@/components/layout/SynthPanelContainer";
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 const PhaseModPanel: AsidePanelComponent<"phaseMod"> = Object.assign(
 	function PhaseModPanel() {
@@ -28,7 +29,7 @@ const PhaseModPanel: AsidePanelComponent<"phaseMod"> = Object.assign(
 						size={52}
 						color="#7f9de4"
 						label="Amount"
-						tooltip="Sets internal phase modulation depth."
+						tooltip={PARAM_META.intPmAmount?.tooltip}
 						valueFormatter={(value) => value.toFixed(2)}
 						modDestination="intPmAmount"
 					/>
@@ -40,14 +41,14 @@ const PhaseModPanel: AsidePanelComponent<"phaseMod"> = Object.assign(
 						size={52}
 						color="#9cb937"
 						label="Ratio"
-						tooltip="Sets modulator-to-carrier frequency ratio."
+						tooltip={PARAM_META.intPmRatio?.tooltip}
 						valueFormatter={(value) => value.toFixed(1)}
 					/>
 				</div>
 				<CzButton
 					active={pmPre}
 					onClick={() => setPmPre(!pmPre)}
-					tooltip="Apply phase modulation before warp shaping."
+					tooltip={PARAM_META.pmPre?.tooltip}
 					className="mt-3 [&_button]:bg-cz-inset [&_button]:border-cz-border"
 				>
 					Pre-warp PM

--- a/packages/cosmo-pd101/src/components/panels/voice/VibratoPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/VibratoPanel.tsx
@@ -28,6 +28,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 							key={w}
 							active={vibratoWave === i + 1}
 							onClick={() => setVibratoWave(i + 1)}
+							tooltip={`Select ${w} vibrato waveform.`}
 						>
 							{w}
 						</CzButton>
@@ -42,6 +43,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 						size={44}
 						color="#7f9de4"
 						label="Rate"
+						tooltip="Sets vibrato speed."
 						valueFormatter={(v) => `${Math.round(v)}`}
 					/>
 					<ControlKnob
@@ -52,6 +54,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 						size={44}
 						color="#7f9de4"
 						label="Depth"
+						tooltip="Sets vibrato pitch modulation amount."
 						valueFormatter={(v) => `${Math.round(v)}`}
 						modDestination="vibratoDepth"
 					/>
@@ -63,6 +66,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 						size={44}
 						color="#7f9de4"
 						label="Delay"
+						tooltip="Delays vibrato onset after a note is triggered."
 						valueFormatter={(v) => `${Math.round(v)}ms`}
 					/>
 				</div>

--- a/packages/cosmo-pd101/src/components/panels/voice/VibratoPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/voice/VibratoPanel.tsx
@@ -3,6 +3,7 @@ import type { AsidePanelComponent } from "@/components/layout/AsidePanelSwitcher
 import SynthPanelContainer from "@/components/layout/SynthPanelContainer";
 import CzButton from "@/components/primitives/CzButton";
 import { useSynthParam } from "@/features/synth/SynthParamController";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 
 const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 	function VibratoPanel() {
@@ -43,7 +44,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 						size={44}
 						color="#7f9de4"
 						label="Rate"
-						tooltip="Sets vibrato speed."
+						tooltip={PARAM_META.vibratoRate?.tooltip}
 						valueFormatter={(v) => `${Math.round(v)}`}
 					/>
 					<ControlKnob
@@ -54,7 +55,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 						size={44}
 						color="#7f9de4"
 						label="Depth"
-						tooltip="Sets vibrato pitch modulation amount."
+						tooltip={PARAM_META.vibratoDepth?.tooltip}
 						valueFormatter={(v) => `${Math.round(v)}`}
 						modDestination="vibratoDepth"
 					/>
@@ -66,7 +67,7 @@ const VibratoPanel: AsidePanelComponent<"vibrato"> = Object.assign(
 						size={44}
 						color="#7f9de4"
 						label="Delay"
-						tooltip="Delays vibrato onset after a note is triggered."
+						tooltip={PARAM_META.vibratoDelay?.tooltip}
 						valueFormatter={(v) => `${Math.round(v)}ms`}
 					/>
 				</div>

--- a/packages/cosmo-pd101/src/components/primitives/CompactButton.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/CompactButton.tsx
@@ -1,9 +1,12 @@
+import { useHoverInfoHandlers } from "../layout/HoverInfo";
+
 type CompactButtonProps = {
 	active?: boolean;
 	onClick?: () => void;
 	children: React.ReactNode;
 	className?: string;
 	disabled?: boolean;
+	tooltip?: string;
 };
 
 /**
@@ -17,12 +20,18 @@ export default function CompactButton({
 	children,
 	className = "",
 	disabled = false,
+	tooltip,
 }: CompactButtonProps) {
+	const hoverHandlers = useHoverInfoHandlers(tooltip);
+	const resolvedTooltip = tooltip?.trim() ? tooltip : undefined;
+
 	return (
 		<button
 			type="button"
 			onClick={onClick}
 			disabled={disabled}
+			data-hover-info={resolvedTooltip}
+			{...hoverHandlers}
 			className={`inline-flex items-center justify-center h-5 min-w-7 px-1 font-mono text-[0.56rem] font-bold uppercase tracking-wide select-none cursor-pointer transition-colors rounded-xs border disabled:opacity-40 disabled:cursor-not-allowed ${
 				active
 					? "bg-cz-cream text-cz-body border-cz-cream"

--- a/packages/cosmo-pd101/src/components/primitives/CompactButton.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/CompactButton.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useHoverInfoHandlers } from "../layout/HoverInfo";
 
 type CompactButtonProps = {
@@ -22,8 +23,8 @@ export default function CompactButton({
 	disabled = false,
 	tooltip,
 }: CompactButtonProps) {
-	const hoverHandlers = useHoverInfoHandlers(tooltip);
-	const resolvedTooltip = tooltip?.trim() ? tooltip : undefined;
+	const resolvedTooltip = tooltip?.trim() ? tooltip.trim() : undefined;
+	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip);
 
 	return (
 		<button

--- a/packages/cosmo-pd101/src/components/primitives/CzButton.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/CzButton.tsx
@@ -1,6 +1,6 @@
 import { motion } from "motion/react";
 import type React from "react";
-import { useHoverInfo } from "../layout/HoverInfo";
+import { useHoverInfoHandlers } from "../layout/HoverInfo";
 
 type CzButtonProps = {
 	active?: boolean;
@@ -35,22 +35,15 @@ export default function CzButton({
 	style,
 	tooltip,
 }: CzButtonProps) {
-	const { setHoverInfo, clearHoverInfo } = useHoverInfo();
-	const hoverHandlers = tooltip
-		? {
-				onPointerEnter: () => setHoverInfo(tooltip),
-				onPointerLeave: clearHoverInfo,
-				onFocus: () => setHoverInfo(tooltip),
-				onBlur: clearHoverInfo,
-			}
-		: undefined;
+	const resolvedTooltip = tooltip?.trim() ? tooltip : undefined;
+	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip);
 
 	const buttonFace = (
 		<motion.button
 			type={type}
 			disabled={disabled}
 			onClick={onClick}
-			data-hover-info={tooltip}
+			data-hover-info={resolvedTooltip}
 			{...hoverHandlers}
 			initial={{
 				boxShadow:

--- a/packages/cosmo-pd101/src/components/primitives/CzTabButton.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/CzTabButton.tsx
@@ -2,7 +2,7 @@ import { motion } from "motion/react";
 import type React from "react";
 import { useRef } from "react";
 import { joinClasses } from "@/components/primitives/Card";
-import { useHoverInfo } from "../layout/HoverInfo";
+import { useHoverInfoHandlers } from "../layout/HoverInfo";
 
 export type CzTabButtonColor = "black" | "blue" | "cyan" | "grey" | "red";
 export type CzTabButtonLedColor = "off" | "red" | "green" | "blue";
@@ -146,7 +146,6 @@ export default function CzTabButton({
 	ledColor,
 	tooltip,
 }: CzTabButtonProps) {
-	const { setHoverInfo, clearHoverInfo } = useHoverInfo();
 	const palette = colorStyles[color];
 	const resolvedLedColor = ledColor ?? (active ? "red" : "off");
 	const resolvedWidth = width ?? height ?? 48;
@@ -213,14 +212,8 @@ export default function CzTabButton({
 		buttonStyle.color = "#ffffff";
 	}
 
-	const hoverHandlers = tooltip
-		? {
-				onPointerEnter: () => setHoverInfo(tooltip),
-				onPointerLeave: clearHoverInfo,
-				onFocus: () => setHoverInfo(tooltip),
-				onBlur: clearHoverInfo,
-			}
-		: undefined;
+	const resolvedTooltip = tooltip?.trim() ? tooltip : undefined;
+	const hoverHandlers = useHoverInfoHandlers(resolvedTooltip);
 
 	return (
 		<div className={joinClasses("flex flex-col items-center gap-1", className)}>
@@ -256,7 +249,7 @@ export default function CzTabButton({
 				onPointerUp={handlePointerUp}
 				onPointerLeave={handlePointerUp}
 				onPointerCancel={handlePointerUp}
-				data-hover-info={tooltip}
+				data-hover-info={resolvedTooltip}
 				{...hoverHandlers}
 				animate={
 					active

--- a/packages/cosmo-pd101/src/components/primitives/CzTabButton.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/CzTabButton.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import type React from "react";
 import { useRef } from "react";
 import { joinClasses } from "@/components/primitives/Card";
+import { useHoverInfo } from "../layout/HoverInfo";
 
 export type CzTabButtonColor = "black" | "blue" | "cyan" | "grey" | "red";
 export type CzTabButtonLedColor = "off" | "red" | "green" | "blue";
@@ -23,6 +24,7 @@ type CzTabButtonProps = {
 	customColor?: string;
 	longPressMs?: number;
 	ledColor?: CzTabButtonLedColor;
+	tooltip?: string;
 };
 
 const clampColor = (value: number) => Math.max(0, Math.min(255, value));
@@ -142,7 +144,9 @@ export default function CzTabButton({
 	customColor,
 	longPressMs = 450,
 	ledColor,
+	tooltip,
 }: CzTabButtonProps) {
+	const { setHoverInfo, clearHoverInfo } = useHoverInfo();
 	const palette = colorStyles[color];
 	const resolvedLedColor = ledColor ?? (active ? "red" : "off");
 	const resolvedWidth = width ?? height ?? 48;
@@ -209,6 +213,15 @@ export default function CzTabButton({
 		buttonStyle.color = "#ffffff";
 	}
 
+	const hoverHandlers = tooltip
+		? {
+				onPointerEnter: () => setHoverInfo(tooltip),
+				onPointerLeave: clearHoverInfo,
+				onFocus: () => setHoverInfo(tooltip),
+				onBlur: clearHoverInfo,
+			}
+		: undefined;
+
 	return (
 		<div className={joinClasses("flex flex-col items-center gap-1", className)}>
 			{showLed ? (
@@ -243,6 +256,8 @@ export default function CzTabButton({
 				onPointerUp={handlePointerUp}
 				onPointerLeave={handlePointerUp}
 				onPointerCancel={handlePointerUp}
+				data-hover-info={tooltip}
+				{...hoverHandlers}
 				animate={
 					active
 						? {

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -39,6 +39,7 @@ import { useSynthStore } from "@/features/synth/synthStore";
 import { useSynthUiStore } from "@/features/synth/synthUiStore";
 import { HoverInfoProvider, useHoverInfo } from "../layout/HoverInfo";
 import MiniKeyboardOverlay from "../layout/MiniKeyboardOverlay";
+import SynthInfoBar from "../layout/SynthInfoBar";
 import PhaserPanel from "../panels/fx/PhaserPanel";
 
 type SynthRendererProps = {
@@ -94,7 +95,7 @@ export default function SynthRenderer({
 	miniKeyboard,
 }: SynthRendererProps) {
 	return (
-		<HoverInfoProvider>
+		<HoverInfoProvider externalReadout={lcdTransientReadout}>
 			<SynthRendererContent
 				headerProps={headerProps}
 				frameClassName={frameClassName}
@@ -126,7 +127,6 @@ function SynthRendererContent({
 	bottomBarExtra,
 	lcdPrimaryText: _lcdPrimaryText,
 	lcdSecondaryText: _lcdSecondaryText,
-	lcdTransientReadout = null,
 	effectivePitchHz,
 	analyserNodeRef,
 	audioCtxRef,
@@ -145,12 +145,7 @@ function SynthRendererContent({
 	const setKeyboardVisible = useSynthUiStore((s) => s.setKeyboardVisible);
 	const libraryModeOpen = useSynthUiStore((s) => s.libraryModeOpen);
 	const setLibraryModeOpen = useSynthUiStore((s) => s.setLibraryModeOpen);
-	const { hoverInfo } = useHoverInfo();
-	const infoText = hoverInfo
-		? hoverInfo
-		: lcdTransientReadout
-			? `${lcdTransientReadout.label}: ${lcdTransientReadout.value}`
-			: "Hover any control for context.";
+	const { infoText, setControlReadout } = useHoverInfo();
 
 	return (
 		<ModMatrixProvider modMatrix={modMatrix} setModMatrix={setModMatrix}>
@@ -208,35 +203,54 @@ function SynthRendererContent({
 										<div className="flex items-end gap-2">
 											<CzTabButton
 												active={mainPanelMode === "phase"}
-												onClick={() => setMainPanelMode("phase")}
+												onClick={() => {
+													setMainPanelMode("phase");
+													setControlReadout({
+														label: "Main Panel",
+														value: "PHASE",
+													});
+												}}
 												topLabel="Main"
 												bottomLabel=""
 												color="red"
 												width={48}
+												tooltip="Show phase editor controls."
 											></CzTabButton>
 											<CzTabButton
 												active={mainPanelMode === "fx"}
 												onClick={() =>
-													setMainPanelMode(
-														mainPanelMode === "fx" ? "phase" : "fx",
-													)
+													{
+														const nextMode = mainPanelMode === "fx" ? "phase" : "fx";
+														setMainPanelMode(nextMode);
+														setControlReadout({
+															label: "Main Panel",
+															value: nextMode.toUpperCase(),
+														});
+													}
 												}
 												topLabel="FX"
 												bottomLabel=""
 												width={48}
 												color="blue"
+												tooltip="Toggle FX console drawer."
 											></CzTabButton>
 											<CzTabButton
 												active={mainPanelMode === "mod"}
 												onClick={() =>
-													setMainPanelMode(
-														mainPanelMode === "mod" ? "phase" : "mod",
-													)
+													{
+														const nextMode = mainPanelMode === "mod" ? "phase" : "mod";
+														setMainPanelMode(nextMode);
+														setControlReadout({
+															label: "Main Panel",
+															value: nextMode.toUpperCase(),
+														});
+													}
 												}
 												topLabel="MOD"
 												bottomLabel=""
 												width={48}
 												color="cyan"
+												tooltip="Toggle modulation console drawer."
 											></CzTabButton>
 										</div>
 									</div>
@@ -332,28 +346,13 @@ function SynthRendererContent({
 							onNoteOff={miniKeyboard.onNoteOff}
 						/>
 					) : null}
-					<div className="relative z-20 mt-1 flex min-h-8 flex-wrap items-center gap-x-3 gap-y-1 rounded-t-sm border border-cz-border/80 bg-cz-body px-3 py-1 font-mono text-[0.62rem] uppercase tracking-[0.22em] text-cz-cream/80 shadow-inner">
-						<span className="text-cz-light-blue/80">Info</span>
-						<span className="min-w-0 flex-1 truncate">{infoText}</span>
-						{bottomBarExtra ? (
-							<div className="flex items-center gap-2 text-[0.54rem] tracking-[0.18em]">
-								{bottomBarExtra}
-							</div>
-						) : null}
-						{miniKeyboard && !libraryModeOpen ? (
-							<button
-								type="button"
-								onClick={() => setKeyboardVisible(!keyboardVisible)}
-								className={`rounded-sm border px-2 py-1 text-[0.56rem] uppercase tracking-[0.24em] transition-colors ${
-									keyboardVisible
-										? "border-cz-gold bg-cz-gold/10 text-cz-gold"
-										: "border-cz-border bg-black/10 text-cz-cream/70 hover:text-cz-cream"
-								}`}
-							>
-								{keyboardVisible ? "Hide Keys" : "Show Keys"}
-							</button>
-						) : null}
-					</div>
+					<SynthInfoBar
+						infoText={infoText}
+						bottomBarExtra={bottomBarExtra}
+						showKeyboardToggle={Boolean(miniKeyboard) && !libraryModeOpen}
+						keyboardVisible={keyboardVisible}
+						onKeyboardToggle={() => setKeyboardVisible(!keyboardVisible)}
+					/>
 				</div>
 			</SynthParamControllerProvider>
 		</ModMatrixProvider>
@@ -373,6 +372,7 @@ function MasterVolumeControl() {
 				size={48}
 				color="white"
 				label="Main Volume"
+				tooltip="Sets the global synth output level."
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 				modDestination="volume"
 			/>

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -218,16 +218,15 @@ function SynthRendererContent({
 											></CzTabButton>
 											<CzTabButton
 												active={mainPanelMode === "fx"}
-												onClick={() =>
-													{
-														const nextMode = mainPanelMode === "fx" ? "phase" : "fx";
-														setMainPanelMode(nextMode);
-														setControlReadout({
-															label: "Main Panel",
-															value: nextMode.toUpperCase(),
-														});
-													}
-												}
+												onClick={() => {
+													const nextMode =
+														mainPanelMode === "fx" ? "phase" : "fx";
+													setMainPanelMode(nextMode);
+													setControlReadout({
+														label: "Main Panel",
+														value: nextMode.toUpperCase(),
+													});
+												}}
 												topLabel="FX"
 												bottomLabel=""
 												width={48}
@@ -236,16 +235,15 @@ function SynthRendererContent({
 											></CzTabButton>
 											<CzTabButton
 												active={mainPanelMode === "mod"}
-												onClick={() =>
-													{
-														const nextMode = mainPanelMode === "mod" ? "phase" : "mod";
-														setMainPanelMode(nextMode);
-														setControlReadout({
-															label: "Main Panel",
-															value: nextMode.toUpperCase(),
-														});
-													}
-												}
+												onClick={() => {
+													const nextMode =
+														mainPanelMode === "mod" ? "phase" : "mod";
+													setMainPanelMode(nextMode);
+													setControlReadout({
+														label: "Main Panel",
+														value: nextMode.toUpperCase(),
+													});
+												}}
 												topLabel="MOD"
 												bottomLabel=""
 												width={48}

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/features/synth/SynthParamController";
 import { useSynthStore } from "@/features/synth/synthStore";
 import { useSynthUiStore } from "@/features/synth/synthUiStore";
+import { PARAM_META } from "@/lib/synth/paramMeta";
 import { HoverInfoProvider, useHoverInfo } from "../layout/HoverInfo";
 import MiniKeyboardOverlay from "../layout/MiniKeyboardOverlay";
 import SynthInfoBar from "../layout/SynthInfoBar";
@@ -370,7 +371,7 @@ function MasterVolumeControl() {
 				size={48}
 				color="white"
 				label="Main Volume"
-				tooltip="Sets the global synth output level."
+				tooltip={PARAM_META.volume?.tooltip}
 				valueFormatter={(value) => `${Math.round(value * 100)}%`}
 				modDestination="volume"
 			/>

--- a/packages/cosmo-pd101/src/features/synth/hooks/useLcdControlReadout.ts
+++ b/packages/cosmo-pd101/src/features/synth/hooks/useLcdControlReadout.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import type { StepEnvData } from "@/lib/synth/bindings/synth";
+import type {
+	EngineParamReadoutFormatV1,
+	StepEnvData,
+} from "@/lib/synth/bindings/synth";
+import { getEngineParamUiMeta } from "@/lib/synth/paramMeta";
 
 type LcdControlReadout = {
 	label: string;
@@ -19,8 +23,60 @@ export function useLcdControlReadout(): UseLcdControlReadoutResult {
 		useState<LcdControlReadout | null>(null);
 	const lcdReadoutTimeoutRef = useRef<number | null>(null);
 
+	const formatEngineValue = useCallback(
+		(
+			format: EngineParamReadoutFormatV1,
+			value: string | number | boolean,
+		): string | null => {
+			switch (format.kind) {
+				case "onOff":
+					return typeof value === "boolean" ? (value ? "ON" : "OFF") : null;
+				case "raw":
+					return typeof value === "string" ? value : null;
+				case "uppercase":
+					return typeof value === "string" ? value.toUpperCase() : null;
+				case "integer":
+					return typeof value === "number" ? `${Math.round(value)}` : null;
+				case "decimal":
+					if (typeof value !== "number") return null;
+					return Number.isInteger(value) ? `${value}` : value.toFixed(2);
+				case "percent":
+					return typeof value === "number"
+						? `${Math.round(value * 100)}%`
+						: null;
+				case "semitones":
+					return typeof value === "number" ? `${Math.round(value)} ST` : null;
+				case "milliseconds":
+					return typeof value === "number" ? `${Math.round(value)} MS` : null;
+				case "seconds2":
+					return typeof value === "number" ? `${value.toFixed(2)} S` : null;
+				case "hertz":
+					return typeof value === "number" ? `${Math.round(value)} HZ` : null;
+				case "enumMap": {
+					if (typeof value !== "string") {
+						return null;
+					}
+					const match = format.values.find((entry) => entry.value === value);
+					return match?.label ?? value.toUpperCase();
+				}
+			}
+		},
+		[],
+	);
+
 	const formatValue = useCallback(
 		(key: string, value: string | number | boolean): string => {
+			const engineMeta = getEngineParamUiMeta(key);
+			if (engineMeta) {
+				const engineFormatted = formatEngineValue(
+					engineMeta.readoutFormat,
+					value,
+				);
+				if (engineFormatted) {
+					return engineFormatted;
+				}
+			}
+
 			if (typeof value === "boolean") {
 				return value ? t("states.on") : t("states.off");
 			}
@@ -73,12 +129,15 @@ export function useLcdControlReadout(): UseLcdControlReadoutResult {
 
 			return Number.isInteger(value) ? `${value}` : value.toFixed(2);
 		},
-		[t],
+		[formatEngineValue, t],
 	);
 
 	const pushLcdControlReadout = useCallback(
 		(key: string, value: unknown) => {
-			const label = t(`lcdControls.${key}`, { defaultValue: key });
+			const engineMeta = getEngineParamUiMeta(key);
+			const label =
+				engineMeta?.readoutLabel ??
+				t(`lcdControls.${key}`, { defaultValue: key });
 			if (
 				typeof value !== "string" &&
 				typeof value !== "number" &&

--- a/packages/cosmo-pd101/src/lib/synth/bindings/synth.ts
+++ b/packages/cosmo-pd101/src/lib/synth/bindings/synth.ts
@@ -2915,3 +2915,542 @@ export const MODULE_PRESET_CATALOG_V1: ModulePresetGroupV1[] = [
     ]
   }
 ];
+
+export type EngineEnumValueLabelV1 = { value: string; label: string };
+export type EngineParamReadoutFormatV1 =
+  | { kind: "onOff" }
+  | { kind: "raw" }
+  | { kind: "uppercase" }
+  | { kind: "integer" }
+  | { kind: "decimal" }
+  | { kind: "percent" }
+  | { kind: "semitones" }
+  | { kind: "milliseconds" }
+  | { kind: "seconds2" }
+  | { kind: "hertz" }
+  | { kind: "enumMap"; values: EngineEnumValueLabelV1[] };
+export type EngineParamUiMetaV1 = { key: string; tooltip: string; readoutLabel: string; readoutFormat: EngineParamReadoutFormatV1 };
+export type EngineEnumValueTooltipV1 = { key: string; value: string; tooltip: string };
+
+/** Rust-owned engine parameter tooltip and readout metadata. */
+export const ENGINE_PARAM_UI_META_V1: EngineParamUiMetaV1[] = [
+  {
+    "key": "volume",
+    "tooltip": "Sets the global synth output level.",
+    "readoutLabel": "Volume",
+    "readoutFormat": {
+      "kind": "percent"
+    }
+  },
+  {
+    "key": "warpAAmount",
+    "tooltip": "Sets base harmonic warp amount for this line.",
+    "readoutLabel": "Line 1 DCW",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "warpBAmount",
+    "tooltip": "Sets base harmonic warp amount for this line.",
+    "readoutLabel": "Line 2 DCW",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "algoBlendA",
+    "tooltip": "Crossfades between Algo A and Algo B outputs.",
+    "readoutLabel": "Line 1 Blend",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "algoBlendB",
+    "tooltip": "Crossfades between Algo A and Algo B outputs.",
+    "readoutLabel": "Line 2 Blend",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "line1Level",
+    "tooltip": "Sets base output level for this line.",
+    "readoutLabel": "Line 1 Level",
+    "readoutFormat": {
+      "kind": "percent"
+    }
+  },
+  {
+    "key": "line2Level",
+    "tooltip": "Sets base output level for this line.",
+    "readoutLabel": "Line 2 Level",
+    "readoutFormat": {
+      "kind": "percent"
+    }
+  },
+  {
+    "key": "line1Octave",
+    "tooltip": "Transposes this line by octave steps.",
+    "readoutLabel": "Line 1 Octave",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "line2Octave",
+    "tooltip": "Transposes this line by octave steps.",
+    "readoutLabel": "Line 2 Octave",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "line1Detune",
+    "tooltip": "Fine tunes this line in cents.",
+    "readoutLabel": "Line 1 Detune",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "line2Detune",
+    "tooltip": "Fine tunes this line in cents.",
+    "readoutLabel": "Line 2 Detune",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "lineSelect",
+    "tooltip": "Selects which oscillator lines are heard together.",
+    "readoutLabel": "Line Select",
+    "readoutFormat": {
+      "kind": "raw"
+    }
+  },
+  {
+    "key": "modMode",
+    "tooltip": "Chooses the interaction mode between oscillator lines.",
+    "readoutLabel": "Modulation",
+    "readoutFormat": {
+      "kind": "uppercase"
+    }
+  },
+  {
+    "key": "polyMode",
+    "tooltip": "Switches between polyphonic and monophonic note allocation.",
+    "readoutLabel": "Voice Mode",
+    "readoutFormat": {
+      "kind": "enumMap",
+      "values": [
+        {
+          "value": "poly8",
+          "label": "POLY 8"
+        },
+        {
+          "value": "mono",
+          "label": "MONO"
+        }
+      ]
+    }
+  },
+  {
+    "key": "intPmAmount",
+    "tooltip": "Sets internal phase modulation depth.",
+    "readoutLabel": "PM Amount",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "intPmRatio",
+    "tooltip": "Sets modulator-to-carrier frequency ratio.",
+    "readoutLabel": "PM Ratio",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "pmPre",
+    "tooltip": "Apply phase modulation before warp shaping.",
+    "readoutLabel": "PM Mode",
+    "readoutFormat": {
+      "kind": "onOff"
+    }
+  },
+  {
+    "key": "vibratoRate",
+    "tooltip": "Sets vibrato speed.",
+    "readoutLabel": "Vibrato Rate",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "vibratoDepth",
+    "tooltip": "Sets vibrato pitch modulation depth.",
+    "readoutLabel": "Vibrato Depth",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "vibratoDelay",
+    "tooltip": "Delays vibrato onset after note start.",
+    "readoutLabel": "Vibrato Delay",
+    "readoutFormat": {
+      "kind": "milliseconds"
+    }
+  },
+  {
+    "key": "lfoWaveform",
+    "tooltip": "Selects LFO 1 waveform shape.",
+    "readoutLabel": "LFO Wave",
+    "readoutFormat": {
+      "kind": "uppercase"
+    }
+  },
+  {
+    "key": "lfoRate",
+    "tooltip": "Sets LFO 1 speed.",
+    "readoutLabel": "LFO Rate",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "lfoDepth",
+    "tooltip": "Sets LFO 1 modulation depth.",
+    "readoutLabel": "LFO Depth",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "lfoOffset",
+    "tooltip": "Offsets LFO 1 output around zero.",
+    "readoutLabel": "LFO Offset",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "lfo2Rate",
+    "tooltip": "Sets LFO 2 speed.",
+    "readoutLabel": "LFO 2 Rate",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "lfo2Depth",
+    "tooltip": "Sets LFO 2 modulation depth.",
+    "readoutLabel": "LFO 2 Depth",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "lfo2Offset",
+    "tooltip": "Offsets LFO 2 output around zero.",
+    "readoutLabel": "LFO 2 Offset",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "randomRate",
+    "tooltip": "Sets sample-and-hold random modulation refresh rate.",
+    "readoutLabel": "Random Rate",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "modEnvAttack",
+    "tooltip": "Sets modulation envelope attack time.",
+    "readoutLabel": "Mod Env Attack",
+    "readoutFormat": {
+      "kind": "seconds2"
+    }
+  },
+  {
+    "key": "modEnvDecay",
+    "tooltip": "Sets modulation envelope decay time.",
+    "readoutLabel": "Mod Env Decay",
+    "readoutFormat": {
+      "kind": "seconds2"
+    }
+  },
+  {
+    "key": "modEnvSustain",
+    "tooltip": "Sets sustained modulation level while note is held.",
+    "readoutLabel": "Mod Env Sustain",
+    "readoutFormat": {
+      "kind": "percent"
+    }
+  },
+  {
+    "key": "modEnvRelease",
+    "tooltip": "Sets modulation envelope release time after note off.",
+    "readoutLabel": "Mod Env Release",
+    "readoutFormat": {
+      "kind": "seconds2"
+    }
+  },
+  {
+    "key": "filterType",
+    "tooltip": "Selects the filter response shape.",
+    "readoutLabel": "Filter Type",
+    "readoutFormat": {
+      "kind": "uppercase"
+    }
+  },
+  {
+    "key": "filterCutoff",
+    "tooltip": "Sets the filter cutoff frequency.",
+    "readoutLabel": "Filter Cutoff",
+    "readoutFormat": {
+      "kind": "hertz"
+    }
+  },
+  {
+    "key": "filterResonance",
+    "tooltip": "Boosts frequencies around the cutoff point.",
+    "readoutLabel": "Filter Resonance",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "filterEnvAmount",
+    "tooltip": "Applies envelope modulation amount to the cutoff.",
+    "readoutLabel": "Filter Env",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "chorusRate",
+    "tooltip": "Sets chorus modulation speed.",
+    "readoutLabel": "Chorus Rate",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "chorusDepth",
+    "tooltip": "Sets intensity of chorus pitch modulation.",
+    "readoutLabel": "Chorus Depth",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "chorusMix",
+    "tooltip": "Blends dry signal with chorus effect.",
+    "readoutLabel": "Chorus Mix",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "delayTime",
+    "tooltip": "Sets the delay repeat interval.",
+    "readoutLabel": "Delay Time",
+    "readoutFormat": {
+      "kind": "seconds2"
+    }
+  },
+  {
+    "key": "delayFeedback",
+    "tooltip": "Feeds delayed signal back for additional repeats.",
+    "readoutLabel": "Delay Feedback",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "delayWarmth",
+    "tooltip": "Adds tape-style saturation and high-frequency rolloff.",
+    "readoutLabel": "Delay Warmth",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "delayMix",
+    "tooltip": "Blends dry signal with delayed signal.",
+    "readoutLabel": "Delay Mix",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "delayTapeMode",
+    "tooltip": "Toggle tape echo coloration for delay repeats.",
+    "readoutLabel": "Tape Mode",
+    "readoutFormat": {
+      "kind": "onOff"
+    }
+  },
+  {
+    "key": "reverbSpace",
+    "tooltip": "Sets the virtual room size for reverb reflections.",
+    "readoutLabel": "Reverb Space",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "reverbPredelay",
+    "tooltip": "Adds delay before the reverb tail starts.",
+    "readoutLabel": "Reverb Pre-Delay",
+    "readoutFormat": {
+      "kind": "milliseconds"
+    }
+  },
+  {
+    "key": "reverbDistance",
+    "tooltip": "Moves source position deeper into the reverb space.",
+    "readoutLabel": "Reverb Distance",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "reverbCharacter",
+    "tooltip": "Shapes reverb tone from dark to bright.",
+    "readoutLabel": "Reverb Character",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "reverbMix",
+    "tooltip": "Blends dry signal with reverb output.",
+    "readoutLabel": "Reverb Mix",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "portamentoMode",
+    "tooltip": "Chooses whether glide uses rate or fixed time behavior.",
+    "readoutLabel": "Portamento Mode",
+    "readoutFormat": {
+      "kind": "uppercase"
+    }
+  },
+  {
+    "key": "portamentoRate",
+    "tooltip": "Sets glide speed when portamento mode is Rate.",
+    "readoutLabel": "Portamento Rate",
+    "readoutFormat": {
+      "kind": "integer"
+    }
+  },
+  {
+    "key": "portamentoTime",
+    "tooltip": "Sets glide duration when portamento mode is Time.",
+    "readoutLabel": "Portamento Time",
+    "readoutFormat": {
+      "kind": "seconds2"
+    }
+  },
+  {
+    "key": "pitchBendRange",
+    "tooltip": "Sets maximum pitch bend range in semitones.",
+    "readoutLabel": "Bend Range",
+    "readoutFormat": {
+      "kind": "semitones"
+    }
+  },
+  {
+    "key": "velocityCurve",
+    "tooltip": "Shapes how keyboard velocity maps to output level.",
+    "readoutLabel": "Vel Curve",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  },
+  {
+    "key": "modWheelVibratoDepth",
+    "tooltip": "Sets how much mod wheel movement affects vibrato depth.",
+    "readoutLabel": "Mod to Vibrato",
+    "readoutFormat": {
+      "kind": "decimal"
+    }
+  }
+];
+
+/** Rust-owned tooltip metadata for enum/select values. */
+export const ENGINE_ENUM_VALUE_TOOLTIPS_V1: EngineEnumValueTooltipV1[] = [
+  {
+    "key": "lineSelect",
+    "value": "L1",
+    "tooltip": "Play oscillator line 1 only."
+  },
+  {
+    "key": "lineSelect",
+    "value": "L1+L2",
+    "tooltip": "Layer oscillator lines 1 and 2."
+  },
+  {
+    "key": "lineSelect",
+    "value": "L2",
+    "tooltip": "Play oscillator line 2 only."
+  },
+  {
+    "key": "lineSelect",
+    "value": "L1+L1'",
+    "tooltip": "Stack line 1 with a detuned variant."
+  },
+  {
+    "key": "lineSelect",
+    "value": "L1+L2'",
+    "tooltip": "Layer line 1 with a detuned line 2 variant."
+  },
+  {
+    "key": "modMode",
+    "value": "normal",
+    "tooltip": "Standard phase modulation behavior."
+  },
+  {
+    "key": "modMode",
+    "value": "ring",
+    "tooltip": "Enable ring modulation between lines."
+  },
+  {
+    "key": "modMode",
+    "value": "noise",
+    "tooltip": "Mix noise source into modulation path."
+  },
+  {
+    "key": "filterType",
+    "value": "lp",
+    "tooltip": "Low-pass mode: attenuates frequencies above cutoff."
+  },
+  {
+    "key": "filterType",
+    "value": "hp",
+    "tooltip": "High-pass mode: attenuates frequencies below cutoff."
+  },
+  {
+    "key": "filterType",
+    "value": "bp",
+    "tooltip": "Band-pass mode: emphasizes a narrow band around cutoff."
+  },
+  {
+    "key": "portamentoMode",
+    "value": "rate",
+    "tooltip": "Portamento time scales with note interval distance."
+  },
+  {
+    "key": "portamentoMode",
+    "value": "time",
+    "tooltip": "Portamento uses a fixed glide time between notes."
+  }
+];

--- a/packages/cosmo-pd101/src/lib/synth/paramMeta.ts
+++ b/packages/cosmo-pd101/src/lib/synth/paramMeta.ts
@@ -1,147 +1,60 @@
 import type { SynthParamKey } from "@/features/synth/SynthParamController";
+import {
+	ENGINE_ENUM_VALUE_TOOLTIPS_V1,
+	ENGINE_PARAM_UI_META_V1,
+	type EngineParamUiMetaV1,
+} from "@/lib/synth/bindings/synth";
 
 export type ParamMeta = {
 	tooltip: string;
 };
 
-/**
- * Canonical tooltip text for every engine parameter.
- * Components must not hardcode these strings — always read from here.
- */
-export const PARAM_META: Partial<Record<SynthParamKey, ParamMeta>> = {
-	// Volume
-	volume: { tooltip: "Sets the global synth output level." },
-
-	// Per-line tuning & levels (A = line 1, B = line 2)
-	warpAAmount: { tooltip: "Sets base harmonic warp amount for this line." },
-	warpBAmount: { tooltip: "Sets base harmonic warp amount for this line." },
-	line1Level: { tooltip: "Sets base output level for this line." },
-	line2Level: { tooltip: "Sets base output level for this line." },
-	line1Octave: { tooltip: "Transposes this line by octave steps." },
-	line2Octave: { tooltip: "Transposes this line by octave steps." },
-	line1Detune: { tooltip: "Fine tunes this line in cents." },
-	line2Detune: { tooltip: "Fine tunes this line in cents." },
-	algoBlendA: { tooltip: "Crossfades between Algo A and Algo B outputs." },
-	algoBlendB: { tooltip: "Crossfades between Algo A and Algo B outputs." },
-
-	// Phase modulation
-	intPmAmount: { tooltip: "Sets internal phase modulation depth." },
-	intPmRatio: { tooltip: "Sets modulator-to-carrier frequency ratio." },
-	pmPre: { tooltip: "Apply phase modulation before warp shaping." },
-
-	// Vibrato
-	vibratoRate: { tooltip: "Sets vibrato speed." },
-	vibratoDepth: { tooltip: "Sets vibrato pitch modulation depth." },
-	vibratoDelay: { tooltip: "Delays vibrato onset after note start." },
-
-	// LFO 1
-	lfoRate: { tooltip: "Sets LFO 1 speed." },
-	lfoDepth: { tooltip: "Sets LFO 1 modulation depth." },
-	lfoOffset: { tooltip: "Offsets LFO 1 output around zero." },
-	lfoSymmetry: { tooltip: "Adjusts LFO 1 waveform symmetry." },
-	lfoRetrigger: { tooltip: "Restart LFO 1 phase on each new note." },
-
-	// LFO 2
-	lfo2Rate: { tooltip: "Sets LFO 2 speed." },
-	lfo2Depth: { tooltip: "Sets LFO 2 modulation depth." },
-	lfo2Offset: { tooltip: "Offsets LFO 2 output around zero." },
-	lfo2Symmetry: { tooltip: "Adjusts LFO 2 waveform symmetry." },
-	lfo2Retrigger: { tooltip: "Restart LFO 2 phase on each new note." },
-
-	// Mod envelope
-	modEnvAttack: { tooltip: "Sets modulation envelope attack time." },
-	modEnvDecay: { tooltip: "Sets modulation envelope decay time." },
-	modEnvSustain: {
-		tooltip: "Sets sustained modulation level while note is held.",
+export const ENGINE_PARAM_UI_META_BY_KEY: Partial<
+	Record<SynthParamKey, EngineParamUiMetaV1>
+> = ENGINE_PARAM_UI_META_V1.reduce(
+	(acc, meta) => {
+		acc[meta.key as SynthParamKey] = meta;
+		return acc;
 	},
-	modEnvRelease: {
-		tooltip: "Sets modulation envelope release time after note off.",
-	},
+	{} as Partial<Record<SynthParamKey, EngineParamUiMetaV1>>,
+);
 
-	// Random (S&H)
-	randomRate: {
-		tooltip: "Sets sample-and-hold random modulation refresh rate.",
-	},
+/** Canonical tooltip text for engine parameters, owned by the engine metadata export. */
+export const PARAM_META: Partial<Record<SynthParamKey, ParamMeta>> =
+	ENGINE_PARAM_UI_META_V1.reduce(
+		(acc, meta) => {
+			acc[meta.key as SynthParamKey] = { tooltip: meta.tooltip };
+			return acc;
+		},
+		{} as Partial<Record<SynthParamKey, ParamMeta>>,
+	);
 
-	// Filter
-	filterCutoff: { tooltip: "Sets the filter cutoff frequency." },
-	filterResonance: { tooltip: "Boosts frequencies around the cutoff point." },
-	filterEnvAmount: {
-		tooltip: "Applies envelope modulation amount to the cutoff.",
-	},
+function buildEnumTooltipMap(key: string): Partial<Record<string, string>> {
+	return ENGINE_ENUM_VALUE_TOOLTIPS_V1.filter(
+		(entry) => entry.key === key,
+	).reduce(
+		(acc, entry) => {
+			acc[entry.value] = entry.tooltip;
+			return acc;
+		},
+		{} as Partial<Record<string, string>>,
+	);
+}
 
-	// Chorus
-	chorusRate: { tooltip: "Sets chorus modulation speed." },
-	chorusDepth: { tooltip: "Sets intensity of chorus pitch modulation." },
-	chorusMix: { tooltip: "Blends dry signal with chorus effect." },
-
-	// Delay
-	delayTime: { tooltip: "Sets the delay repeat interval." },
-	delayFeedback: { tooltip: "Feeds delayed signal back for additional repeats." },
-	delayWarmth: {
-		tooltip: "Adds tape-style saturation and high-frequency rolloff.",
-	},
-	delayMix: { tooltip: "Blends dry signal with delayed signal." },
-	delayTapeMode: { tooltip: "Toggle tape echo coloration for delay repeats." },
-
-	// Reverb
-	reverbSpace: { tooltip: "Sets the virtual room size for reverb reflections." },
-	reverbPredelay: { tooltip: "Adds delay before the reverb tail starts." },
-	reverbDistance: {
-		tooltip: "Moves source position deeper into the reverb space.",
-	},
-	reverbCharacter: { tooltip: "Shapes reverb tone from dark to bright." },
-	reverbMix: { tooltip: "Blends dry signal with reverb output." },
-
-	// Phaser
-	phaserRate: { tooltip: "Sets phaser sweep speed." },
-	phaserDepth: { tooltip: "Sets depth of the phaser notch sweep." },
-	phaserFeedback: {
-		tooltip: "Feeds phased signal back for stronger notches.",
-	},
-	phaserMix: { tooltip: "Blends dry signal with phaser output." },
-
-	// Portamento
-	portamentoRate: { tooltip: "Sets glide speed when portamento mode is Rate." },
-	portamentoTime: {
-		tooltip: "Sets glide duration when portamento mode is Time.",
-	},
-
-	// Global voice
-	pitchBendRange: { tooltip: "Sets maximum pitch bend range in semitones." },
-	velocityCurve: {
-		tooltip: "Shapes how keyboard velocity maps to output level.",
-	},
-	modWheelVibratoDepth: {
-		tooltip: "Sets how much mod wheel movement affects vibrato depth.",
-	},
-};
+export function getEngineParamUiMeta(
+	key: string,
+): EngineParamUiMetaV1 | undefined {
+	return ENGINE_PARAM_UI_META_BY_KEY[key as SynthParamKey];
+}
 
 /** Canonical tooltips for `lineSelect` enum values. */
-export const LINE_SELECT_TOOLTIPS: Partial<Record<string, string>> = {
-	L1: "Play oscillator line 1 only.",
-	"L1+L2": "Layer oscillator lines 1 and 2.",
-	L2: "Play oscillator line 2 only.",
-	"L1+L1'": "Stack line 1 with a detuned variant.",
-	"L1+L2'": "Layer line 1 with a detuned line 2 variant.",
-};
+export const LINE_SELECT_TOOLTIPS = buildEnumTooltipMap("lineSelect");
 
 /** Canonical tooltips for `modMode` enum values. */
-export const MOD_MODE_TOOLTIPS: Partial<Record<string, string>> = {
-	normal: "Standard phase modulation behavior.",
-	ring: "Enable ring modulation between lines.",
-	noise: "Mix noise source into modulation path.",
-};
+export const MOD_MODE_TOOLTIPS = buildEnumTooltipMap("modMode");
 
 /** Canonical tooltips for `filterType` enum values. */
-export const FILTER_TYPE_TOOLTIPS: Partial<Record<string, string>> = {
-	lp: "Low-pass mode: attenuates frequencies above cutoff.",
-	hp: "High-pass mode: attenuates frequencies below cutoff.",
-	bp: "Band-pass mode: emphasizes a narrow band around cutoff.",
-};
+export const FILTER_TYPE_TOOLTIPS = buildEnumTooltipMap("filterType");
 
 /** Canonical tooltips for `portamentoMode` enum values. */
-export const PORTAMENTO_MODE_TOOLTIPS: Partial<Record<string, string>> = {
-	rate: "Portamento time scales with note interval distance.",
-	time: "Portamento uses a fixed glide time between notes.",
-};
+export const PORTAMENTO_MODE_TOOLTIPS = buildEnumTooltipMap("portamentoMode");

--- a/packages/cosmo-pd101/src/lib/synth/paramMeta.ts
+++ b/packages/cosmo-pd101/src/lib/synth/paramMeta.ts
@@ -1,0 +1,147 @@
+import type { SynthParamKey } from "@/features/synth/SynthParamController";
+
+export type ParamMeta = {
+	tooltip: string;
+};
+
+/**
+ * Canonical tooltip text for every engine parameter.
+ * Components must not hardcode these strings — always read from here.
+ */
+export const PARAM_META: Partial<Record<SynthParamKey, ParamMeta>> = {
+	// Volume
+	volume: { tooltip: "Sets the global synth output level." },
+
+	// Per-line tuning & levels (A = line 1, B = line 2)
+	warpAAmount: { tooltip: "Sets base harmonic warp amount for this line." },
+	warpBAmount: { tooltip: "Sets base harmonic warp amount for this line." },
+	line1Level: { tooltip: "Sets base output level for this line." },
+	line2Level: { tooltip: "Sets base output level for this line." },
+	line1Octave: { tooltip: "Transposes this line by octave steps." },
+	line2Octave: { tooltip: "Transposes this line by octave steps." },
+	line1Detune: { tooltip: "Fine tunes this line in cents." },
+	line2Detune: { tooltip: "Fine tunes this line in cents." },
+	algoBlendA: { tooltip: "Crossfades between Algo A and Algo B outputs." },
+	algoBlendB: { tooltip: "Crossfades between Algo A and Algo B outputs." },
+
+	// Phase modulation
+	intPmAmount: { tooltip: "Sets internal phase modulation depth." },
+	intPmRatio: { tooltip: "Sets modulator-to-carrier frequency ratio." },
+	pmPre: { tooltip: "Apply phase modulation before warp shaping." },
+
+	// Vibrato
+	vibratoRate: { tooltip: "Sets vibrato speed." },
+	vibratoDepth: { tooltip: "Sets vibrato pitch modulation depth." },
+	vibratoDelay: { tooltip: "Delays vibrato onset after note start." },
+
+	// LFO 1
+	lfoRate: { tooltip: "Sets LFO 1 speed." },
+	lfoDepth: { tooltip: "Sets LFO 1 modulation depth." },
+	lfoOffset: { tooltip: "Offsets LFO 1 output around zero." },
+	lfoSymmetry: { tooltip: "Adjusts LFO 1 waveform symmetry." },
+	lfoRetrigger: { tooltip: "Restart LFO 1 phase on each new note." },
+
+	// LFO 2
+	lfo2Rate: { tooltip: "Sets LFO 2 speed." },
+	lfo2Depth: { tooltip: "Sets LFO 2 modulation depth." },
+	lfo2Offset: { tooltip: "Offsets LFO 2 output around zero." },
+	lfo2Symmetry: { tooltip: "Adjusts LFO 2 waveform symmetry." },
+	lfo2Retrigger: { tooltip: "Restart LFO 2 phase on each new note." },
+
+	// Mod envelope
+	modEnvAttack: { tooltip: "Sets modulation envelope attack time." },
+	modEnvDecay: { tooltip: "Sets modulation envelope decay time." },
+	modEnvSustain: {
+		tooltip: "Sets sustained modulation level while note is held.",
+	},
+	modEnvRelease: {
+		tooltip: "Sets modulation envelope release time after note off.",
+	},
+
+	// Random (S&H)
+	randomRate: {
+		tooltip: "Sets sample-and-hold random modulation refresh rate.",
+	},
+
+	// Filter
+	filterCutoff: { tooltip: "Sets the filter cutoff frequency." },
+	filterResonance: { tooltip: "Boosts frequencies around the cutoff point." },
+	filterEnvAmount: {
+		tooltip: "Applies envelope modulation amount to the cutoff.",
+	},
+
+	// Chorus
+	chorusRate: { tooltip: "Sets chorus modulation speed." },
+	chorusDepth: { tooltip: "Sets intensity of chorus pitch modulation." },
+	chorusMix: { tooltip: "Blends dry signal with chorus effect." },
+
+	// Delay
+	delayTime: { tooltip: "Sets the delay repeat interval." },
+	delayFeedback: { tooltip: "Feeds delayed signal back for additional repeats." },
+	delayWarmth: {
+		tooltip: "Adds tape-style saturation and high-frequency rolloff.",
+	},
+	delayMix: { tooltip: "Blends dry signal with delayed signal." },
+	delayTapeMode: { tooltip: "Toggle tape echo coloration for delay repeats." },
+
+	// Reverb
+	reverbSpace: { tooltip: "Sets the virtual room size for reverb reflections." },
+	reverbPredelay: { tooltip: "Adds delay before the reverb tail starts." },
+	reverbDistance: {
+		tooltip: "Moves source position deeper into the reverb space.",
+	},
+	reverbCharacter: { tooltip: "Shapes reverb tone from dark to bright." },
+	reverbMix: { tooltip: "Blends dry signal with reverb output." },
+
+	// Phaser
+	phaserRate: { tooltip: "Sets phaser sweep speed." },
+	phaserDepth: { tooltip: "Sets depth of the phaser notch sweep." },
+	phaserFeedback: {
+		tooltip: "Feeds phased signal back for stronger notches.",
+	},
+	phaserMix: { tooltip: "Blends dry signal with phaser output." },
+
+	// Portamento
+	portamentoRate: { tooltip: "Sets glide speed when portamento mode is Rate." },
+	portamentoTime: {
+		tooltip: "Sets glide duration when portamento mode is Time.",
+	},
+
+	// Global voice
+	pitchBendRange: { tooltip: "Sets maximum pitch bend range in semitones." },
+	velocityCurve: {
+		tooltip: "Shapes how keyboard velocity maps to output level.",
+	},
+	modWheelVibratoDepth: {
+		tooltip: "Sets how much mod wheel movement affects vibrato depth.",
+	},
+};
+
+/** Canonical tooltips for `lineSelect` enum values. */
+export const LINE_SELECT_TOOLTIPS: Partial<Record<string, string>> = {
+	L1: "Play oscillator line 1 only.",
+	"L1+L2": "Layer oscillator lines 1 and 2.",
+	L2: "Play oscillator line 2 only.",
+	"L1+L1'": "Stack line 1 with a detuned variant.",
+	"L1+L2'": "Layer line 1 with a detuned line 2 variant.",
+};
+
+/** Canonical tooltips for `modMode` enum values. */
+export const MOD_MODE_TOOLTIPS: Partial<Record<string, string>> = {
+	normal: "Standard phase modulation behavior.",
+	ring: "Enable ring modulation between lines.",
+	noise: "Mix noise source into modulation path.",
+};
+
+/** Canonical tooltips for `filterType` enum values. */
+export const FILTER_TYPE_TOOLTIPS: Partial<Record<string, string>> = {
+	lp: "Low-pass mode: attenuates frequencies above cutoff.",
+	hp: "High-pass mode: attenuates frequencies below cutoff.",
+	bp: "Band-pass mode: emphasizes a narrow band around cutoff.",
+};
+
+/** Canonical tooltips for `portamentoMode` enum values. */
+export const PORTAMENTO_MODE_TOOLTIPS: Partial<Record<string, string>> = {
+	rate: "Portamento time scales with note interval distance.",
+	time: "Portamento uses a fixed glide time between notes.",
+};

--- a/packages/cosmo-pd101/src/lib/synth/pdAlgorithms.ts
+++ b/packages/cosmo-pd101/src/lib/synth/pdAlgorithms.ts
@@ -73,6 +73,46 @@ export const PD_ALGOS: PdAlgoDef[] = [
 	}),
 ];
 
+const ALGO_BEHAVIOR_DESCRIPTIONS: Record<PdAlgo, string> = {
+	cz101:
+		"Classic CZ phase-distortion core. Use DCW and the CZ preset controls to shape the harmonic contour.",
+	bend: "Bends phase toward one side, adding asymmetry and a brighter edge as depth increases.",
+	sync: "Applies hard-sync style phase resets for harmonic-rich, edgy tones.",
+	pinch:
+		"Compresses phase around the center, emphasizing mid-cycle detail and nasal character.",
+	fold: "Folds the phase path back on itself for wavefold-style harmonics and sharper timbre.",
+	skew: "Tilts phase timing earlier vs later to shift harmonic balance and attack character.",
+	quantize:
+		"Steps the phase into discrete levels for a digitized, stair-stepped texture.",
+	twist:
+		"Applies sinusoidal phase twisting for animated, swirling harmonic motion.",
+	clip: "Limits phase excursion, flattening peaks for a harder, clipped tone.",
+	ripple:
+		"Adds high-frequency ripple to the phase trajectory for fine, buzzy harmonic detail.",
+	mirror:
+		"Blends toward an inverted phase path to create mirrored, symmetrical timbres.",
+	fof: "Formant-like shaping with windowed resonant emphasis suited to vocal-style colors.",
+	karpunk:
+		"Plucked/resonant distortion character with decaying inharmonic overtones.",
+	sine: "Pure sine phase path with minimal harmonics and smooth tone.",
+	// Legacy waveform aliases supported by Algo type
+	saw: "Saw transfer shape with a bright, harmonically rich spectrum.",
+	square: "Square transfer shape emphasizing odd harmonics for hollow tone.",
+	pulse: "Pulse transfer shape with a narrow-duty harmonic profile.",
+	null: "Sparse transfer shape with thin, subdued harmonic content.",
+	sinePulse: "Hybrid sine/pulse transfer for mixed smooth and buzzy harmonics.",
+	sawPulse: "Hybrid saw/pulse transfer balancing edge and body.",
+	multiSine: "Multi-sine resonant transfer emphasizing vocal-like peaks.",
+	pulse2: "Dual-pulse style transfer with hollow, comb-like harmonic spacing.",
+};
+
+export function getPdAlgoBehaviorDescription(algo: PdAlgo): string {
+	return (
+		ALGO_BEHAVIOR_DESCRIPTIONS[algo] ??
+		"Phase-distortion algorithm with a distinct harmonic shaping profile."
+	);
+}
+
 export function getPdAlgoDef(algo: PdAlgo): PdAlgoDef | undefined {
 	return PD_ALGOS.find((entry) => isAlgoRefEqual(entry.value, algo));
 }

--- a/packages/cosmo-synth-engine/export_specta_bindings.rs
+++ b/packages/cosmo-synth-engine/export_specta_bindings.rs
@@ -16,13 +16,13 @@ use cosmo_synth_engine::generators::{
 };
 use cosmo_synth_engine::module_presets::{module_preset_catalog_v1, ModulePresetGroupV1};
 use cosmo_synth_engine::params::{
-    Algo, AlgoControlValueV1, BitcrusherParams, ChorusParams, CompressorParams, CzAlgo,
-    CzLineParams, CzWaveform, DelayParams, DistortionParams, EnvStep, EqParams, FilterParams,
-    FilterType, FxSlotConfig, FxSlotType, GrainDelayParams, JunoChorusParams, LfoParams,
-    LfoWaveform, LineParams, LineSelect, ModDestination, ModEnvParams, ModMatrix, ModMode,
-    ModRoute, ModSource, PhaserParams, PolyMode, PortamentoMode, PortamentoParams, RandomParams,
-    ReverbParams, RingModParams, ShimmerVerbParams, StepEnvData, SynthParams, TremoloParams,
-    VibratoParams, WavefolderParams, WindowType,
+    engine_enum_value_tooltips_v1, engine_param_ui_meta_v1, Algo, AlgoControlValueV1,
+    BitcrusherParams, ChorusParams, CompressorParams, CzAlgo, CzLineParams, CzWaveform, DelayParams,
+    DistortionParams, EnvStep, EqParams, FilterParams, FilterType, FxSlotConfig, FxSlotType,
+    GrainDelayParams, JunoChorusParams, LfoParams, LfoWaveform, LineParams, LineSelect,
+    ModDestination, ModEnvParams, ModMatrix, ModMode, ModRoute, ModSource, PhaserParams, PolyMode,
+    PortamentoMode, PortamentoParams, RandomParams, ReverbParams, RingModParams, ShimmerVerbParams,
+    StepEnvData, SynthParams, TremoloParams, VibratoParams, WavefolderParams, WindowType,
 };
 use cosmo_synth_engine::preset_wire::{
     algo_definitions_v1, algo_ui_catalog_v1, cz_presets, SynthPresetV1,
@@ -212,6 +212,41 @@ fn main() {
     out.push_str("/** Rust-owned module preset labels and ordering. */\n");
     out.push_str("export const MODULE_PRESET_CATALOG_V1: ModulePresetGroupV1[] = ");
     out.push_str(&module_preset_catalog_json);
+    out.push_str(";\n");
+    out.push_str("\n");
+
+    let engine_param_ui_meta_json = serde_json::to_string_pretty(engine_param_ui_meta_v1())
+        .expect("Failed to serialize ENGINE_PARAM_UI_META_V1");
+    let engine_enum_value_tooltips_json =
+        serde_json::to_string_pretty(engine_enum_value_tooltips_v1())
+            .expect("Failed to serialize ENGINE_ENUM_VALUE_TOOLTIPS_V1");
+
+    out.push_str("export type EngineEnumValueLabelV1 = { value: string; label: string };\n");
+    out.push_str("export type EngineParamReadoutFormatV1 =\n");
+    out.push_str("  | { kind: \"onOff\" }\n");
+    out.push_str("  | { kind: \"raw\" }\n");
+    out.push_str("  | { kind: \"uppercase\" }\n");
+    out.push_str("  | { kind: \"integer\" }\n");
+    out.push_str("  | { kind: \"decimal\" }\n");
+    out.push_str("  | { kind: \"percent\" }\n");
+    out.push_str("  | { kind: \"semitones\" }\n");
+    out.push_str("  | { kind: \"milliseconds\" }\n");
+    out.push_str("  | { kind: \"seconds2\" }\n");
+    out.push_str("  | { kind: \"hertz\" }\n");
+    out.push_str("  | { kind: \"enumMap\"; values: EngineEnumValueLabelV1[] };\n");
+    out.push_str(
+        "export type EngineParamUiMetaV1 = { key: string; tooltip: string; readoutLabel: string; readoutFormat: EngineParamReadoutFormatV1 };\n"
+    );
+    out.push_str(
+        "export type EngineEnumValueTooltipV1 = { key: string; value: string; tooltip: string };\n\n"
+    );
+    out.push_str("/** Rust-owned engine parameter tooltip and readout metadata. */\n");
+    out.push_str("export const ENGINE_PARAM_UI_META_V1: EngineParamUiMetaV1[] = ");
+    out.push_str(&engine_param_ui_meta_json);
+    out.push_str(";\n\n");
+    out.push_str("/** Rust-owned tooltip metadata for enum/select values. */\n");
+    out.push_str("export const ENGINE_ENUM_VALUE_TOOLTIPS_V1: EngineEnumValueTooltipV1[] = ");
+    out.push_str(&engine_enum_value_tooltips_json);
     out.push_str(";\n");
 
     std::fs::write(&ts_path, out)

--- a/packages/cosmo-synth-engine/export_specta_bindings.rs
+++ b/packages/cosmo-synth-engine/export_specta_bindings.rs
@@ -17,9 +17,9 @@ use cosmo_synth_engine::generators::{
 use cosmo_synth_engine::module_presets::{module_preset_catalog_v1, ModulePresetGroupV1};
 use cosmo_synth_engine::params::{
     engine_enum_value_tooltips_v1, engine_param_ui_meta_v1, Algo, AlgoControlValueV1,
-    BitcrusherParams, ChorusParams, CompressorParams, CzAlgo, CzLineParams, CzWaveform, DelayParams,
-    DistortionParams, EnvStep, EqParams, FilterParams, FilterType, FxSlotConfig, FxSlotType,
-    GrainDelayParams, JunoChorusParams, LfoParams, LfoWaveform, LineParams, LineSelect,
+    BitcrusherParams, ChorusParams, CompressorParams, CzAlgo, CzLineParams, CzWaveform,
+    DelayParams, DistortionParams, EnvStep, EqParams, FilterParams, FilterType, FxSlotConfig,
+    FxSlotType, GrainDelayParams, JunoChorusParams, LfoParams, LfoWaveform, LineParams, LineSelect,
     ModDestination, ModEnvParams, ModMatrix, ModMode, ModRoute, ModSource, PhaserParams, PolyMode,
     PortamentoMode, PortamentoParams, RandomParams, ReverbParams, RingModParams, ShimmerVerbParams,
     StepEnvData, SynthParams, TremoloParams, VibratoParams, WavefolderParams, WindowType,

--- a/packages/cosmo-synth-engine/src/params.rs
+++ b/packages/cosmo-synth-engine/src/params.rs
@@ -1372,6 +1372,474 @@ impl Default for SynthParams {
     }
 }
 
+/// Readout label for one string enum value.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineEnumValueLabelV1 {
+    pub value: &'static str,
+    pub label: &'static str,
+}
+
+/// Engine-owned formatting strategy for infobar readouts.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum EngineParamReadoutFormatV1 {
+    OnOff,
+    Raw,
+    Uppercase,
+    Integer,
+    Decimal,
+    Percent,
+    Semitones,
+    Milliseconds,
+    Seconds2,
+    Hertz,
+    EnumMap {
+        values: &'static [EngineEnumValueLabelV1],
+    },
+}
+
+/// Engine-owned UI metadata for one parameter key.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineParamUiMetaV1 {
+    pub key: &'static str,
+    pub tooltip: &'static str,
+    pub readout_label: &'static str,
+    pub readout_format: EngineParamReadoutFormatV1,
+}
+
+/// Tooltip metadata for enum-like button choices.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineEnumValueTooltipV1 {
+    pub key: &'static str,
+    pub value: &'static str,
+    pub tooltip: &'static str,
+}
+
+const POLY_MODE_LABELS_V1: [EngineEnumValueLabelV1; 2] = [
+    EngineEnumValueLabelV1 {
+        value: "poly8",
+        label: "POLY 8",
+    },
+    EngineEnumValueLabelV1 {
+        value: "mono",
+        label: "MONO",
+    },
+];
+
+const ENGINE_PARAM_UI_META_V1: [EngineParamUiMetaV1; 55] = [
+    EngineParamUiMetaV1 {
+        key: "volume",
+        tooltip: "Sets the global synth output level.",
+        readout_label: "Volume",
+        readout_format: EngineParamReadoutFormatV1::Percent,
+    },
+    EngineParamUiMetaV1 {
+        key: "warpAAmount",
+        tooltip: "Sets base harmonic warp amount for this line.",
+        readout_label: "Line 1 DCW",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "warpBAmount",
+        tooltip: "Sets base harmonic warp amount for this line.",
+        readout_label: "Line 2 DCW",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "algoBlendA",
+        tooltip: "Crossfades between Algo A and Algo B outputs.",
+        readout_label: "Line 1 Blend",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "algoBlendB",
+        tooltip: "Crossfades between Algo A and Algo B outputs.",
+        readout_label: "Line 2 Blend",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "line1Level",
+        tooltip: "Sets base output level for this line.",
+        readout_label: "Line 1 Level",
+        readout_format: EngineParamReadoutFormatV1::Percent,
+    },
+    EngineParamUiMetaV1 {
+        key: "line2Level",
+        tooltip: "Sets base output level for this line.",
+        readout_label: "Line 2 Level",
+        readout_format: EngineParamReadoutFormatV1::Percent,
+    },
+    EngineParamUiMetaV1 {
+        key: "line1Octave",
+        tooltip: "Transposes this line by octave steps.",
+        readout_label: "Line 1 Octave",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "line2Octave",
+        tooltip: "Transposes this line by octave steps.",
+        readout_label: "Line 2 Octave",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "line1Detune",
+        tooltip: "Fine tunes this line in cents.",
+        readout_label: "Line 1 Detune",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "line2Detune",
+        tooltip: "Fine tunes this line in cents.",
+        readout_label: "Line 2 Detune",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "lineSelect",
+        tooltip: "Selects which oscillator lines are heard together.",
+        readout_label: "Line Select",
+        readout_format: EngineParamReadoutFormatV1::Raw,
+    },
+    EngineParamUiMetaV1 {
+        key: "modMode",
+        tooltip: "Chooses the interaction mode between oscillator lines.",
+        readout_label: "Modulation",
+        readout_format: EngineParamReadoutFormatV1::Uppercase,
+    },
+    EngineParamUiMetaV1 {
+        key: "polyMode",
+        tooltip: "Switches between polyphonic and monophonic note allocation.",
+        readout_label: "Voice Mode",
+        readout_format: EngineParamReadoutFormatV1::EnumMap {
+            values: &POLY_MODE_LABELS_V1,
+        },
+    },
+    EngineParamUiMetaV1 {
+        key: "intPmAmount",
+        tooltip: "Sets internal phase modulation depth.",
+        readout_label: "PM Amount",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "intPmRatio",
+        tooltip: "Sets modulator-to-carrier frequency ratio.",
+        readout_label: "PM Ratio",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "pmPre",
+        tooltip: "Apply phase modulation before warp shaping.",
+        readout_label: "PM Mode",
+        readout_format: EngineParamReadoutFormatV1::OnOff,
+    },
+    EngineParamUiMetaV1 {
+        key: "vibratoRate",
+        tooltip: "Sets vibrato speed.",
+        readout_label: "Vibrato Rate",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "vibratoDepth",
+        tooltip: "Sets vibrato pitch modulation depth.",
+        readout_label: "Vibrato Depth",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "vibratoDelay",
+        tooltip: "Delays vibrato onset after note start.",
+        readout_label: "Vibrato Delay",
+        readout_format: EngineParamReadoutFormatV1::Milliseconds,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfoWaveform",
+        tooltip: "Selects LFO 1 waveform shape.",
+        readout_label: "LFO Wave",
+        readout_format: EngineParamReadoutFormatV1::Uppercase,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfoRate",
+        tooltip: "Sets LFO 1 speed.",
+        readout_label: "LFO Rate",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfoDepth",
+        tooltip: "Sets LFO 1 modulation depth.",
+        readout_label: "LFO Depth",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfoOffset",
+        tooltip: "Offsets LFO 1 output around zero.",
+        readout_label: "LFO Offset",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfo2Rate",
+        tooltip: "Sets LFO 2 speed.",
+        readout_label: "LFO 2 Rate",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfo2Depth",
+        tooltip: "Sets LFO 2 modulation depth.",
+        readout_label: "LFO 2 Depth",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "lfo2Offset",
+        tooltip: "Offsets LFO 2 output around zero.",
+        readout_label: "LFO 2 Offset",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "randomRate",
+        tooltip: "Sets sample-and-hold random modulation refresh rate.",
+        readout_label: "Random Rate",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "modEnvAttack",
+        tooltip: "Sets modulation envelope attack time.",
+        readout_label: "Mod Env Attack",
+        readout_format: EngineParamReadoutFormatV1::Seconds2,
+    },
+    EngineParamUiMetaV1 {
+        key: "modEnvDecay",
+        tooltip: "Sets modulation envelope decay time.",
+        readout_label: "Mod Env Decay",
+        readout_format: EngineParamReadoutFormatV1::Seconds2,
+    },
+    EngineParamUiMetaV1 {
+        key: "modEnvSustain",
+        tooltip: "Sets sustained modulation level while note is held.",
+        readout_label: "Mod Env Sustain",
+        readout_format: EngineParamReadoutFormatV1::Percent,
+    },
+    EngineParamUiMetaV1 {
+        key: "modEnvRelease",
+        tooltip: "Sets modulation envelope release time after note off.",
+        readout_label: "Mod Env Release",
+        readout_format: EngineParamReadoutFormatV1::Seconds2,
+    },
+    EngineParamUiMetaV1 {
+        key: "filterType",
+        tooltip: "Selects the filter response shape.",
+        readout_label: "Filter Type",
+        readout_format: EngineParamReadoutFormatV1::Uppercase,
+    },
+    EngineParamUiMetaV1 {
+        key: "filterCutoff",
+        tooltip: "Sets the filter cutoff frequency.",
+        readout_label: "Filter Cutoff",
+        readout_format: EngineParamReadoutFormatV1::Hertz,
+    },
+    EngineParamUiMetaV1 {
+        key: "filterResonance",
+        tooltip: "Boosts frequencies around the cutoff point.",
+        readout_label: "Filter Resonance",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "filterEnvAmount",
+        tooltip: "Applies envelope modulation amount to the cutoff.",
+        readout_label: "Filter Env",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "chorusRate",
+        tooltip: "Sets chorus modulation speed.",
+        readout_label: "Chorus Rate",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "chorusDepth",
+        tooltip: "Sets intensity of chorus pitch modulation.",
+        readout_label: "Chorus Depth",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "chorusMix",
+        tooltip: "Blends dry signal with chorus effect.",
+        readout_label: "Chorus Mix",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "delayTime",
+        tooltip: "Sets the delay repeat interval.",
+        readout_label: "Delay Time",
+        readout_format: EngineParamReadoutFormatV1::Seconds2,
+    },
+    EngineParamUiMetaV1 {
+        key: "delayFeedback",
+        tooltip: "Feeds delayed signal back for additional repeats.",
+        readout_label: "Delay Feedback",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "delayWarmth",
+        tooltip: "Adds tape-style saturation and high-frequency rolloff.",
+        readout_label: "Delay Warmth",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "delayMix",
+        tooltip: "Blends dry signal with delayed signal.",
+        readout_label: "Delay Mix",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "delayTapeMode",
+        tooltip: "Toggle tape echo coloration for delay repeats.",
+        readout_label: "Tape Mode",
+        readout_format: EngineParamReadoutFormatV1::OnOff,
+    },
+    EngineParamUiMetaV1 {
+        key: "reverbSpace",
+        tooltip: "Sets the virtual room size for reverb reflections.",
+        readout_label: "Reverb Space",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "reverbPredelay",
+        tooltip: "Adds delay before the reverb tail starts.",
+        readout_label: "Reverb Pre-Delay",
+        readout_format: EngineParamReadoutFormatV1::Milliseconds,
+    },
+    EngineParamUiMetaV1 {
+        key: "reverbDistance",
+        tooltip: "Moves source position deeper into the reverb space.",
+        readout_label: "Reverb Distance",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "reverbCharacter",
+        tooltip: "Shapes reverb tone from dark to bright.",
+        readout_label: "Reverb Character",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "reverbMix",
+        tooltip: "Blends dry signal with reverb output.",
+        readout_label: "Reverb Mix",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "portamentoMode",
+        tooltip: "Chooses whether glide uses rate or fixed time behavior.",
+        readout_label: "Portamento Mode",
+        readout_format: EngineParamReadoutFormatV1::Uppercase,
+    },
+    EngineParamUiMetaV1 {
+        key: "portamentoRate",
+        tooltip: "Sets glide speed when portamento mode is Rate.",
+        readout_label: "Portamento Rate",
+        readout_format: EngineParamReadoutFormatV1::Integer,
+    },
+    EngineParamUiMetaV1 {
+        key: "portamentoTime",
+        tooltip: "Sets glide duration when portamento mode is Time.",
+        readout_label: "Portamento Time",
+        readout_format: EngineParamReadoutFormatV1::Seconds2,
+    },
+    EngineParamUiMetaV1 {
+        key: "pitchBendRange",
+        tooltip: "Sets maximum pitch bend range in semitones.",
+        readout_label: "Bend Range",
+        readout_format: EngineParamReadoutFormatV1::Semitones,
+    },
+    EngineParamUiMetaV1 {
+        key: "velocityCurve",
+        tooltip: "Shapes how keyboard velocity maps to output level.",
+        readout_label: "Vel Curve",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+    EngineParamUiMetaV1 {
+        key: "modWheelVibratoDepth",
+        tooltip: "Sets how much mod wheel movement affects vibrato depth.",
+        readout_label: "Mod to Vibrato",
+        readout_format: EngineParamReadoutFormatV1::Decimal,
+    },
+];
+
+const ENGINE_ENUM_VALUE_TOOLTIPS_V1: [EngineEnumValueTooltipV1; 13] = [
+    EngineEnumValueTooltipV1 {
+        key: "lineSelect",
+        value: "L1",
+        tooltip: "Play oscillator line 1 only.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "lineSelect",
+        value: "L1+L2",
+        tooltip: "Layer oscillator lines 1 and 2.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "lineSelect",
+        value: "L2",
+        tooltip: "Play oscillator line 2 only.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "lineSelect",
+        value: "L1+L1'",
+        tooltip: "Stack line 1 with a detuned variant.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "lineSelect",
+        value: "L1+L2'",
+        tooltip: "Layer line 1 with a detuned line 2 variant.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "modMode",
+        value: "normal",
+        tooltip: "Standard phase modulation behavior.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "modMode",
+        value: "ring",
+        tooltip: "Enable ring modulation between lines.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "modMode",
+        value: "noise",
+        tooltip: "Mix noise source into modulation path.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "filterType",
+        value: "lp",
+        tooltip: "Low-pass mode: attenuates frequencies above cutoff.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "filterType",
+        value: "hp",
+        tooltip: "High-pass mode: attenuates frequencies below cutoff.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "filterType",
+        value: "bp",
+        tooltip: "Band-pass mode: emphasizes a narrow band around cutoff.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "portamentoMode",
+        value: "rate",
+        tooltip: "Portamento time scales with note interval distance.",
+    },
+    EngineEnumValueTooltipV1 {
+        key: "portamentoMode",
+        value: "time",
+        tooltip: "Portamento uses a fixed glide time between notes.",
+    },
+];
+
+pub fn engine_param_ui_meta_v1() -> &'static [EngineParamUiMetaV1] {
+    &ENGINE_PARAM_UI_META_V1
+}
+
+pub fn engine_enum_value_tooltips_v1() -> &'static [EngineEnumValueTooltipV1] {
+    &ENGINE_ENUM_VALUE_TOOLTIPS_V1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/cosmo-synth-engine/src/params.rs
+++ b/packages/cosmo-synth-engine/src/params.rs
@@ -1976,4 +1976,88 @@ mod tests {
             .iter()
             .all(|s| matches!(s, FxSlotConfig::Empty)));
     }
+
+    #[test]
+    fn engine_param_ui_meta_v1_keys_are_unique_and_non_empty() {
+        let meta = engine_param_ui_meta_v1();
+        let mut seen_keys = std::collections::HashSet::new();
+        for entry in meta {
+            assert!(!entry.key.is_empty(), "param key must not be empty");
+            assert!(
+                seen_keys.insert(entry.key),
+                "duplicate param key: {}",
+                entry.key
+            );
+        }
+    }
+
+    #[test]
+    fn engine_param_ui_meta_v1_labels_and_tooltips_non_empty() {
+        for entry in engine_param_ui_meta_v1() {
+            assert!(
+                !entry.tooltip.is_empty(),
+                "tooltip must not be empty for key: {}",
+                entry.key
+            );
+            assert!(
+                !entry.readout_label.is_empty(),
+                "readout_label must not be empty for key: {}",
+                entry.key
+            );
+        }
+    }
+
+    #[test]
+    fn engine_param_ui_meta_v1_enum_map_values_are_unique() {
+        for entry in engine_param_ui_meta_v1() {
+            if let EngineParamReadoutFormatV1::EnumMap { values } = &entry.readout_format {
+                let mut seen = std::collections::HashSet::new();
+                for ev in *values {
+                    assert!(
+                        !ev.value.is_empty(),
+                        "enum value must not be empty for key: {}",
+                        entry.key
+                    );
+                    assert!(
+                        !ev.label.is_empty(),
+                        "enum label must not be empty for key: {}, value: {}",
+                        entry.key,
+                        ev.value
+                    );
+                    assert!(
+                        seen.insert(ev.value),
+                        "duplicate enum value '{}' for key: {}",
+                        ev.value,
+                        entry.key
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn engine_enum_value_tooltips_v1_are_unique_and_non_empty() {
+        let tooltips = engine_enum_value_tooltips_v1();
+        let mut seen = std::collections::HashSet::new();
+        for entry in tooltips {
+            assert!(!entry.key.is_empty(), "enum tooltip key must not be empty");
+            assert!(
+                !entry.value.is_empty(),
+                "enum tooltip value must not be empty for key: {}",
+                entry.key
+            );
+            assert!(
+                !entry.tooltip.is_empty(),
+                "tooltip must not be empty for key: {}, value: {}",
+                entry.key,
+                entry.value
+            );
+            assert!(
+                seen.insert((entry.key, entry.value)),
+                "duplicate (key, value) pair: ({}, {})",
+                entry.key,
+                entry.value
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extract the Synth info bar into a dedicated `SynthInfoBar` component
- extend the hover info provider into a unified info controller that composes hover tooltip text with transient control readouts
- add shared hover handler utilities to reduce duplicated tooltip event wiring
- add tooltip support to `CzTabButton` and apply toolbar tooltip copy for line select/modulation/tab controls
- emit live value readouts from knobs, sliders, algo dropdowns, and algo toggles so changes show in the info bar while interacting
- add fallback tooltip behavior for knobs based on control label to improve coverage

## Commits
- `feat(cosmo-pd101): extract synth infobar and unify info text composition`
- `feat(cosmo-pd101): unify tooltip handlers and push live control readouts`

## Validation
- `bunx biome check` passed for all modified files
- Full `bun run lint` is currently blocked by existing workspace issues unrelated to this change:
  - missing Rust vendor path for `beamer` in workspace cargo formatting/check step
  - existing unused import warning in `packages/cosmo-pd101/src/features/synth/hooks/useNoteHandling.test.ts`
- Focused vitest execution was blocked in this environment due missing package deps required by `vitest.config.ts` (e.g. `@tailwindcss/vite`)