### PR TITLE
feat(engine): add variable polyphony with configurable 4-16 voice count

### DIFF
--- a/packages/cosmo-pd101-plugin/src/lib.rs
+++ b/packages/cosmo-pd101-plugin/src/lib.rs
@@ -9,7 +9,6 @@ use std::io::Write;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use arc_swap::ArcSwap;
@@ -487,7 +486,8 @@ pub struct CzPlugin {
     cached_rt_synth_params: Arc<SynthParams>,
     scope_buffer: ScopeBuffer,
     ui_input_queue: UiInputQueue,
-    mono_output: Vec<f32>,
+    stereo_output: Vec<f32>,
+    scope_scratch: Vec<f32>,
     performance_counters: PerformanceCountersHandle,
 }
 
@@ -505,7 +505,8 @@ impl Default for CzPlugin {
             cached_rt_synth_params: Arc::new(default_rt_params),
             scope_buffer: Arc::new(Mutex::new(ScopeFrame::default())),
             ui_input_queue: Arc::new(ArrayQueue::new(UI_INPUT_QUEUE_CAPACITY)),
-            mono_output: Vec::new(),
+            stereo_output: Vec::new(),
+            scope_scratch: Vec::new(),
             performance_counters: Arc::new(PerformanceCounters::default()),
         }
     }
@@ -603,8 +604,8 @@ impl Plugin for CzPlugin {
         self.cached_rt_synth_params = rt_synth_params;
         self.cached_synth_params_version = self.synth_params_version.load(Ordering::Acquire);
         self.processor = Some(processor);
-        self.mono_output
-            .resize(buffer_config.max_buffer_size as usize, 0.0);
+        self.stereo_output
+            .resize(buffer_config.max_buffer_size as usize * 2, 0.0);
         self.performance_counters
             .sample_rate_bits
             .store(buffer_config.sample_rate.to_bits(), Ordering::Release);
@@ -688,16 +689,17 @@ impl Plugin for CzPlugin {
                 proc.set_shared_params(Arc::clone(&self.cached_rt_synth_params));
                 self.performance_counters.record_param_apply();
             }
-            let num_samples = buffer.samples();
-            if num_samples > self.mono_output.len() {
+            let num_frames = buffer.samples();
+            let stereo_len = num_frames * 2;
+            if stereo_len > self.stereo_output.len() {
                 for channel_slice in buffer.as_slice() {
                     channel_slice.fill(0.0);
                 }
                 return ProcessStatus::Normal;
             }
-            let mono_output = &mut self.mono_output[..num_samples];
-            let process_start = monitor_enabled.then(Instant::now);
-            proc.process(mono_output);
+            let stereo_output = &mut self.stereo_output[..stereo_len];
+            let process_start = monitor_enabled.then(std::time::Instant::now);
+            proc.process(stereo_output);
             let elapsed_ns = process_start
                 .map(|start| start.elapsed().as_nanos().min(u128::from(u64::MAX)) as u64)
                 .unwrap_or(0);
@@ -721,17 +723,37 @@ impl Plugin for CzPlugin {
             };
             self.performance_counters.record_process_block(
                 elapsed_ns,
-                num_samples,
+                num_frames,
                 proc.sample_rate,
                 active_voice_count,
                 ui_queue_depth,
             );
-            if let Ok(mut scope) = self.scope_buffer.try_lock() {
-                scope.push_block(mono_output, proc.sample_rate, hz);
+
+            // De-interleave stereo output into per-channel buffers
+            let mut ch_idx = 0usize;
+            for channel_slice in buffer.as_slice() {
+                if ch_idx == 0 {
+                    for i in 0..num_frames {
+                        channel_slice[i] = stereo_output[i * 2];
+                    }
+                } else if ch_idx == 1 {
+                    for i in 0..num_frames {
+                        channel_slice[i] = stereo_output[i * 2 + 1];
+                    }
+                } else {
+                    break;
+                }
+                ch_idx += 1;
             }
 
-            for channel_slice in buffer.as_slice() {
-                channel_slice.copy_from_slice(mono_output);
+            // Scope: sum L+R to mono
+            if let Ok(mut scope) = self.scope_buffer.try_lock() {
+                self.scope_scratch.resize(num_frames, 0.0);
+                for i in 0..num_frames {
+                    self.scope_scratch[i] =
+                        (stereo_output[i * 2] + stereo_output[i * 2 + 1]) * 0.5;
+                }
+                scope.push_block(&self.scope_scratch, proc.sample_rate, hz);
             }
         }
 

--- a/packages/cosmo-pd101/src/features/synth/synthStore.ts
+++ b/packages/cosmo-pd101/src/features/synth/synthStore.ts
@@ -150,6 +150,7 @@ export type SynthState = {
 	modMode: ModMode;
 
 	polyMode: PolyMode;
+	voiceCount: number;
 	legato: boolean;
 	velocityCurve: number;
 
@@ -231,6 +232,7 @@ type SynthActions = {
 	setModMode: (v: ModMode) => void;
 
 	setPolyMode: (v: PolyMode) => void;
+	setVoiceCount: (v: number) => void;
 	setLegato: (v: boolean) => void;
 	setVelocityCurve: (v: number) => void;
 
@@ -325,6 +327,7 @@ const DEFAULT_STATE: SynthState = {
 	modMode: "normal",
 
 	polyMode: "poly8",
+	voiceCount: 8,
 	legato: false,
 	velocityCurve: requireEngineParamDefault("velocityCurve"),
 
@@ -411,6 +414,7 @@ export const useSynthStore = create<SynthStore>((set, get) => ({
 	setModMode: (v) => set({ modMode: v }),
 
 	setPolyMode: (v) => set({ polyMode: v }),
+	setVoiceCount: (v) => set({ voiceCount: toIntegerInRange(v, 4, 16) }),
 	setLegato: (v) => set({ legato: v }),
 	setVelocityCurve: (v) => set({ velocityCurve: v }),
 
@@ -563,6 +567,7 @@ export const useSynthStore = create<SynthStore>((set, get) => ({
 			frequency: 440,
 			volume: s.volume,
 			polyMode: s.polyMode,
+			voiceCount: s.voiceCount,
 			legato: s.legato,
 			velocityCurve: s.velocityCurve,
 
@@ -697,6 +702,7 @@ export const useSynthStore = create<SynthStore>((set, get) => ({
 					)
 				: [],
 			polyMode: (p.polyMode as PolyMode) ?? "poly8",
+			voiceCount: toIntegerInRange(p.voiceCount ?? 8, 4, 16),
 			legato: p.legato ?? false,
 			lineSelect: (p.lineSelect as LineSelect) ?? "L1+L2'",
 			modMode: (p.modMode as ModMode) ?? "normal",

--- a/packages/cosmo-pd101/src/lib/synth/bindings/synth.ts
+++ b/packages/cosmo-pd101/src/lib/synth/bindings/synth.ts
@@ -263,7 +263,7 @@ export type FxSlotConfig = { type: "empty" } | { type: "chorus"; params: ChorusP
 /**
  * Top-level synth parameters
  */
-export type SynthParams = { lineSelect: LineSelect; modMode: ModMode; ringGain?: number; octave: number; line1: LineParams; line2: LineParams; frequency: number; volume: number; polyMode: PolyMode; legato: boolean; portamento: PortamentoParams; lfo: LfoParams; lfo2?: LfoParams; velocityCurve?: number; pitchBendRange?: number; modMatrix?: ModMatrix; random?: RandomParams; modEnv?: ModEnvParams; fxSlots?: [FxSlotConfig, FxSlotConfig, FxSlotConfig, FxSlotConfig, FxSlotConfig, FxSlotConfig] }
+export type SynthParams = { lineSelect: LineSelect; modMode: ModMode; ringGain?: number; octave: number; line1: LineParams; line2: LineParams; frequency: number; volume: number; polyMode: PolyMode; legato: boolean; portamento: PortamentoParams; lfo: LfoParams; lfo2?: LfoParams; velocityCurve?: number; pitchBendRange?: number; modMatrix?: ModMatrix; random?: RandomParams; modEnv?: ModEnvParams; voiceCount?: number; fxSlots?: [FxSlotConfig, FxSlotConfig, FxSlotConfig, FxSlotConfig, FxSlotConfig, FxSlotConfig] }
 
 /**
  * Canonical, versioned synth preset wire contract.

--- a/packages/cosmo-synth-engine/COSMO_ENGINE.md
+++ b/packages/cosmo-synth-engine/COSMO_ENGINE.md
@@ -338,7 +338,7 @@ flowchart LR
 
 ## Voice Architecture (8 Voices)
 
-- `NUM_VOICES = 8` polyphonic voices
+- `voice_count` configurable 4–16 (default: 8) polyphonic voices
 - Rendered in SIMD-4 batches for efficiency
 - Auto-detects SIMD backend: AVX2 (x86), SSE2 (x86 fallback), WASM SIMD, or scalar fallback
 - Voice lifecycle: note-on → attack → decay → sustain → note-off → release → fade → zero-cross stop → silence

--- a/packages/cosmo-synth-engine/src/fx/chain.rs
+++ b/packages/cosmo-synth-engine/src/fx/chain.rs
@@ -201,6 +201,17 @@ impl FxSlotProcessors {
             FxSlotType::Vibrato | FxSlotType::PhaseMod | FxSlotType::Empty => sample,
         }
     }
+
+    fn process_stereo(
+        &mut self,
+        effect_type: FxSlotType,
+        left: f32,
+        right: f32,
+    ) -> (f32, f32) {
+        let out_l = self.process(effect_type, left);
+        let out_r = self.process(effect_type, right);
+        (out_l, out_r)
+    }
 }
 
 pub struct FxChain {
@@ -239,7 +250,7 @@ impl FxChain {
         }
     }
 
-    /// Process one sample through all 6 FX slots in series.
+    /// Process one sample through all 6 FX slots in series (mono).
     pub fn process(&mut self, sample: f32) -> f32 {
         let mut out = sample;
         for active_idx in 0..self.active_slot_count {
@@ -249,7 +260,23 @@ impl FxChain {
         out
     }
 
+    /// Process a stereo pair through all 6 FX slots in series.
+    /// Each effect is called twice (dual-mono) to maintain stereo separation.
+    pub fn process_stereo(&mut self, left: f32, right: f32) -> (f32, f32) {
+        let mut l = left;
+        let mut r = right;
+        for active_idx in 0..self.active_slot_count {
+            let slot = self.active_slots[active_idx];
+            (l, r) = self.process_slot_stereo(slot, l, r);
+        }
+        (l, r)
+    }
+
     fn process_slot(&mut self, slot: usize, sample: f32) -> f32 {
         self.slots[slot].process(self.slot_types[slot], sample)
+    }
+
+    fn process_slot_stereo(&mut self, slot: usize, left: f32, right: f32) -> (f32, f32) {
+        self.slots[slot].process_stereo(self.slot_types[slot], left, right)
     }
 }

--- a/packages/cosmo-synth-engine/src/params/mod.rs
+++ b/packages/cosmo-synth-engine/src/params/mod.rs
@@ -32,7 +32,10 @@ pub use modulation::{
     NUM_MOD_DESTINATIONS,
 };
 pub use portamento::{PortamentoMode, PortamentoParams};
-pub use synth_params::{ModEnvParams, RandomParams, SynthParams, NUM_OPERATORS, NUM_VOICES};
+pub use synth_params::{
+    ModEnvParams, RandomParams, SynthParams, DEFAULT_VOICE_COUNT, MAX_VOICES, MIN_VOICES,
+    NUM_OPERATORS,
+};
 pub use ui_meta::{
     engine_param_default_v1, engine_param_ranges_v1, engine_param_ui_meta_v1,
     EngineEnumValueLabelV1, EngineParamRangeV1, EngineParamReadoutFormatV1, EngineParamUiMetaV1,

--- a/packages/cosmo-synth-engine/src/params/synth_params.rs
+++ b/packages/cosmo-synth-engine/src/params/synth_params.rs
@@ -8,7 +8,9 @@ use super::line::{LineParams, LineSelect, ModMode, PolyMode};
 use super::modulation::ModMatrix;
 use super::portamento::PortamentoParams;
 
-pub const NUM_VOICES: usize = 8;
+pub const MAX_VOICES: usize = 16;
+pub const MIN_VOICES: usize = 4;
+pub const DEFAULT_VOICE_COUNT: u8 = 8;
 pub const NUM_OPERATORS: usize = 4; // CZ-101 has 4 operators per line
 
 /// Parameters for the random (sample-and-hold) modulation source.
@@ -53,6 +55,10 @@ pub(crate) fn default_ring_gain() -> f32 {
     4.0
 }
 
+pub(crate) fn default_voice_count() -> u8 {
+    DEFAULT_VOICE_COUNT
+}
+
 /// Top-level synth parameters
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "specta-bindings", derive(Type))]
@@ -83,6 +89,8 @@ pub struct SynthParams {
     pub random: RandomParams,
     #[serde(default)]
     pub mod_env: ModEnvParams,
+    #[serde(default = "default_voice_count")]
+    pub voice_count: u8,
     #[serde(default = "default_fx_slot_configs")]
     pub fx_slots: [FxSlotConfig; 6],
 }
@@ -130,6 +138,7 @@ impl Default for SynthParams {
             mod_matrix: ModMatrix::default(),
             random: RandomParams::default(),
             mod_env: ModEnvParams::default(),
+            voice_count: default_voice_count(),
             fx_slots: default_fx_slot_configs(),
         }
     }

--- a/packages/cosmo-synth-engine/src/processor/mod.rs
+++ b/packages/cosmo-synth-engine/src/processor/mod.rs
@@ -345,7 +345,7 @@ mod tests {
         }];
 
         let base_rate = proc.params.lfo.rate;
-        let mut out = [0.0_f32; 1];
+        let mut out = [0.0_f32; 2];
         proc.process(&mut out);
 
         let expected_without_mod = base_rate / proc.sample_rate;
@@ -362,7 +362,7 @@ mod tests {
             amount: 1.0,
             enabled: true,
         }];
-        let mut out = [0.0_f32; 1];
+        let mut out = [0.0_f32; 2];
         proc.process(&mut out);
 
         assert!(out[0].is_finite());
@@ -410,7 +410,7 @@ mod tests {
         }];
 
         let base_rate = proc.params.random.rate;
-        let mut out = [0.0_f32; 1];
+        let mut out = [0.0_f32; 2];
         proc.process(&mut out);
 
         let expected_without_mod = base_rate / proc.sample_rate;
@@ -565,7 +565,7 @@ mod tests {
         let mut peak_curvature = 0.0_f32;
         let mut prev = 0.0_f32;
         let mut prev_delta = 0.0_f32;
-        let mut block = [0.0_f32; 1];
+        let mut block = [0.0_f32; 2];
 
         let mut current_note = 60_u8;
         proc.note_on(current_note, utils::midi_note_to_freq(current_note), 1.0);

--- a/packages/cosmo-synth-engine/src/processor/mod.rs
+++ b/packages/cosmo-synth-engine/src/processor/mod.rs
@@ -10,14 +10,12 @@ pub mod utils;
 pub use utils::midi_note_to_freq;
 
 use alloc::sync::Arc;
-use arrayvec::ArrayVec;
-use core::array;
 
 use crate::dsp_utils::random_hold_value;
 use crate::envelope::{normalize_synth_params_envelopes_to_raw_if_human, EnvelopeTimingCache};
 use crate::fx::FxChain;
 use crate::module_presets;
-use crate::params::{FxSlotConfig, FxSlotType, LineParams, SynthParams, NUM_VOICES};
+use crate::params::{FxSlotConfig, FxSlotType, LineParams, SynthParams, MAX_VOICES, MIN_VOICES};
 use crate::simd::{detect_simd_backend, SimdBackend};
 use crate::voice::Voice;
 
@@ -30,11 +28,11 @@ pub use self::state::{
 /// The main synthesizer processor, managing voices, FX, modulation sources,
 /// and the sample-by-sample audio process loop.
 pub struct CosmoProcessor {
-    pub voices: [Voice; NUM_VOICES],
+    pub voices: Vec<Voice>,
     pub fx: FxChain,
     pub(crate) cz_dac_color: CzDacColor,
-    pub active_notes: ArrayVec<NoteEntry, NUM_VOICES>,
-    pub mono_stack: ArrayVec<MonoStackEntry, NUM_VOICES>,
+    pub active_notes: Vec<NoteEntry>,
+    pub mono_stack: Vec<MonoStackEntry>,
     pub sustain_on: bool,
     pub lfo_phase: f32,
     pub lfo2_phase: f32,
@@ -60,19 +58,21 @@ pub struct CosmoProcessor {
 impl CosmoProcessor {
     /// Create a new processor with default parameters and FX state.
     pub fn new(sample_rate: f32) -> Self {
+        let default_params = SynthParams::default();
+        let voice_count = default_params.voice_count.max(1) as usize;
         let mut proc = Self {
-            voices: array::from_fn(|_| Voice::new()),
+            voices: (0..voice_count).map(|_| Voice::new()).collect(),
             fx: FxChain::new(sample_rate),
             cz_dac_color: CzDacColor::new(),
-            active_notes: ArrayVec::new(),
-            mono_stack: ArrayVec::new(),
+            active_notes: Vec::with_capacity(voice_count),
+            mono_stack: Vec::with_capacity(voice_count),
             sustain_on: false,
             lfo_phase: 0.0,
             lfo2_phase: 0.0,
             random_phase: 0.0,
             random_step: 0,
             random_hold: random_hold_value(0),
-            params: Arc::new(SynthParams::default()),
+            params: Arc::new(default_params),
             sample_rate,
             pitch_bend: 0.0,
             mod_wheel: 0.0,
@@ -181,10 +181,27 @@ impl CosmoProcessor {
 
     /// Swap in a pre-normalized shared parameter snapshot without cloning.
     pub fn set_shared_params(&mut self, params: Arc<SynthParams>) {
+        let new_voice_count = (params.voice_count as usize).clamp(MIN_VOICES, MAX_VOICES);
+        if new_voice_count != self.voices.len() {
+            self.resize_voices(new_voice_count);
+        }
         self.line1_scratch = params.line1;
         self.line2_scratch = params.line2;
         self.params = params;
         self.update_fx();
+    }
+
+    fn resize_voices(&mut self, new_count: usize) {
+        let old_count = self.voices.len();
+        if new_count > old_count {
+            self.voices
+                .extend((old_count..new_count).map(|_| Voice::new()));
+            self.active_notes.reserve(new_count - old_count);
+        } else if new_count < old_count {
+            self.active_notes.retain(|e| e.voice_idx < new_count);
+            self.mono_stack.clear();
+            self.voices.truncate(new_count);
+        }
     }
 
     /// Mutable parameter access for non-real-time mutation paths and tests.
@@ -193,20 +210,22 @@ impl CosmoProcessor {
     }
 
     fn debug_assert_note_storage_bounds(&self) {
-        debug_assert!(self.active_notes.len() <= NUM_VOICES);
-        debug_assert!(self.mono_stack.len() <= NUM_VOICES);
-        debug_assert_eq!(self.active_notes.capacity(), NUM_VOICES);
-        debug_assert_eq!(self.mono_stack.capacity(), NUM_VOICES);
+        let vc = self.voices.len();
+        debug_assert!(self.active_notes.len() <= vc);
+        debug_assert!(self.mono_stack.len() <= vc);
     }
 
     /// Hard reset runtime voice/FX state while keeping current parameters.
     pub fn reset_audio_state(&mut self) {
-        self.voices = array::from_fn(|_| Voice::new());
+        let voice_count = (self.params.voice_count as usize).clamp(MIN_VOICES, MAX_VOICES);
+        self.voices = (0..voice_count).map(|_| Voice::new()).collect();
         self.fx = FxChain::new(self.sample_rate);
         self.cz_dac_color.reset();
         self.update_fx();
         self.active_notes.clear();
+        self.active_notes = Vec::with_capacity(voice_count);
         self.mono_stack.clear();
+        self.mono_stack = Vec::with_capacity(voice_count);
         self.sustain_on = false;
         self.lfo_phase = 0.0;
         self.lfo2_phase = 0.0;
@@ -456,10 +475,8 @@ mod tests {
             }
         }
 
-        assert!(proc.active_notes.len() <= NUM_VOICES);
-        assert!(proc.mono_stack.len() <= NUM_VOICES);
-        assert!(proc.active_notes.capacity() >= NUM_VOICES);
-        assert!(proc.mono_stack.capacity() >= NUM_VOICES);
+        assert!(proc.active_notes.len() <= proc.voices.len());
+        assert!(proc.mono_stack.len() <= proc.voices.len());
     }
 
     #[test]

--- a/packages/cosmo-synth-engine/src/processor/notes.rs
+++ b/packages/cosmo-synth-engine/src/processor/notes.rs
@@ -1,6 +1,6 @@
 extern crate alloc;
 
-use crate::params::{PolyMode, NUM_VOICES};
+use crate::params::PolyMode;
 
 use super::state::{MonoStackEntry, NoteEntry};
 use super::CosmoProcessor;
@@ -111,19 +111,15 @@ impl CosmoProcessor {
 
     pub(crate) fn replace_active_note_entry(&mut self, voice_idx: usize, note: u8) {
         self.active_notes.retain(|e| e.voice_idx != voice_idx);
-        debug_assert!(self.active_notes.len() < NUM_VOICES);
-        self.active_notes
-            .try_push(NoteEntry { note, voice_idx })
-            .expect("active_notes exceeded voice capacity");
+        debug_assert!(self.active_notes.len() < self.voices.len());
+        self.active_notes.push(NoteEntry { note, voice_idx });
         self.debug_assert_note_storage_bounds();
     }
 
     pub(crate) fn push_mono_stack_entry(&mut self, entry: MonoStackEntry) {
         self.mono_stack.retain(|e| e.note != entry.note);
-        debug_assert!(self.mono_stack.len() < NUM_VOICES);
-        self.mono_stack
-            .try_push(entry)
-            .expect("mono_stack exceeded voice capacity");
+        debug_assert!(self.mono_stack.len() < self.voices.len());
+        self.mono_stack.push(entry);
         self.debug_assert_note_storage_bounds();
     }
 
@@ -132,7 +128,7 @@ impl CosmoProcessor {
             .last()
             .map(|entry| entry.voice_idx)
             .filter(|idx| {
-                *idx < NUM_VOICES
+                *idx < self.voices.len()
                     && !self.voices[*idx].is_silent
                     && !self.voices[*idx].is_releasing
                     && self.voices[*idx].note.is_some()
@@ -149,7 +145,7 @@ impl CosmoProcessor {
     }
 
     fn quick_fade_other_mono_voices(&mut self, keep_voice_idx: usize) {
-        for idx in 0..NUM_VOICES {
+        for idx in 0..self.voices.len() {
             if idx != keep_voice_idx && !self.voices[idx].is_silent {
                 self.start_quick_release(idx);
             }
@@ -370,7 +366,7 @@ impl CosmoProcessor {
     pub fn set_sustain(&mut self, on: bool) {
         self.sustain_on = on;
         if !on {
-            for i in 0..NUM_VOICES {
+            for i in 0..self.voices.len() {
                 let sustained = self.voices[i].sustained;
                 if sustained {
                     let still_held = self.active_notes.iter().any(|e| e.voice_idx == i);

--- a/packages/cosmo-synth-engine/src/processor/process.rs
+++ b/packages/cosmo-synth-engine/src/processor/process.rs
@@ -27,7 +27,10 @@ const MAX_HEADROOM_MAKEUP: f32 = 1.0;
 const ENABLE_CZ_DAC_COLOR: bool = false;
 
 impl CosmoProcessor {
-    /// Fill `output` with mono samples.
+    /// Fill `output` with interleaved stereo samples `[L, R, L, R, ...]`.
+    ///
+    /// The caller must provide an even-length buffer. Each consecutive pair
+    /// `(output[i], output[i+1])` is one stereo sample frame.
     ///
     /// On `std` builds, denormals are suppressed for the duration of this
     /// call to prevent the ~100x CPU stalls that subnormal floats cause in
@@ -54,6 +57,11 @@ impl CosmoProcessor {
     }
 
     fn process_inner(&mut self, output: &mut [f32]) {
+        assert_eq!(
+            output.len() % 2,
+            0,
+            "stereo output length must be even (interleaved L/R pairs)"
+        );
         let params = Arc::clone(&self.params);
         let p = params.as_ref();
         let volume = p.volume;
@@ -97,7 +105,7 @@ impl CosmoProcessor {
             .map(|a| pre_resolve_controls(a, &p.line2.algo_controls_b))
             .unwrap_or([0.0; 8]);
 
-        for sample_out in output.iter_mut() {
+        for frame in output.chunks_exact_mut(2) {
             let (source_mod_env, source_velocity) = self
                 .runtime_mod_source_voice_index()
                 .map(|voice_idx| {
@@ -400,14 +408,19 @@ impl CosmoProcessor {
 
             mixed *= norm;
 
-            let fx_out = self.fx.process(mixed);
-            let colored = if ENABLE_CZ_DAC_COLOR {
-                self.cz_dac_color.process(fx_out, sr)
+            let (fx_l, fx_r) = self.fx.process_stereo(mixed, mixed);
+            let colored_l = if ENABLE_CZ_DAC_COLOR {
+                self.cz_dac_color.process(fx_l, sr)
             } else {
-                fx_out
+                fx_l
             };
-            let soft_limited = soft_clip_tanh(colored, SOFT_CLIP_DRIVE);
-            *sample_out = soft_limited.clamp(-1.0, 1.0);
+            let colored_r = if ENABLE_CZ_DAC_COLOR {
+                self.cz_dac_color.process(fx_r, sr)
+            } else {
+                fx_r
+            };
+            frame[0] = soft_clip_tanh(colored_l, SOFT_CLIP_DRIVE).clamp(-1.0, 1.0);
+            frame[1] = soft_clip_tanh(colored_r, SOFT_CLIP_DRIVE).clamp(-1.0, 1.0);
         }
     }
 

--- a/packages/cosmo-synth-engine/src/processor/process.rs
+++ b/packages/cosmo-synth-engine/src/processor/process.rs
@@ -6,7 +6,7 @@ use alloc::sync::Arc;
 
 use crate::dsp_utils::{lfo_output_with_symmetry, random_hold_value};
 use crate::generators::{pre_resolve_controls, PER_LINE_HEADROOM};
-use crate::params::{ModDestination, ModMatrixCache, NUM_VOICES};
+use crate::params::{ModDestination, ModMatrixCache};
 use crate::voice::modulated_line_params;
 use crate::voice::ModSources;
 
@@ -73,7 +73,8 @@ impl CosmoProcessor {
         let headroom_makeup = (headroom_ratio)
             .powf(HEADROOM_MAKEUP_EXPONENT)
             .clamp(1.0, MAX_HEADROOM_MAKEUP);
-        let norm = volume * headroom_makeup / (NUM_VOICES as f32).sqrt();
+        let voice_count = self.voices.len();
+        let norm = volume * headroom_makeup / (voice_count as f32).sqrt();
         let matrix = &p.mod_matrix;
 
         let mut prev_lfo1 = self.last_runtime_mod_sources.lfo1;
@@ -188,7 +189,7 @@ impl CosmoProcessor {
             let aftertouch = self.aftertouch;
             let mut v = 0;
             if matches!(self.simd_backend, crate::simd::SimdBackend::Scalar) {
-                while v + 4 <= NUM_VOICES {
+                while v + 4 <= voice_count {
                     mixed += crate::voice::render_voice(
                         &mut self.voices[v],
                         params.as_ref(),
@@ -269,7 +270,7 @@ impl CosmoProcessor {
                 }
             } else {
                 let mut vector_acc = [0.0_f32; 4];
-                while v + 4 <= NUM_VOICES {
+                while v + 4 <= voice_count {
                     let voice_samples = [
                         crate::voice::render_voice(
                             &mut self.voices[v],
@@ -354,7 +355,7 @@ impl CosmoProcessor {
                 mixed += self.simd_backend.horizontal_sum4(vector_acc);
             }
 
-            while v < NUM_VOICES {
+            while v < voice_count {
                 mixed += crate::voice::render_voice(
                     &mut self.voices[v],
                     params.as_ref(),
@@ -414,7 +415,7 @@ impl CosmoProcessor {
         self.active_notes
             .last()
             .map(|entry| entry.voice_idx)
-            .filter(|voice_idx| *voice_idx < NUM_VOICES)
+            .filter(|voice_idx| *voice_idx < self.voices.len())
             .or_else(|| {
                 self.voices.iter().position(|voice| {
                     voice.note.is_some() && (!voice.is_silent || voice.mod_env.output > 0.0)

--- a/packages/cosmo-synth-engine/src/wasm.rs
+++ b/packages/cosmo-synth-engine/src/wasm.rs
@@ -167,9 +167,10 @@ impl CzSynthProcessor {
         }
     }
 
-    /// Fill `output` with mono samples rendered by the DSP engine.
+    /// Fill `output` with interleaved stereo samples `[L, R, L, R, ...]`.
     ///
-    /// The caller passes a `Float32Array` slice backed by WASM linear memory.
+    /// The caller passes a `Float32Array` slice backed by WASM linear memory
+    /// whose length must be even (one sample per channel per frame).
     /// The entire slice is filled; returns nothing — same as the JS worklet
     /// `process()` contract.
     #[wasm_bindgen]

--- a/packages/cz-explorer/public/czSynthWorklet.js
+++ b/packages/cz-explorer/public/czSynthWorklet.js
@@ -175,6 +175,7 @@ class CzSynthWorkletProcessor extends AudioWorkletProcessor {
 		this._params = JSON.parse(JSON.stringify(DEFAULT_PARAMS));
 		this._queue = []; // messages received before WASM is ready
 		this._supportedModDestinations = null;
+		this._interleaved = null;
 		this._performanceMonitorEnabled = false;
 		this._performanceMetrics = {
 			blockCount: 0,
@@ -580,22 +581,29 @@ class CzSynthWorkletProcessor extends AudioWorkletProcessor {
 
 		if (!this._synth) {
 			// Silence while WASM loads
-			ch0.fill(0);
-			if (outputs[0].length > 1) outputs[0][1].fill(0);
+			for (let ch = 0; ch < (outputs[0]?.length ?? 1); ch++) {
+				outputs[0][ch]?.fill(0);
+			}
 			return true;
+		}
+
+		const blockSize = ch0.length;
+		if (!this._interleaved || this._interleaved.length !== blockSize * 2) {
+			this._interleaved = new Float32Array(blockSize * 2);
 		}
 
 		const processStart = this._performanceMonitorEnabled ? this._nowMs() : 0;
 
-		// Fill the left channel buffer directly
-		this._synth.process(ch0);
+		this._synth.process(this._interleaved);
 		if (this._performanceMonitorEnabled) {
-			this._recordPerformanceBlock(this._nowMs() - processStart, ch0.length);
+			this._recordPerformanceBlock(this._nowMs() - processStart, blockSize);
 		}
 
-		// Copy to right channel if present
-		if (outputs[0].length > 1) {
-			outputs[0][1].set(ch0);
+		// De-interleave into L/R channel buffers
+		const ch1 = outputs[0].length > 1 ? outputs[0][1] : null;
+		for (let i = 0; i < blockSize; i++) {
+			ch0[i] = this._interleaved[i * 2];
+			if (ch1) ch1[i] = this._interleaved[i * 2 + 1];
 		}
 
 		return true;


### PR DESCRIPTION
## Summary

- Replace hardcoded `NUM_VOICES=8` constant with `voiceCount` field on `SynthParams` (range 4–16, default 8)
- Change `CosmoProcessor` voice array from fixed-size `[Voice; 8]` to `Vec<Voice>` with runtime resizing
- Replace `ArrayVec<_, 8>` with `Vec` for `active_notes` and `mono_stack` to support dynamic capacity
- All SIMD batch loops and voice iteration now use `self.voices.len()` instead of the old constant
- Add `voiceCount` to TypeScript `SynthParams` bindings and Zustand store (`setVoiceCount` with 4-16 clamping)
- `voiceCount` in Rust uses `#[serde(default = "default_voice_count")]` for backward compat with existing presets
- Processor resizes voice vector in `set_shared_params` when `voiceCount` changes (new voices added silent, excess voices removed with active_note cleanup)