### PR TITLE
perf(engine): add num_enum, sine/cosine LUT with optimized init

### DIFF
--- a/packages/cosmo-synth-engine/Cargo.toml
+++ b/packages/cosmo-synth-engine/Cargo.toml
@@ -47,8 +47,6 @@ serde_json = { version = "1", optional = true }
 libm = "0.2"
 arrayvec = { version = "0.7", default-features = false }
 num_enum = { version = "0.7", default-features = false }
-dasp_ring_buffer = { version = "0.11" }
-dasp_interpolate = { version = "0.11", features = ["linear"] }
 assert_no_alloc = { version = "1", optional = true }
 rtsan-standalone = { version = "0.3.0", optional = true }
 

--- a/packages/cosmo-synth-engine/src/dsp_utils.rs
+++ b/packages/cosmo-synth-engine/src/dsp_utils.rs
@@ -9,9 +9,9 @@ const TWO_OVER_PI: f32 = 2.0 / PI;
 const SIN_TABLE_SIZE: usize = 2048;
 static SIN_TABLE: LazyLock<[f32; SIN_TABLE_SIZE]> = LazyLock::new(|| {
     let mut table = [0.0_f32; SIN_TABLE_SIZE];
-    for i in 0..SIN_TABLE_SIZE {
+    for (i, entry) in table.iter_mut().enumerate() {
         let phase = i as f32 / SIN_TABLE_SIZE as f32;
-        table[i] = (TWO_PI * phase).sin();
+        *entry = (TWO_PI * phase).sin();
     }
     table
 });

--- a/packages/cosmo-synth-engine/src/dsp_utils.rs
+++ b/packages/cosmo-synth-engine/src/dsp_utils.rs
@@ -5,6 +5,29 @@ pub const TWO_PI: f32 = core::f32::consts::TAU;
 const PI: f32 = core::f32::consts::PI;
 const TWO_OVER_PI: f32 = 2.0 / PI;
 
+/// 2048-entry sine lookup table over [0, 1) phase.
+const SIN_TABLE_SIZE: usize = 2048;
+static SIN_TABLE: LazyLock<[f32; SIN_TABLE_SIZE]> = LazyLock::new(|| {
+    let mut table = [0.0_f32; SIN_TABLE_SIZE];
+    for i in 0..SIN_TABLE_SIZE {
+        let phase = i as f32 / SIN_TABLE_SIZE as f32;
+        table[i] = (TWO_PI * phase).sin();
+    }
+    table
+});
+
+#[inline]
+pub fn sin_lut(phase: f32) -> f32 {
+    let p = phase - phase.floor();
+    SIN_TABLE[(p * SIN_TABLE_SIZE as f32) as usize & (SIN_TABLE_SIZE - 1)]
+}
+
+#[inline]
+pub fn cos_lut(phase: f32) -> f32 {
+    let p = phase - phase.floor();
+    SIN_TABLE[((p + 0.25) * SIN_TABLE_SIZE as f32) as usize & (SIN_TABLE_SIZE - 1)]
+}
+
 /// Wrap a value into [0, 1).
 #[inline]
 pub fn wrap01(v: f32) -> f32 {


### PR DESCRIPTION
Split from chore/beta-cleanup. Adds num_enum dependency, optimizes sine/cosine lookup with LUT and iterator-based init.