### PR TITLE
feat(envelope): replace dropdowns with per-step SUS/END buttons

### DIFF
--- a/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx
@@ -54,8 +54,6 @@ interface PerLineWarpBlockProps {
 	setCzSlotBWaveform: (v: CzWaveform) => void;
 	czWindow: WindowType;
 	setCzWindow: (v: WindowType) => void;
-	keyFollow: number;
-	setKeyFollow: (v: number) => void;
 	algoControlsA: AlgoControlValueV1[];
 	setAlgoControlsA: (value: AlgoControlValueV1[]) => void;
 	algoControlsB: AlgoControlValueV1[];
@@ -100,8 +98,6 @@ export const PerLineWarpBlock = memo(function PerLineWarpBlock({
 	setCzSlotBWaveform,
 	czWindow,
 	setCzWindow,
-	keyFollow,
-	setKeyFollow,
 	algoControlsA = [],
 	setAlgoControlsA = () => {},
 	algoControlsB = [],
@@ -522,21 +518,6 @@ export const PerLineWarpBlock = memo(function PerLineWarpBlock({
 									color={activeEnv.envColor}
 									compact
 								/>
-								<div className="mt-2 flex items-center gap-2">
-									<span className="text-3xs text-cz-cream uppercase tracking-[0.2em]">
-										Key Follow:
-									</span>
-									<input
-										type="range"
-										min={0}
-										max={9}
-										value={keyFollow}
-										onChange={(e) => setKeyFollow(Number(e.target.value))}
-										className="range range-xs"
-										style={{ accentColor: "var(--color-cz-gold)" }}
-									/>
-									<span className="text-xs text-cz-cream w-4">{keyFollow}</span>
-								</div>
 							</Card>
 						</div>
 					)}

--- a/packages/cosmo-pd101/src/components/editor/PhaseLinesSection.tsx
+++ b/packages/cosmo-pd101/src/components/editor/PhaseLinesSection.tsx
@@ -87,11 +87,6 @@ export default function PhaseLinesSection({
 		useSynthParam("line2AlgoControlsA");
 	const { value: line2AlgoControlsB, setValue: setLine2AlgoControlsB } =
 		useSynthParam("line2AlgoControlsB");
-	const { value: line1DcwKeyFollow, setValue: setLine1DcwKeyFollow } =
-		useSynthParam("line1DcwKeyFollow");
-	const { value: line2DcwKeyFollow, setValue: setLine2DcwKeyFollow } =
-		useSynthParam("line2DcwKeyFollow");
-
 	const line1 = {
 		warpAmount: warpAAmount,
 		setWarpAmount: setWarpAAmount,
@@ -123,8 +118,6 @@ export default function PhaseLinesSection({
 		setAlgoControlsA: setLine1AlgoControlsA,
 		algoControlsB: line1AlgoControlsB,
 		setAlgoControlsB: setLine1AlgoControlsB,
-		keyFollow: line1DcwKeyFollow,
-		setKeyFollow: setLine1DcwKeyFollow,
 	};
 
 	const line2 = {
@@ -158,8 +151,6 @@ export default function PhaseLinesSection({
 		setAlgoControlsA: setLine2AlgoControlsA,
 		algoControlsB: line2AlgoControlsB,
 		setAlgoControlsB: setLine2AlgoControlsB,
-		keyFollow: line2DcwKeyFollow,
-		setKeyFollow: setLine2DcwKeyFollow,
 	};
 
 	const activeTab = useSynthUiStore((s) => s.phaseLinePanelTab);
@@ -271,8 +262,6 @@ export default function PhaseLinesSection({
 						setAlgoControlsA={activeLineConfig.setAlgoControlsA}
 						algoControlsB={activeLineConfig.algoControlsB}
 						setAlgoControlsB={activeLineConfig.setAlgoControlsB}
-						keyFollow={activeLineConfig.keyFollow}
-						setKeyFollow={activeLineConfig.setKeyFollow}
 						activeSection={activeSection}
 					/>
 				</div>

--- a/packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.test.tsx
+++ b/packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StepEnvData } from "@/lib/synth/bindings/synth";
+import { StepEnvelopeEditor } from "./StepEnvelopeEditor";
+
+vi.mock("@/components/controls/ControlKnob", () => ({
+	default: ({ label, disabled }: { label?: string; disabled?: boolean }) => (
+		<button type="button" disabled={disabled}>
+			{label}
+		</button>
+	),
+}));
+
+const createEnv = (overrides: Partial<StepEnvData> = {}): StepEnvData => ({
+	steps: Array.from({ length: 8 }, (_, index) => ({
+		level: Math.max(0, 99 - index * 10),
+		rate: 40 + index,
+	})),
+	sustainStep: 1,
+	stepCount: 4,
+	loop: false,
+	...overrides,
+});
+
+describe("StepEnvelopeEditor", () => {
+	beforeEach(() => {
+		vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+	});
+
+	it("renders all 8 step panels and removes the old dropdown/footer UI", () => {
+		render(
+			<StepEnvelopeEditor
+				title="Line 1 DCW"
+				env={createEnv()}
+				onChange={vi.fn()}
+				compact
+			/>,
+		);
+
+		expect(screen.getAllByRole("group", { name: /Step / })).toHaveLength(8);
+		expect(screen.queryAllByRole("combobox")).toHaveLength(0);
+		expect(screen.queryByText(/Release:/i)).not.toBeInTheDocument();
+		// SUS cannot be set beyond END
+		expect(
+			within(screen.getByRole("group", { name: "Step 8" })).getByRole(
+				"button",
+				{ name: "SUS" },
+			),
+		).toBeDisabled();
+	});
+
+	it("sets sustain from the SUS button on an active step", () => {
+		const onChange = vi.fn();
+
+		render(
+			<StepEnvelopeEditor
+				title="Line 1 DCW"
+				env={createEnv()}
+				onChange={onChange}
+				compact
+			/>,
+		);
+
+		fireEvent.click(
+			within(screen.getByRole("group", { name: "Step 3" })).getByRole(
+				"button",
+				{ name: "SUS" },
+			),
+		);
+
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sustainStep: 2,
+				stepCount: 4,
+			}),
+		);
+	});
+
+	it("sets END on a later step and extends the active envelope range", () => {
+		const onChange = vi.fn();
+
+		render(
+			<StepEnvelopeEditor
+				title="Line 1 DCW"
+				env={createEnv()}
+				onChange={onChange}
+				compact
+			/>,
+		);
+
+		fireEvent.click(
+			within(screen.getByRole("group", { name: "Step 6" })).getByRole(
+				"button",
+				{ name: "END" },
+			),
+		);
+
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({
+				stepCount: 6,
+				sustainStep: 1,
+			}),
+		);
+	});
+
+	it("clamps sustain when END moves earlier than the current sustain step", () => {
+		const onChange = vi.fn();
+
+		render(
+			<StepEnvelopeEditor
+				title="Line 1 DCW"
+				env={createEnv({ stepCount: 6, sustainStep: 4 })}
+				onChange={onChange}
+				compact
+			/>,
+		);
+
+		fireEvent.click(
+			within(screen.getByRole("group", { name: "Step 3" })).getByRole(
+				"button",
+				{ name: "END" },
+			),
+		);
+
+		expect(onChange).toHaveBeenCalledWith(
+			expect.objectContaining({
+				stepCount: 3,
+				sustainStep: 2,
+			}),
+		);
+	});
+});

--- a/packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.tsx
+++ b/packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.tsx
@@ -4,6 +4,7 @@ import Card from "@/components/primitives/Card";
 import type { StepEnvData } from "@/lib/synth/bindings/synth";
 
 const STEP_KEYS = ["s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7"] as const;
+const DEFAULT_STEP = { level: 0, rate: 50 };
 
 interface StepEnvelopeEditorProps {
 	title: string;
@@ -25,6 +26,27 @@ const HOVER_RADIUS_PX = 22;
 
 function clamp(value: number, min: number, max: number) {
 	return Math.max(min, Math.min(max, value));
+}
+
+function normalizeStepCount(stepCount: number) {
+	return clamp(Math.round(stepCount), 1, STEP_KEYS.length);
+}
+
+function getPaddedSteps(steps: StepEnvData["steps"]) {
+	return STEP_KEYS.map((_, index) => {
+		const step = steps[index];
+		return step ? { ...step } : { ...DEFAULT_STEP };
+	});
+}
+
+function normalizeEnvelope(env: StepEnvData): StepEnvData {
+	const stepCount = normalizeStepCount(env.stepCount);
+	return {
+		...env,
+		steps: getPaddedSteps(env.steps),
+		stepCount,
+		sustainStep: clamp(Math.round(env.sustainStep), 0, stepCount - 1),
+	};
 }
 
 function editorStepDuration(rate: number, activeStepCount: number): number {
@@ -184,6 +206,10 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 }: StepEnvelopeEditorProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const [hoverStep, setHoverStep] = useState<number | null>(null);
+	const normalizedEnv = normalizeEnvelope(env);
+	const steps = normalizedEnv.steps;
+	const activeStepCount = normalizedEnv.stepCount;
+	const sustainStep = normalizedEnv.sustainStep;
 	const [dragState, setDragState] = useState<{
 		pointerId: number;
 		stepIndex: number;
@@ -197,43 +223,74 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 		if (canvasRef.current) {
 			drawEnvPreview(
 				canvasRef.current,
-				env,
+				normalizedEnv,
 				color,
 				dragState?.stepIndex ?? hoverStep,
 			);
 		}
-	}, [env, color, hoverStep, dragState]);
+	}, [normalizedEnv, color, hoverStep, dragState]);
+
+	const commitEnvelope = useCallback(
+		(nextEnv: StepEnvData) => {
+			onChange(normalizeEnvelope(nextEnv));
+		},
+		[onChange],
+	);
 
 	const updateStep = useCallback(
 		(index: number, field: "level" | "rate", value: number) => {
-			const newSteps = env.steps.map((s, i) =>
+			const newSteps = steps.map((s, i) =>
 				i === index ? { ...s, [field]: value } : s,
 			);
-			onChange({ ...env, steps: newSteps });
+			commitEnvelope({ ...normalizedEnv, steps: newSteps });
 		},
-		[env, onChange],
+		[commitEnvelope, normalizedEnv, steps],
 	);
 
 	const updateStepValues = useCallback(
 		(index: number, level: number, rate: number) => {
-			const newSteps = env.steps.map((step, i) =>
+			const newSteps = steps.map((step, i) =>
 				i === index ? { ...step, level, rate } : step,
 			);
-			onChange({ ...env, steps: newSteps });
+			commitEnvelope({ ...normalizedEnv, steps: newSteps });
 		},
-		[env, onChange],
+		[commitEnvelope, normalizedEnv, steps],
+	);
+
+	const setSustainStepForIndex = useCallback(
+		(index: number) => {
+			if (index < 0 || index >= activeStepCount) {
+				return;
+			}
+
+			commitEnvelope({
+				...normalizedEnv,
+				sustainStep: index,
+			});
+		},
+		[activeStepCount, commitEnvelope, normalizedEnv],
+	);
+
+	const setEndStepForIndex = useCallback(
+		(index: number) => {
+			commitEnvelope({
+				...normalizedEnv,
+				stepCount: index + 1,
+			});
+		},
+		[commitEnvelope, normalizedEnv],
 	);
 
 	const getRateForPointerX = useCallback(
 		(stepIndex: number, pointerX: number, canvasWidth: number) => {
-			const activeSteps = env.steps.slice(0, env.stepCount);
-			const activeStepCount = activeSteps.length;
+			const activeSteps = steps.slice(0, activeStepCount);
+			const visibleStepCount = activeSteps.length;
 			if (stepIndex < 0 || stepIndex >= activeSteps.length) {
-				return env.steps[stepIndex]?.rate ?? 0;
+				return steps[stepIndex]?.rate ?? 0;
 			}
 			const allowed = getStepAllowedXRange(
 				stepIndex,
-				activeStepCount,
+				visibleStepCount,
 				canvasWidth,
 			);
 			const clampedPointerX = clamp(pointerX, allowed.minX, allowed.maxX);
@@ -248,7 +305,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 
 				for (let i = 0; i < activeSteps.length; i++) {
 					const rate = i === stepIndex ? candidateRate : activeSteps[i].rate;
-					const duration = editorStepDuration(rate, activeStepCount);
+					const duration = editorStepDuration(rate, visibleStepCount);
 					totalTime += duration;
 					if (i <= stepIndex) cumulative += duration;
 				}
@@ -265,7 +322,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 
 			return bestRate;
 		},
-		[env.stepCount, env.steps],
+		[activeStepCount, steps],
 	);
 
 	const getRelativePointerPosition = useCallback(
@@ -286,7 +343,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 			const pos = getRelativePointerPosition(clientX, clientY);
 			if (!pos) return null;
 
-			const points = buildEnvelopePoints(env, 1000, 200);
+			const points = buildEnvelopePoints(normalizedEnv, 1000, 200);
 			const closest = findClosestPoint(points, pos.x, pos.y);
 			if (!closest) return null;
 
@@ -295,7 +352,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 				distanceSquared: closest.distanceSquared,
 			};
 		},
-		[env, getRelativePointerPosition],
+		[getRelativePointerPosition, normalizedEnv],
 	);
 
 	const handleCanvasPointerDown = useCallback(
@@ -305,7 +362,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 			const closest = getClosestStepAtPointer(e.clientX, e.clientY);
 			if (!closest) return;
 
-			const step = env.steps[closest.stepIndex];
+			const step = steps[closest.stepIndex];
 			if (!step) return;
 
 			canvas.setPointerCapture(e.pointerId);
@@ -319,7 +376,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 				startRate: step.rate,
 			});
 		},
-		[env.steps, getClosestStepAtPointer],
+		[getClosestStepAtPointer, steps],
 	);
 
 	const handleCanvasPointerMove = useCallback(
@@ -331,10 +388,10 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 				const levelDelta =
 					(dragState.startClientY - e.clientY) / pos.rect.height;
 				const level = clamp(dragState.startLevel + levelDelta * 99, 0, 99);
-				const isLastActiveStep = dragState.stepIndex === env.stepCount - 1;
+				const isLastActiveStep = dragState.stepIndex === activeStepCount - 1;
 				const allowed = getStepAllowedXRange(
 					dragState.stepIndex,
-					env.stepCount,
+					activeStepCount,
 					canvasRef.current?.width ?? 1000,
 				);
 				const clampedX = clamp(pos.x, allowed.minX, allowed.maxX);
@@ -372,7 +429,7 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 		},
 		[
 			dragState,
-			env.stepCount,
+			activeStepCount,
 			getClosestStepAtPointer,
 			getRateForPointerX,
 			getRelativePointerPosition,
@@ -407,30 +464,16 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 					<label className="text-xs flex items-center gap-1">
 						<input
 							type="checkbox"
-							checked={env.loop}
-							onChange={(e) => onChange({ ...env, loop: e.target.checked })}
+							checked={normalizedEnv.loop}
+							onChange={(e) =>
+								commitEnvelope({
+									...normalizedEnv,
+									loop: e.target.checked,
+								})
+							}
 							className="checkbox checkbox-xs"
 						/>
 						Loop
-					</label>
-					<label className="text-xs flex items-center gap-1">
-						<span>Sus</span>
-						<select
-							className="select select-bordered select-xs w-12"
-							value={env.sustainStep}
-							onChange={(e) =>
-								onChange({
-									...env,
-									sustainStep: Number(e.target.value),
-								})
-							}
-						>
-							{env.steps.map((_, i) => (
-								<option key={STEP_KEYS[i]} value={i}>
-									{i + 1}
-								</option>
-							))}
-						</select>
 					</label>
 				</div>
 			</div>
@@ -455,24 +498,31 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 						: "grid grid-cols-2 gap-2 sm:grid-cols-4 2xl:grid-cols-8"
 				}
 			>
-				{env.steps.slice(0, env.stepCount).map((step, i) => {
-					const isLastStep = i === env.stepCount - 1;
+				{steps.map((step, i) => {
+					const isActiveStep = i < activeStepCount;
+					const isEndStep = i === activeStepCount - 1;
+					const isSustainStep = i === sustainStep;
 					return (
 						<div
 							key={STEP_KEYS[i]}
-							className={`rounded-xl border px-1 ${
-								isLastStep
-									? "border-base-300/40 bg-base-300/10 opacity-70"
+							role="group"
+							aria-label={`Step ${i + 1}`}
+							className={`flex flex-col rounded-xl border px-1 transition-colors ${
+								!isActiveStep
+									? "border-base-300/30 bg-base-300/10"
 									: "border-base-300/60 bg-base-300/20"
 							} ${compact ? "py-1.5" : "py-2"}`}
 						>
-							<div className="mb-1 text-center text-4xs uppercase tracking-[0.2em] text-base-content/45">
-								{i + 1}
+							<div className="mb-1 flex items-center justify-start px-1">
+								<div className="text-4xs uppercase tracking-[0.2em] text-base-content/45">
+									{i + 1}
+								</div>
 							</div>
-							<div className="flex flex-col items-center justify-center gap-2">
+							<div className={`flex flex-col items-center justify-center gap-2 ${!isActiveStep ? "opacity-40" : ""}`}>
 								<ControlKnob
 									value={step.level}
 									onChange={(v) => updateStep(i, "level", v)}
+									disabled={!isActiveStep}
 									min={0}
 									max={99}
 									label="Lvl"
@@ -481,48 +531,56 @@ export const StepEnvelopeEditor = memo(function StepEnvelopeEditor({
 									// value as 0 but the stored value is still editable so it
 									// is preserved when the step count is increased.
 									valueFormatter={(v) =>
-										isLastStep ? "0*" : `${Math.round(v)}`
+										isEndStep ? "0*" : `${Math.round(v)}`
 									}
-									color={isLastStep ? "#6b7280" : color}
+									color={
+										!isActiveStep ? "#6b7280" : isEndStep ? "#f59e0b" : color
+									}
 									size={compact ? 26 : 30}
 								/>
 								<ControlKnob
 									value={step.rate}
 									onChange={(v) => updateStep(i, "rate", v)}
+									disabled={!isActiveStep}
 									min={0}
 									max={99}
 									label="Rate"
 									tooltip={`Sets envelope transition speed for step ${i + 1}.`}
 									valueFormatter={(v) => `${Math.round(v)}`}
-									color="#a3a3a3"
+									color={!isActiveStep ? "#6b7280" : "#a3a3a3"}
 									size={compact ? 26 : 30}
 								/>
+							</div>
+							<div className="mt-1 flex w-full flex-col gap-1 pt-1">
+								<button
+									type="button"
+									onClick={() => setSustainStepForIndex(i)}
+									disabled={!isActiveStep}
+									aria-pressed={isSustainStep}
+									className={`rounded border px-1 py-1 text-[0.55rem] font-semibold uppercase tracking-[0.18em] transition-colors ${
+										isSustainStep
+											? "border-warning/60 bg-warning/15 text-warning"
+											: "border-base-300/60 bg-base-100/40 text-base-content/70"
+									} disabled:cursor-not-allowed disabled:opacity-40`}
+								>
+									SUS
+								</button>
+								<button
+									type="button"
+									onClick={() => setEndStepForIndex(i)}
+									aria-pressed={isEndStep}
+									className={`rounded border px-1 py-1 text-[0.55rem] font-semibold uppercase tracking-[0.18em] transition-colors ${
+										isEndStep
+											? "border-cz-gold/60 bg-cz-gold/15 text-cz-gold"
+											: "border-base-300/60 bg-base-100/40 text-base-content/70"
+									}`}
+								>
+									END
+								</button>
 							</div>
 						</div>
 					);
 				})}
-			</div>
-
-			<div className="flex items-center gap-2">
-				<label className="text-xs flex items-center gap-1">
-					<span>Steps</span>
-					<select
-						className="select select-bordered select-xs w-12"
-						value={env.stepCount}
-						onChange={(e) =>
-							onChange({ ...env, stepCount: Number(e.target.value) })
-						}
-					>
-						{[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
-							<option key={n} value={n}>
-								{n}
-							</option>
-						))}
-					</select>
-				</label>
-				<span className="text-xs text-base-content/50 ml-auto">
-					Release: L0* R{(env.steps[env.stepCount - 1]?.rate ?? 0).toFixed(0)}
-				</span>
 			</div>
 		</Card>
 	);


### PR DESCRIPTION
## Summary

Redesigns the step envelope panel in the phase lines section.

### Changes

- **Always show all 8 step panels** — removed the step count dropdown; the END button controls the active range instead
- **Per-step SUS and END buttons** (stacked vertically) replace the old sustain/stepCount dropdowns
- **SUS disabled beyond END** — SUS buttons are disabled for inactive steps, enforcing `sustainStep < stepCount`
- **END always clickable** — clicking END on a later step extends the envelope range
- **Removed UI chrome**: sustain/stepCount dropdowns, release footer, key-follow slider, SUS/END indicator badges (buttons are the indicators)
- **Tests**: added `StepEnvelopeEditor.test.tsx` with 4 focused unit tests covering render, SUS, END, and clamp-on-END-move behaviour

### Files changed

- `packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.tsx`
- `packages/cosmo-pd101/src/components/editor/StepEnvelopeEditor.test.tsx` _(new)_
- `packages/cosmo-pd101/src/components/editor/PerLineWarpBlock.tsx`
- `packages/cosmo-pd101/src/components/editor/PhaseLinesSection.tsx`