### PR TITLE
fix(cosmo-pd101-plugin): prevent stale hydration on webview reopen

### DIFF
--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx
@@ -1,0 +1,83 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PluginPage from "./PluginPage";
+
+const mockUseSynthPresetManager = vi.hoisted(() => vi.fn());
+const mockUsePluginParamBridge = vi.hoisted(() => vi.fn());
+
+vi.mock("./hooks/usePluginParamBridge", () => ({
+	usePluginParamBridge: mockUsePluginParamBridge,
+}));
+
+vi.mock("@cosmo/cosmo-pd101", () => {
+	const synthStoreState = {
+		gatherState: () => ({ params: { volume: 1 } }),
+		applyPreset: vi.fn(),
+		velocityCurve: "linear",
+	};
+	const synthUiStoreState = {
+		activeAsidePanel: null,
+		setActiveAsidePanel: vi.fn(),
+	};
+
+	return {
+		DEFAULT_SYNTH_PRESETS: {},
+		getSynthRuntimeCapabilities: () => ({
+			uiScaleOptions: [70],
+			showUiScaleControl: true,
+		}),
+		SynthRenderer: () => <div data-testid="synth-renderer" />,
+		useLcdControlReadout: () => ({
+			lcdControlReadout: "",
+			pushLcdControlReadout: vi.fn(),
+		}),
+		useNoteHandling: () => ({
+			activeNotes: [],
+			sendNoteOn: vi.fn(),
+			sendNoteOff: vi.fn(),
+		}),
+		useSynthPresetManager: mockUseSynthPresetManager,
+		useSynthStore: (selector: (state: typeof synthStoreState) => unknown) =>
+			selector(synthStoreState),
+		useSynthUiStore: (selector: (state: typeof synthUiStoreState) => unknown) =>
+			selector(synthUiStoreState),
+	};
+});
+
+describe("PluginPage", () => {
+	beforeEach(() => {
+		mockUsePluginParamBridge.mockReset();
+		mockUseSynthPresetManager.mockReset();
+		mockUseSynthPresetManager.mockReturnValue({
+			allPresetEntries: [],
+			activePresetId: null,
+			activePresetName: "Current State",
+			pendingPresetChange: null,
+			handleLoadLocal: vi.fn(),
+			handleLoadBuiltin: vi.fn(),
+			handleLoadLibrary: vi.fn(),
+			handleStepPreset: vi.fn(),
+			handleSavePreset: vi.fn(),
+			handleDeletePreset: vi.fn(),
+			handleRenamePreset: vi.fn(),
+			handleInitPreset: vi.fn(),
+			handleExportPreset: vi.fn(),
+			handleImportPreset: vi.fn(),
+			handleExportCurrentState: vi.fn(),
+			handleSavePendingPresetChange: vi.fn(),
+			handleDiscardPendingPresetChange: vi.fn(),
+			handleCancelPendingPresetChange: vi.fn(),
+		});
+		delete (window as Window & { ipc?: unknown }).ipc;
+	});
+
+	it("does not hydrate persisted current state in plugin mode", () => {
+		render(<PluginPage />);
+
+		expect(mockUseSynthPresetManager).toHaveBeenCalledTimes(1);
+		const options = mockUseSynthPresetManager.mock.calls[0]?.[0] as {
+			shouldLoadCurrentState: () => boolean;
+		};
+		expect(options.shouldLoadCurrentState()).toBe(false);
+	});
+});

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
@@ -86,8 +86,6 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 		localStorage.setItem(UI_SCALE_KEY, String(uiScale));
 	}, [uiScale]);
 
-	const shouldLoadCurrentState = useCallback(() => !window.ipc, []);
-
 	const {
 		allPresetEntries,
 		activePresetId,
@@ -111,7 +109,7 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 		builtinPresets: DEFAULT_SYNTH_PRESETS,
 		gatherState,
 		applyPreset,
-		shouldLoadCurrentState,
+		shouldLoadCurrentState: () => false,
 		presetStateKey,
 	});
 


### PR DESCRIPTION
## Summary
- disable persisted current-state hydration in plugin webview preset manager init
- keep plugin state source-of-truth with host/runtime bridge instead of browser local storage
- add `PluginPage` unit regression test verifying plugin mode does not request persisted hydration

## Why
On plugin webview reopen, local persisted state could be applied during init and alter sound unexpectedly before/while bridge sync occurs.

## Tests
- added `packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx`

## Validation
- `bunx biome check packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx`
- `bun --filter @cosmo/cosmo-pd101-plugin-webview build`
- `bun --filter @cosmo/cosmo-pd101-plugin-webview test:unit -- src/PluginPage.test.tsx`

Closes #134