### PR TITLE
chore(rust): migrate workspace to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "MIT"
 repository = "https://github.com/fpbrault/cosmo-pd"
 

--- a/packages/cosmo-pd101-plugin/Cargo.toml
+++ b/packages/cosmo-pd101-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmo-pd101-plugin"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Cosmo PD-101 synthesizer CLAP/VST3/VST2/LV2/AU/AAX plugin"
 
 [lib]

--- a/packages/cosmo-pd101-plugin/src/ffi.rs
+++ b/packages/cosmo-pd101-plugin/src/ffi.rs
@@ -518,14 +518,14 @@ fn engine_ref<'a>(
 unsafe fn output_slice_mut<'a, T>(
     output: *mut T,
     len: usize,
-) -> Result<&'a mut [T], CosmoPd101FfiStatus> {
+) -> Result<&'a mut [T], CosmoPd101FfiStatus> { unsafe {
     if output.is_null() && len > 0 {
         return Err(CosmoPd101FfiStatus::NullPointer);
     }
     Ok(slice::from_raw_parts_mut(output, len))
-}
+}}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_engine_create(
     sample_rate: f32,
     max_frames: usize,
@@ -541,14 +541,14 @@ pub extern "C" fn cosmo_pd101_ffi_engine_create(
 ///
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`] and must not have been destroyed yet.
-#[no_mangle]
-pub unsafe extern "C" fn cosmo_pd101_ffi_engine_destroy(engine: *mut CosmoPd101FfiEngine) {
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn cosmo_pd101_ffi_engine_destroy(engine: *mut CosmoPd101FfiEngine) { unsafe {
     if !engine.is_null() {
         drop(Box::from_raw(engine));
     }
-}
+}}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_reset_audio_state(
     engine: *mut CosmoPd101FfiEngine,
 ) -> CosmoPd101FfiStatus {
@@ -564,11 +564,11 @@ pub extern "C" fn cosmo_pd101_ffi_reset_audio_state(
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `json` must be a non-null,
 /// nul-terminated C string.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_set_params_json(
     engine: *mut CosmoPd101FfiEngine,
     json: *const c_char,
-) -> CosmoPd101FfiStatus {
+) -> CosmoPd101FfiStatus { unsafe {
     let Ok(engine) = engine_mut(engine) else {
         return CosmoPd101FfiStatus::NullPointer;
     };
@@ -584,19 +584,19 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_set_params_json(
     };
     engine.processor.set_params(params);
     CosmoPd101FfiStatus::Ok
-}
+}}
 
 /// # Safety
 ///
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `output` must be non-null and point to a
 /// buffer of at least `output_len` bytes when `output_len > 0`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_params_json(
     engine: *const CosmoPd101FfiEngine,
     output: *mut u8,
     output_len: usize,
-) -> usize {
+) -> usize { unsafe {
     let Ok(engine) = engine_ref(engine) else {
         return 0;
     };
@@ -613,9 +613,9 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_params_json(
     let bytes_to_write = bytes.len().min(output.len());
     output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
     bytes.len()
-}
+}}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_get_factory_preset_count() -> usize {
     factory_presets().len()
 }
@@ -624,12 +624,12 @@ pub extern "C" fn cosmo_pd101_ffi_get_factory_preset_count() -> usize {
 ///
 /// `output` must be non-null and point to a buffer of at least `output_len`
 /// bytes when `output_len > 0`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_factory_preset_name(
     index: usize,
     output: *mut u8,
     output_len: usize,
-) -> usize {
+) -> usize { unsafe {
     let Some(name) = factory_presets()
         .get(index)
         .map(|preset| preset.name.as_str())
@@ -646,18 +646,18 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_factory_preset_name(
     let bytes_to_write = bytes.len().min(output.len());
     output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
     bytes.len()
-}
+}}
 
 /// # Safety
 ///
 /// `output` must be non-null and point to a buffer of at least `output_len`
 /// bytes when `output_len > 0`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_factory_preset_params_json(
     index: usize,
     output: *mut u8,
     output_len: usize,
-) -> usize {
+) -> usize { unsafe {
     let Some(params_json) = factory_presets()
         .get(index)
         .map(|preset| &preset.params_json)
@@ -674,19 +674,19 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_factory_preset_params_json(
     let bytes_to_write = bytes.len().min(output.len());
     output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
     bytes.len()
-}
+}}
 
 /// # Safety
 ///
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `output` must be non-null and point to a
 /// buffer of at least `output_len` bytes when `output_len > 0`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_runtime_voice_states_json(
     engine: *const CosmoPd101FfiEngine,
     output: *mut u8,
     output_len: usize,
-) -> usize {
+) -> usize { unsafe {
     let Ok(engine) = engine_ref(engine) else {
         return 0;
     };
@@ -703,19 +703,19 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_runtime_voice_states_json(
     let bytes_to_write = bytes.len().min(output.len());
     output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
     bytes.len()
-}
+}}
 
 /// # Safety
 ///
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `output` must be non-null and point to a
 /// buffer of at least `output_len` bytes when `output_len > 0`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_runtime_mod_sources_json(
     engine: *const CosmoPd101FfiEngine,
     output: *mut u8,
     output_len: usize,
-) -> usize {
+) -> usize { unsafe {
     let Ok(engine) = engine_ref(engine) else {
         return 0;
     };
@@ -732,9 +732,9 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_runtime_mod_sources_json(
     let bytes_to_write = bytes.len().min(output.len());
     output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
     bytes.len()
-}
+}}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_get_parameter_count() -> usize {
     AUTOMATABLE_PARAMS.len()
 }
@@ -742,11 +742,11 @@ pub extern "C" fn cosmo_pd101_ffi_get_parameter_count() -> usize {
 /// # Safety
 ///
 /// `out_info` must be non-null and point to a valid `CosmoPd101FfiParamInfo`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_parameter_info(
     index: usize,
     out_info: *mut CosmoPd101FfiParamInfo,
-) -> CosmoPd101FfiStatus {
+) -> CosmoPd101FfiStatus { unsafe {
     if out_info.is_null() {
         return CosmoPd101FfiStatus::NullPointer;
     }
@@ -767,18 +767,18 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_parameter_info(
     write_c_char_array(&mut info.key, spec.key);
     write_c_char_array(&mut info.label, &meta_label_for_key(spec.key));
     CosmoPd101FfiStatus::Ok
-}
+}}
 
 /// # Safety
 ///
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `out_value` must be non-null.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_parameter_value(
     engine: *const CosmoPd101FfiEngine,
     id: u32,
     out_value: *mut f32,
-) -> CosmoPd101FfiStatus {
+) -> CosmoPd101FfiStatus { unsafe {
     let Ok(engine) = engine_ref(engine) else {
         return CosmoPd101FfiStatus::NullPointer;
     };
@@ -793,9 +793,9 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_parameter_value(
     };
     *out_value = value;
     CosmoPd101FfiStatus::Ok
-}
+}}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_set_parameter_value(
     engine: *mut CosmoPd101FfiEngine,
     id: u32,
@@ -819,7 +819,7 @@ pub extern "C" fn cosmo_pd101_ffi_set_parameter_value(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_note_on(
     engine: *mut CosmoPd101FfiEngine,
     note: u8,
@@ -840,7 +840,7 @@ pub extern "C" fn cosmo_pd101_ffi_note_on(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_note_off(
     engine: *mut CosmoPd101FfiEngine,
     note: u8,
@@ -852,7 +852,7 @@ pub extern "C" fn cosmo_pd101_ffi_note_off(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_all_notes_off(
     engine: *mut CosmoPd101FfiEngine,
 ) -> CosmoPd101FfiStatus {
@@ -866,7 +866,7 @@ pub extern "C" fn cosmo_pd101_ffi_all_notes_off(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_set_sustain(
     engine: *mut CosmoPd101FfiEngine,
     on: bool,
@@ -878,7 +878,7 @@ pub extern "C" fn cosmo_pd101_ffi_set_sustain(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_set_pitch_bend(
     engine: *mut CosmoPd101FfiEngine,
     value: f32,
@@ -890,7 +890,7 @@ pub extern "C" fn cosmo_pd101_ffi_set_pitch_bend(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_set_mod_wheel(
     engine: *mut CosmoPd101FfiEngine,
     value: f32,
@@ -902,7 +902,7 @@ pub extern "C" fn cosmo_pd101_ffi_set_mod_wheel(
     CosmoPd101FfiStatus::Ok
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_set_aftertouch(
     engine: *mut CosmoPd101FfiEngine,
     value: f32,
@@ -919,12 +919,12 @@ pub extern "C" fn cosmo_pd101_ffi_set_aftertouch(
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `output` must be non-null and point to a
 /// buffer of at least `frames` floats.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_render_mono(
     engine: *mut CosmoPd101FfiEngine,
     output: *mut f32,
     frames: usize,
-) -> CosmoPd101FfiStatus {
+) -> CosmoPd101FfiStatus { unsafe {
     let Ok(engine) = engine_mut(engine) else {
         return CosmoPd101FfiStatus::NullPointer;
     };
@@ -937,20 +937,20 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_render_mono(
     }
     output.copy_from_slice(&engine.scratch[..frames]);
     CosmoPd101FfiStatus::Ok
-}
+}}
 
 /// # Safety
 ///
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`]. `output_left` and `output_right` must be
 /// non-null and each point to a buffer of at least `frames` floats.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_render_stereo(
     engine: *mut CosmoPd101FfiEngine,
     output_left: *mut f32,
     output_right: *mut f32,
     frames: usize,
-) -> CosmoPd101FfiStatus {
+) -> CosmoPd101FfiStatus { unsafe {
     let Ok(engine) = engine_mut(engine) else {
         return CosmoPd101FfiStatus::NullPointer;
     };
@@ -967,7 +967,7 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_render_stereo(
     left.copy_from_slice(&engine.scratch[..frames]);
     right.copy_from_slice(&engine.scratch[..frames]);
     CosmoPd101FfiStatus::Ok
-}
+}}
 
 /// # Safety
 ///
@@ -975,14 +975,14 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_render_stereo(
 /// [`cosmo_pd101_ffi_engine_create`]. `output` must be non-null and point to a
 /// buffer of at least `output_len` i8s when `output_len > 0`.
 /// `out_sample_rate` and `out_hz` may be null.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_i8(
     engine: *const CosmoPd101FfiEngine,
     output: *mut i8,
     output_len: usize,
     out_sample_rate: *mut f32,
     out_hz: *mut f32,
-) -> usize {
+) -> usize { unsafe {
     let Ok(engine) = engine_ref(engine) else {
         return 0;
     };
@@ -999,7 +999,7 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_i8(
         return 0;
     };
     engine.scope.copy_linear_i8(output).unwrap_or(0)
-}
+}}
 
 /// # Safety
 ///
@@ -1007,14 +1007,14 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_i8(
 /// [`cosmo_pd101_ffi_engine_create`]. `output` must be non-null and point to a
 /// buffer of at least `output_len` f32s when `output_len > 0`.
 /// `out_sample_rate` and `out_hz` may be null.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_f32(
     engine: *const CosmoPd101FfiEngine,
     output: *mut f32,
     output_len: usize,
     out_sample_rate: *mut f32,
     out_hz: *mut f32,
-) -> usize {
+) -> usize { unsafe {
     let Ok(engine) = engine_ref(engine) else {
         return 0;
     };
@@ -1031,7 +1031,7 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_f32(
         return 0;
     };
     engine.scope.copy_linear_f32(output).unwrap_or(0)
-}
+}}
 
 #[cfg(test)]
 mod tests {

--- a/packages/cosmo-pd101-plugin/src/ffi.rs
+++ b/packages/cosmo-pd101-plugin/src/ffi.rs
@@ -5,9 +5,9 @@ use std::slice;
 use std::sync::OnceLock;
 
 use cosmo_synth_engine::params::{
-    engine_param_default_v1, engine_param_ui_meta_v1, EngineParamReadoutFormatV1, SynthParams,
+    EngineParamReadoutFormatV1, SynthParams, engine_param_default_v1, engine_param_ui_meta_v1,
 };
-use cosmo_synth_engine::processor::{midi_note_to_freq, CosmoProcessor};
+use cosmo_synth_engine::processor::{CosmoProcessor, midi_note_to_freq};
 
 const SCOPE_CAPACITY: usize = 4096;
 const PARAM_KEY_CAPACITY: usize = 64;
@@ -518,12 +518,14 @@ fn engine_ref<'a>(
 unsafe fn output_slice_mut<'a, T>(
     output: *mut T,
     len: usize,
-) -> Result<&'a mut [T], CosmoPd101FfiStatus> { unsafe {
-    if output.is_null() && len > 0 {
-        return Err(CosmoPd101FfiStatus::NullPointer);
+) -> Result<&'a mut [T], CosmoPd101FfiStatus> {
+    unsafe {
+        if output.is_null() && len > 0 {
+            return Err(CosmoPd101FfiStatus::NullPointer);
+        }
+        Ok(slice::from_raw_parts_mut(output, len))
     }
-    Ok(slice::from_raw_parts_mut(output, len))
-}}
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_engine_create(
@@ -542,11 +544,13 @@ pub extern "C" fn cosmo_pd101_ffi_engine_create(
 /// `engine` must be a valid, non-null pointer returned by
 /// [`cosmo_pd101_ffi_engine_create`] and must not have been destroyed yet.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn cosmo_pd101_ffi_engine_destroy(engine: *mut CosmoPd101FfiEngine) { unsafe {
-    if !engine.is_null() {
-        drop(Box::from_raw(engine));
+pub unsafe extern "C" fn cosmo_pd101_ffi_engine_destroy(engine: *mut CosmoPd101FfiEngine) {
+    unsafe {
+        if !engine.is_null() {
+            drop(Box::from_raw(engine));
+        }
     }
-}}
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_reset_audio_state(
@@ -568,23 +572,25 @@ pub extern "C" fn cosmo_pd101_ffi_reset_audio_state(
 pub unsafe extern "C" fn cosmo_pd101_ffi_set_params_json(
     engine: *mut CosmoPd101FfiEngine,
     json: *const c_char,
-) -> CosmoPd101FfiStatus { unsafe {
-    let Ok(engine) = engine_mut(engine) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    if json.is_null() {
-        return CosmoPd101FfiStatus::NullPointer;
-    }
+) -> CosmoPd101FfiStatus {
+    unsafe {
+        let Ok(engine) = engine_mut(engine) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        if json.is_null() {
+            return CosmoPd101FfiStatus::NullPointer;
+        }
 
-    let Ok(json) = CStr::from_ptr(json).to_str() else {
-        return CosmoPd101FfiStatus::InvalidArgument;
-    };
-    let Ok(params) = serde_json::from_str::<SynthParams>(json) else {
-        return CosmoPd101FfiStatus::JsonError;
-    };
-    engine.processor.set_params(params);
-    CosmoPd101FfiStatus::Ok
-}}
+        let Ok(json) = CStr::from_ptr(json).to_str() else {
+            return CosmoPd101FfiStatus::InvalidArgument;
+        };
+        let Ok(params) = serde_json::from_str::<SynthParams>(json) else {
+            return CosmoPd101FfiStatus::JsonError;
+        };
+        engine.processor.set_params(params);
+        CosmoPd101FfiStatus::Ok
+    }
+}
 
 /// # Safety
 ///
@@ -596,24 +602,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_params_json(
     engine: *const CosmoPd101FfiEngine,
     output: *mut u8,
     output_len: usize,
-) -> usize { unsafe {
-    let Ok(engine) = engine_ref(engine) else {
-        return 0;
-    };
-    let Ok(json) = serde_json::to_string(engine.processor.params.as_ref()) else {
-        return 0;
-    };
-    let bytes = json.as_bytes();
-    if output.is_null() || output_len == 0 {
-        return bytes.len();
+) -> usize {
+    unsafe {
+        let Ok(engine) = engine_ref(engine) else {
+            return 0;
+        };
+        let Ok(json) = serde_json::to_string(engine.processor.params.as_ref()) else {
+            return 0;
+        };
+        let bytes = json.as_bytes();
+        if output.is_null() || output_len == 0 {
+            return bytes.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        let bytes_to_write = bytes.len().min(output.len());
+        output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
+        bytes.len()
     }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    let bytes_to_write = bytes.len().min(output.len());
-    output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
-    bytes.len()
-}}
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_get_factory_preset_count() -> usize {
@@ -629,24 +637,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_factory_preset_name(
     index: usize,
     output: *mut u8,
     output_len: usize,
-) -> usize { unsafe {
-    let Some(name) = factory_presets()
-        .get(index)
-        .map(|preset| preset.name.as_str())
-    else {
-        return 0;
-    };
-    let bytes = name.as_bytes();
-    if output.is_null() || output_len == 0 {
-        return bytes.len();
+) -> usize {
+    unsafe {
+        let Some(name) = factory_presets()
+            .get(index)
+            .map(|preset| preset.name.as_str())
+        else {
+            return 0;
+        };
+        let bytes = name.as_bytes();
+        if output.is_null() || output_len == 0 {
+            return bytes.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        let bytes_to_write = bytes.len().min(output.len());
+        output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
+        bytes.len()
     }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    let bytes_to_write = bytes.len().min(output.len());
-    output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
-    bytes.len()
-}}
+}
 
 /// # Safety
 ///
@@ -657,24 +667,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_factory_preset_params_json(
     index: usize,
     output: *mut u8,
     output_len: usize,
-) -> usize { unsafe {
-    let Some(params_json) = factory_presets()
-        .get(index)
-        .map(|preset| &preset.params_json)
-    else {
-        return 0;
-    };
-    let bytes = params_json.as_bytes();
-    if output.is_null() || output_len == 0 {
-        return bytes.len();
+) -> usize {
+    unsafe {
+        let Some(params_json) = factory_presets()
+            .get(index)
+            .map(|preset| &preset.params_json)
+        else {
+            return 0;
+        };
+        let bytes = params_json.as_bytes();
+        if output.is_null() || output_len == 0 {
+            return bytes.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        let bytes_to_write = bytes.len().min(output.len());
+        output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
+        bytes.len()
     }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    let bytes_to_write = bytes.len().min(output.len());
-    output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
-    bytes.len()
-}}
+}
 
 /// # Safety
 ///
@@ -686,24 +698,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_runtime_voice_states_json(
     engine: *const CosmoPd101FfiEngine,
     output: *mut u8,
     output_len: usize,
-) -> usize { unsafe {
-    let Ok(engine) = engine_ref(engine) else {
-        return 0;
-    };
-    let Ok(json) = serde_json::to_string(&engine.processor.runtime_voice_debug_state()) else {
-        return 0;
-    };
-    let bytes = json.as_bytes();
-    if output.is_null() || output_len == 0 {
-        return bytes.len();
+) -> usize {
+    unsafe {
+        let Ok(engine) = engine_ref(engine) else {
+            return 0;
+        };
+        let Ok(json) = serde_json::to_string(&engine.processor.runtime_voice_debug_state()) else {
+            return 0;
+        };
+        let bytes = json.as_bytes();
+        if output.is_null() || output_len == 0 {
+            return bytes.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        let bytes_to_write = bytes.len().min(output.len());
+        output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
+        bytes.len()
     }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    let bytes_to_write = bytes.len().min(output.len());
-    output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
-    bytes.len()
-}}
+}
 
 /// # Safety
 ///
@@ -715,24 +729,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_runtime_mod_sources_json(
     engine: *const CosmoPd101FfiEngine,
     output: *mut u8,
     output_len: usize,
-) -> usize { unsafe {
-    let Ok(engine) = engine_ref(engine) else {
-        return 0;
-    };
-    let Ok(json) = serde_json::to_string(&engine.processor.runtime_mod_sources()) else {
-        return 0;
-    };
-    let bytes = json.as_bytes();
-    if output.is_null() || output_len == 0 {
-        return bytes.len();
+) -> usize {
+    unsafe {
+        let Ok(engine) = engine_ref(engine) else {
+            return 0;
+        };
+        let Ok(json) = serde_json::to_string(&engine.processor.runtime_mod_sources()) else {
+            return 0;
+        };
+        let bytes = json.as_bytes();
+        if output.is_null() || output_len == 0 {
+            return bytes.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        let bytes_to_write = bytes.len().min(output.len());
+        output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
+        bytes.len()
     }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    let bytes_to_write = bytes.len().min(output.len());
-    output[..bytes_to_write].copy_from_slice(&bytes[..bytes_to_write]);
-    bytes.len()
-}}
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_get_parameter_count() -> usize {
@@ -746,28 +762,30 @@ pub extern "C" fn cosmo_pd101_ffi_get_parameter_count() -> usize {
 pub unsafe extern "C" fn cosmo_pd101_ffi_get_parameter_info(
     index: usize,
     out_info: *mut CosmoPd101FfiParamInfo,
-) -> CosmoPd101FfiStatus { unsafe {
-    if out_info.is_null() {
-        return CosmoPd101FfiStatus::NullPointer;
-    }
-    let Some(spec) = automatable_param_by_index(index) else {
-        return CosmoPd101FfiStatus::InvalidArgument;
-    };
+) -> CosmoPd101FfiStatus {
+    unsafe {
+        if out_info.is_null() {
+            return CosmoPd101FfiStatus::NullPointer;
+        }
+        let Some(spec) = automatable_param_by_index(index) else {
+            return CosmoPd101FfiStatus::InvalidArgument;
+        };
 
-    let info = &mut *out_info;
-    *info = CosmoPd101FfiParamInfo::default();
-    info.id = spec.id;
-    info.default_value = engine_param_default_v1(spec.key).unwrap_or(spec.min);
-    info.min_value = spec.min;
-    info.max_value = spec.max;
-    info.flags = PARAM_FLAG_AUTOMATABLE;
-    if is_stepped_key(spec.key) {
-        info.flags |= 1 << 1;
+        let info = &mut *out_info;
+        *info = CosmoPd101FfiParamInfo::default();
+        info.id = spec.id;
+        info.default_value = engine_param_default_v1(spec.key).unwrap_or(spec.min);
+        info.min_value = spec.min;
+        info.max_value = spec.max;
+        info.flags = PARAM_FLAG_AUTOMATABLE;
+        if is_stepped_key(spec.key) {
+            info.flags |= 1 << 1;
+        }
+        write_c_char_array(&mut info.key, spec.key);
+        write_c_char_array(&mut info.label, &meta_label_for_key(spec.key));
+        CosmoPd101FfiStatus::Ok
     }
-    write_c_char_array(&mut info.key, spec.key);
-    write_c_char_array(&mut info.label, &meta_label_for_key(spec.key));
-    CosmoPd101FfiStatus::Ok
-}}
+}
 
 /// # Safety
 ///
@@ -778,22 +796,24 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_get_parameter_value(
     engine: *const CosmoPd101FfiEngine,
     id: u32,
     out_value: *mut f32,
-) -> CosmoPd101FfiStatus { unsafe {
-    let Ok(engine) = engine_ref(engine) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    if out_value.is_null() {
-        return CosmoPd101FfiStatus::NullPointer;
+) -> CosmoPd101FfiStatus {
+    unsafe {
+        let Ok(engine) = engine_ref(engine) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        if out_value.is_null() {
+            return CosmoPd101FfiStatus::NullPointer;
+        }
+        let Some(spec) = automatable_param_by_id(id) else {
+            return CosmoPd101FfiStatus::InvalidArgument;
+        };
+        let Some(value) = parameter_value(&engine.processor.params, spec.key) else {
+            return CosmoPd101FfiStatus::InvalidArgument;
+        };
+        *out_value = value;
+        CosmoPd101FfiStatus::Ok
     }
-    let Some(spec) = automatable_param_by_id(id) else {
-        return CosmoPd101FfiStatus::InvalidArgument;
-    };
-    let Some(value) = parameter_value(&engine.processor.params, spec.key) else {
-        return CosmoPd101FfiStatus::InvalidArgument;
-    };
-    *out_value = value;
-    CosmoPd101FfiStatus::Ok
-}}
+}
 
 #[unsafe(no_mangle)]
 pub extern "C" fn cosmo_pd101_ffi_set_parameter_value(
@@ -924,20 +944,22 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_render_mono(
     engine: *mut CosmoPd101FfiEngine,
     output: *mut f32,
     frames: usize,
-) -> CosmoPd101FfiStatus { unsafe {
-    let Ok(engine) = engine_mut(engine) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    let Ok(output) = output_slice_mut(output, frames) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    let status = engine.render_to_scratch(frames);
-    if status != CosmoPd101FfiStatus::Ok {
-        return status;
+) -> CosmoPd101FfiStatus {
+    unsafe {
+        let Ok(engine) = engine_mut(engine) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        let Ok(output) = output_slice_mut(output, frames) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        let status = engine.render_to_scratch(frames);
+        if status != CosmoPd101FfiStatus::Ok {
+            return status;
+        }
+        output.copy_from_slice(&engine.scratch[..frames]);
+        CosmoPd101FfiStatus::Ok
     }
-    output.copy_from_slice(&engine.scratch[..frames]);
-    CosmoPd101FfiStatus::Ok
-}}
+}
 
 /// # Safety
 ///
@@ -950,24 +972,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_render_stereo(
     output_left: *mut f32,
     output_right: *mut f32,
     frames: usize,
-) -> CosmoPd101FfiStatus { unsafe {
-    let Ok(engine) = engine_mut(engine) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    let Ok(left) = output_slice_mut(output_left, frames) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    let Ok(right) = output_slice_mut(output_right, frames) else {
-        return CosmoPd101FfiStatus::NullPointer;
-    };
-    let status = engine.render_to_scratch(frames);
-    if status != CosmoPd101FfiStatus::Ok {
-        return status;
+) -> CosmoPd101FfiStatus {
+    unsafe {
+        let Ok(engine) = engine_mut(engine) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        let Ok(left) = output_slice_mut(output_left, frames) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        let Ok(right) = output_slice_mut(output_right, frames) else {
+            return CosmoPd101FfiStatus::NullPointer;
+        };
+        let status = engine.render_to_scratch(frames);
+        if status != CosmoPd101FfiStatus::Ok {
+            return status;
+        }
+        left.copy_from_slice(&engine.scratch[..frames]);
+        right.copy_from_slice(&engine.scratch[..frames]);
+        CosmoPd101FfiStatus::Ok
     }
-    left.copy_from_slice(&engine.scratch[..frames]);
-    right.copy_from_slice(&engine.scratch[..frames]);
-    CosmoPd101FfiStatus::Ok
-}}
+}
 
 /// # Safety
 ///
@@ -982,24 +1006,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_i8(
     output_len: usize,
     out_sample_rate: *mut f32,
     out_hz: *mut f32,
-) -> usize { unsafe {
-    let Ok(engine) = engine_ref(engine) else {
-        return 0;
-    };
-    if !out_sample_rate.is_null() {
-        *out_sample_rate = engine.scope.sample_rate;
+) -> usize {
+    unsafe {
+        let Ok(engine) = engine_ref(engine) else {
+            return 0;
+        };
+        if !out_sample_rate.is_null() {
+            *out_sample_rate = engine.scope.sample_rate;
+        }
+        if !out_hz.is_null() {
+            *out_hz = engine.scope.hz;
+        }
+        if output.is_null() || output_len == 0 {
+            return engine.scope.samples.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        engine.scope.copy_linear_i8(output).unwrap_or(0)
     }
-    if !out_hz.is_null() {
-        *out_hz = engine.scope.hz;
-    }
-    if output.is_null() || output_len == 0 {
-        return engine.scope.samples.len();
-    }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    engine.scope.copy_linear_i8(output).unwrap_or(0)
-}}
+}
 
 /// # Safety
 ///
@@ -1014,24 +1040,26 @@ pub unsafe extern "C" fn cosmo_pd101_ffi_copy_scope_f32(
     output_len: usize,
     out_sample_rate: *mut f32,
     out_hz: *mut f32,
-) -> usize { unsafe {
-    let Ok(engine) = engine_ref(engine) else {
-        return 0;
-    };
-    if !out_sample_rate.is_null() {
-        *out_sample_rate = engine.scope.sample_rate;
+) -> usize {
+    unsafe {
+        let Ok(engine) = engine_ref(engine) else {
+            return 0;
+        };
+        if !out_sample_rate.is_null() {
+            *out_sample_rate = engine.scope.sample_rate;
+        }
+        if !out_hz.is_null() {
+            *out_hz = engine.scope.hz;
+        }
+        if output.is_null() || output_len == 0 {
+            return engine.scope.samples.len();
+        }
+        let Ok(output) = output_slice_mut(output, output_len) else {
+            return 0;
+        };
+        engine.scope.copy_linear_f32(output).unwrap_or(0)
     }
-    if !out_hz.is_null() {
-        *out_hz = engine.scope.hz;
-    }
-    if output.is_null() || output_len == 0 {
-        return engine.scope.samples.len();
-    }
-    let Ok(output) = output_slice_mut(output, output_len) else {
-        return 0;
-    };
-    engine.scope.copy_linear_f32(output).unwrap_or(0)
-}}
+}
 
 #[cfg(test)]
 mod tests {

--- a/packages/cosmo-pd101-plugin/src/gui.rs
+++ b/packages/cosmo-pd101-plugin/src/gui.rs
@@ -17,18 +17,18 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
-use truce_core::editor::{Editor, RawWindowHandle};
 use truce_core::PluginContext;
+use truce_core::editor::{Editor, RawWindowHandle};
 #[cfg(target_os = "macos")]
 use wry::WebViewBuilder;
 #[cfg(target_os = "macos")]
 use wry::WebViewBuilderExtDarwin;
 
+use crate::CzPluginParams;
 #[cfg(target_os = "macos")]
 use crate::handle_ipc_invoke;
-use crate::CzPluginParams;
 use crate::{
-    append_log, PerformanceCountersHandle, ScopeBuffer, SharedRuntimeModSources, UiInputQueue,
+    PerformanceCountersHandle, ScopeBuffer, SharedRuntimeModSources, UiInputQueue, append_log,
 };
 use cosmo_synth_engine::params::SynthParams;
 
@@ -221,10 +221,10 @@ impl CzEditor {
         let script = format!(
             "if(typeof window.__czOnParams === 'function') {{ window.__czOnParams(\"{escaped}\"); }}"
         );
-        if let Ok(container) = self.webview_state.lock() {
-            if let Some(wv) = &container.webview {
-                let _ = wv.evaluate_script(&script);
-            }
+        if let Ok(container) = self.webview_state.lock()
+            && let Some(wv) = &container.webview
+        {
+            let _ = wv.evaluate_script(&script);
         }
     }
 
@@ -245,10 +245,10 @@ impl CzEditor {
             "if (document?.documentElement) {{ document.documentElement.style.zoom = '{zoom}'; }}"
         );
 
-        if let Ok(container) = self.webview_state.lock() {
-            if let Some(wv) = &container.webview {
-                let _ = wv.evaluate_script(&script);
-            }
+        if let Ok(container) = self.webview_state.lock()
+            && let Some(wv) = &container.webview
+        {
+            let _ = wv.evaluate_script(&script);
         }
     }
 }
@@ -312,13 +312,13 @@ impl Editor for CzEditor {
         }
 
         #[cfg(target_os = "macos")]
-        if !self.has_live_webview() {
-            if let Some(ns_view) = self.pending_parent_ns_view {
-                let ns_view = ns_view as *mut std::ffi::c_void;
-                if unsafe { parent_has_window(ns_view) } {
-                    append_log("idle: retrying deferred WebView creation");
-                    let _ = self.try_create_webview(ns_view);
-                }
+        if !self.has_live_webview()
+            && let Some(ns_view) = self.pending_parent_ns_view
+        {
+            let ns_view = ns_view as *mut std::ffi::c_void;
+            if unsafe { parent_has_window(ns_view) } {
+                append_log("idle: retrying deferred WebView creation");
+                let _ = self.try_create_webview(ns_view);
             }
         }
 
@@ -344,12 +344,12 @@ fn screenshot_webview() -> Option<(Vec<u8>, u32, u32)> {
 /// and return RGBA pixel data. Must be called on the main thread.
 #[cfg(target_os = "macos")]
 fn screenshot_webview_impl() -> Option<(Vec<u8>, u32, u32)> {
-    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use block2::RcBlock;
     use objc2::rc::{Allocated, Retained};
-    use objc2::{class, msg_send, msg_send_id, AnyThread};
+    use objc2::{AnyThread, class, msg_send, msg_send_id};
     use objc2_app_kit::{
         NSBackingStoreType, NSBitmapImageRep, NSImage, NSWindow, NSWindowStyleMask,
     };
@@ -426,7 +426,8 @@ fn screenshot_webview_impl() -> Option<(Vec<u8>, u32, u32)> {
                 };
                 let header = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: {}\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n",
-                    mime, data.len()
+                    mime,
+                    data.len()
                 );
                 let _ = stream.write_all(header.as_bytes());
                 let _ = stream.write_all(&data);
@@ -531,8 +532,7 @@ fn screenshot_webview_impl() -> Option<(Vec<u8>, u32, u32)> {
         rl.runUntilDate(&d);
     }
 
-    let pixels = result.lock().unwrap().take();
-    pixels
+    result.lock().unwrap().take()
 }
 
 // ─── Standalone Window helper ─────────────────────────────────────────────────
@@ -547,8 +547,7 @@ struct StandaloneWindow {
 #[cfg(target_os = "macos")]
 fn terminate_delegate_class() -> &'static objc::runtime::Class {
     use objc::{class, declare::ClassDecl, msg_send, sel, sel_impl};
-    static CLASS: std::sync::OnceLock<&'static objc::runtime::Class> =
-        std::sync::OnceLock::new();
+    static CLASS: std::sync::OnceLock<&'static objc::runtime::Class> = std::sync::OnceLock::new();
     CLASS.get_or_init(|| {
         let mut decl = ClassDecl::new("StandaloneWindowCloseDelegate", class!(NSObject))
             .expect("failed to create delegate class");
@@ -578,7 +577,7 @@ fn terminate_delegate_class() -> &'static objc::runtime::Class {
             decl.register()
         }
     });
-    *CLASS.get().unwrap()
+    CLASS.get().unwrap()
 }
 
 #[cfg(target_os = "macos")]
@@ -726,37 +725,38 @@ unsafe fn build_webview_from_ns_view(
     params: Arc<CzPluginParams>,
     runtime_mod_sources: SharedRuntimeModSources,
     webview_state: Arc<Mutex<WebViewContainer>>,
-) -> (Option<wry::WebView>, Option<StandaloneWindow>) { unsafe {
-    use core::ptr::NonNull;
-    use rwh_06::{
-        AppKitDisplayHandle, AppKitWindowHandle, DisplayHandle, HandleError, HasDisplayHandle,
-        HasWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle,
-    };
-    use wry::dpi;
+) -> (Option<wry::WebView>, Option<StandaloneWindow>) {
+    unsafe {
+        use core::ptr::NonNull;
+        use rwh_06::{
+            AppKitDisplayHandle, AppKitWindowHandle, DisplayHandle, HandleError, HasDisplayHandle,
+            HasWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle,
+        };
+        use wry::dpi;
 
-    struct NsViewWrapper(pub *mut std::ffi::c_void);
-    impl HasWindowHandle for NsViewWrapper {
-        fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
-            let non_null = NonNull::new(self.0).expect("ns_view pointer is null");
-            let handle = AppKitWindowHandle::new(non_null);
-            Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle)) })
+        struct NsViewWrapper(pub *mut std::ffi::c_void);
+        impl HasWindowHandle for NsViewWrapper {
+            fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+                let non_null = NonNull::new(self.0).expect("ns_view pointer is null");
+                let handle = AppKitWindowHandle::new(non_null);
+                Ok(unsafe { WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle)) })
+            }
         }
-    }
-    impl HasDisplayHandle for NsViewWrapper {
-        fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
-            let handle = AppKitDisplayHandle::new();
-            Ok(unsafe { DisplayHandle::borrow_raw(RawDisplayHandle::AppKit(handle)) })
+        impl HasDisplayHandle for NsViewWrapper {
+            fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+                let handle = AppKitDisplayHandle::new();
+                Ok(unsafe { DisplayHandle::borrow_raw(RawDisplayHandle::AppKit(handle)) })
+            }
         }
-    }
-    unsafe impl Send for NsViewWrapper {}
-    unsafe impl Sync for NsViewWrapper {}
+        unsafe impl Send for NsViewWrapper {}
+        unsafe impl Sync for NsViewWrapper {}
 
-    let webview_state_for_response = webview_state.clone();
-    let params_repush_done = Arc::new(AtomicBool::new(false));
+        let webview_state_for_response = webview_state.clone();
+        let params_repush_done = Arc::new(AtomicBool::new(false));
 
-    let scheme = get_instance_scheme();
-    append_log(&format!("webview scheme: {scheme}"));
-    let builder = WebViewBuilder::new()
+        let scheme = get_instance_scheme();
+        append_log(&format!("webview scheme: {scheme}"));
+        let builder = WebViewBuilder::new()
         .with_bounds(wry::Rect {
             position: dpi::LogicalPosition::new(0, 0).into(),
             size: dpi::LogicalSize::new(DEFAULT_WIDTH, DEFAULT_HEIGHT).into(),
@@ -800,24 +800,22 @@ unsafe fn build_webview_from_ns_view(
                     "window.__czIpcResponse && window.__czIpcResponse({})",
                     response
                 );
-                if let Ok(container) = webview_state_for_response.lock() {
-                    if let Some(wv) = &container.webview {
-                        let _ = wv.evaluate_script(&script);
+                if let Ok(container) = webview_state_for_response.lock() && let Some(wv) = &container.webview {
+                    let _ = wv.evaluate_script(&script);
 
-                        if params_repush_done
-                            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                            .is_ok()
-                        {
-                            let sp = synth_params.load();
-                            if let Ok(json_str) = serde_json::to_string(sp.as_ref()) {
-                                let escaped = json_str
-                                    .replace('\\', "\\\\")
-                                    .replace('"', "\\\"");
-                                let params_script = format!(
-                                    "if(typeof window.__czOnParams === 'function') {{ window.__czOnParams(\"{escaped}\"); }}"
-                                );
-                                let _ = wv.evaluate_script(&params_script);
-                            }
+                    if params_repush_done
+                        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                    {
+                        let sp = synth_params.load();
+                        if let Ok(json_str) = serde_json::to_string(sp.as_ref()) {
+                            let escaped = json_str
+                                .replace('\\', "\\\\")
+                                .replace('"', "\\\"");
+                            let params_script = format!(
+                                "if(typeof window.__czOnParams === 'function') {{ window.__czOnParams(\"{escaped}\"); }}"
+                            );
+                            let _ = wv.evaluate_script(&params_script);
                         }
                     }
                 }
@@ -825,60 +823,63 @@ unsafe fn build_webview_from_ns_view(
         })
         .with_devtools(inspector_enabled());
 
-    // ── DECISION POINT ──
-    if parent_has_window(ns_view) {
-        // BRANCH A: ns_view already has an associated NSWindow (DAW mode).
-        // Embed webview as child of the existing window.
-        append_log("parent NSView has a real window — embedding as child");
-        let parent = NsViewWrapper(ns_view);
-        let webview = builder
-            .with_url(format!("{}://localhost/", scheme))
-            .build_as_child(&parent);
-        match webview {
-            Ok(webview) => {
-                append_log("build_as_child returned — WebView created");
-                (Some(webview), None)
+        // ── DECISION POINT ──
+        if parent_has_window(ns_view) {
+            // BRANCH A: ns_view already has an associated NSWindow (DAW mode).
+            // Embed webview as child of the existing window.
+            append_log("parent NSView has a real window — embedding as child");
+            let parent = NsViewWrapper(ns_view);
+            let webview = builder
+                .with_url(format!("{}://localhost/", scheme))
+                .build_as_child(&parent);
+            match webview {
+                Ok(webview) => {
+                    append_log("build_as_child returned — WebView created");
+                    (Some(webview), None)
+                }
+                Err(e) => {
+                    append_log(&format!("failed to create plugin WebView: {e}"));
+                    (None, None)
+                }
             }
-            Err(e) => {
-                append_log(&format!("failed to create plugin WebView: {e}"));
-                (None, None)
-            }
-        }
-    } else if is_standalone_mode() {
-        // BRANCH B: standalone binary — create our own window (hides baseview
-        // window from truce-standalone) and embed the WebView inside it.
-        append_log("standalone mode — creating standalone NSWindow");
-        let standalone_window = StandaloneWindow::new();
-        let content_view = standalone_window.content_view();
+        } else if is_standalone_mode() {
+            // BRANCH B: standalone binary — create our own window (hides baseview
+            // window from truce-standalone) and embed the WebView inside it.
+            append_log("standalone mode — creating standalone NSWindow");
+            let standalone_window = StandaloneWindow::new();
+            let content_view = standalone_window.content_view();
 
-        // Allow a tick for the NSView/NSWindow association to settle.
-        let mut attempts = 0;
-        while !parent_has_window(content_view) && attempts < 10 {
-            std::thread::sleep(std::time::Duration::from_millis(10));
-            attempts += 1;
-        }
+            // Allow a tick for the NSView/NSWindow association to settle.
+            let mut attempts = 0;
+            while !parent_has_window(content_view) && attempts < 10 {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                attempts += 1;
+            }
 
-        let parent = NsViewWrapper(content_view);
-        let webview = builder
-            .with_url(format!("{}://localhost/", scheme))
-            .build_as_child(&parent);
-        match webview {
-            Ok(webview) => {
-                append_log("standalone: WebView created in own window");
-                (Some(webview), Some(standalone_window))
+            let parent = NsViewWrapper(content_view);
+            let webview = builder
+                .with_url(format!("{}://localhost/", scheme))
+                .build_as_child(&parent);
+            match webview {
+                Ok(webview) => {
+                    append_log("standalone: WebView created in own window");
+                    (Some(webview), Some(standalone_window))
+                }
+                Err(e) => {
+                    append_log(&format!("standalone: failed to create plugin WebView: {e}"));
+                    (None, None)
+                }
             }
-            Err(e) => {
-                append_log(&format!("standalone: failed to create plugin WebView: {e}"));
-                (None, None)
-            }
+        } else {
+            // BRANCH C: no window association AND not standalone — defer.
+            // idle() will retry when the host window finishes setting up.
+            append_log(
+                "parent NSView has no window — deferring WebView creation (idle() will retry)",
+            );
+            (None, None)
         }
-    } else {
-        // BRANCH C: no window association AND not standalone — defer.
-        // idle() will retry when the host window finishes setting up.
-        append_log("parent NSView has no window — deferring WebView creation (idle() will retry)");
-        (None, None)
     }
-}}
+}
 
 // ─── Protocol file server ────────────────────────────────────────────────────
 

--- a/packages/cosmo-pd101-plugin/src/gui.rs
+++ b/packages/cosmo-pd101-plugin/src/gui.rs
@@ -547,9 +547,9 @@ struct StandaloneWindow {
 #[cfg(target_os = "macos")]
 fn terminate_delegate_class() -> &'static objc::runtime::Class {
     use objc::{class, declare::ClassDecl, msg_send, sel, sel_impl};
-    static INIT: std::sync::Once = std::sync::Once::new();
-    static mut CLASS: Option<&'static objc::runtime::Class> = None;
-    INIT.call_once(|| {
+    static CLASS: std::sync::OnceLock<&'static objc::runtime::Class> =
+        std::sync::OnceLock::new();
+    CLASS.get_or_init(|| {
         let mut decl = ClassDecl::new("StandaloneWindowCloseDelegate", class!(NSObject))
             .expect("failed to create delegate class");
         extern "C" fn window_should_close(
@@ -575,10 +575,10 @@ fn terminate_delegate_class() -> &'static objc::runtime::Class {
                         *mut objc::runtime::Object,
                     ) -> objc::runtime::BOOL,
             );
-            CLASS = Some(decl.register());
+            decl.register()
         }
     });
-    unsafe { CLASS.unwrap() }
+    *CLASS.get().unwrap()
 }
 
 #[cfg(target_os = "macos")]
@@ -726,7 +726,7 @@ unsafe fn build_webview_from_ns_view(
     params: Arc<CzPluginParams>,
     runtime_mod_sources: SharedRuntimeModSources,
     webview_state: Arc<Mutex<WebViewContainer>>,
-) -> (Option<wry::WebView>, Option<StandaloneWindow>) {
+) -> (Option<wry::WebView>, Option<StandaloneWindow>) { unsafe {
     use core::ptr::NonNull;
     use rwh_06::{
         AppKitDisplayHandle, AppKitWindowHandle, DisplayHandle, HandleError, HasDisplayHandle,
@@ -878,7 +878,7 @@ unsafe fn build_webview_from_ns_view(
         append_log("parent NSView has no window — deferring WebView creation (idle() will retry)");
         (None, None)
     }
-}
+}}
 
 // ─── Protocol file server ────────────────────────────────────────────────────
 
@@ -1069,7 +1069,7 @@ fn binary_path() -> Option<std::path::PathBuf> {
             dli_saddr: *mut libc::c_void,
         }
 
-        extern "C" {
+        unsafe extern "C" {
             fn dladdr(addr: *const libc::c_void, info: *mut DlInfo) -> libc::c_int;
         }
 

--- a/packages/cosmo-pd101-plugin/src/gui.rs
+++ b/packages/cosmo-pd101-plugin/src/gui.rs
@@ -277,6 +277,7 @@ impl Editor for CzEditor {
 
         #[cfg(not(target_os = "macos"))]
         {
+            let _ = &parent;
             append_log("CzEditor::open: non-macOS build; no-op");
             return;
         }
@@ -1027,7 +1028,7 @@ fn binary_path() -> Option<std::path::PathBuf> {
         const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: DWORD = 0x00000004;
         const GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT: DWORD = 0x00000002;
 
-        extern "system" {
+        unsafe extern "system" {
             fn GetModuleHandleExW(
                 dwFlags: DWORD,
                 lpModuleName: LPCWSTR,

--- a/packages/cosmo-pd101-plugin/src/lib.rs
+++ b/packages/cosmo-pd101-plugin/src/lib.rs
@@ -13,7 +13,7 @@ use arc_swap::ArcSwap;
 use cosmo_synth_engine::envelope::normalize_synth_params_envelopes_to_raw_if_human;
 use cosmo_synth_engine::params::SynthParams;
 use cosmo_synth_engine::processor::state::RuntimeModSources;
-use cosmo_synth_engine::processor::{midi_note_to_freq, CosmoProcessor};
+use cosmo_synth_engine::processor::{CosmoProcessor, midi_note_to_freq};
 use crossbeam_queue::ArrayQueue;
 use truce::prelude::*;
 
@@ -759,37 +759,26 @@ impl PluginLogic for CzPlugin {
             let Some(event) = events.get(i) else {
                 continue;
             };
+            let Some(ref mut proc) = self.processor else {
+                continue;
+            };
             match &event.body {
-                EventBody::NoteOff { note, .. } => {
-                    if let Some(ref mut proc) = self.processor {
-                        proc.note_off(*note);
-                    }
-                }
+                EventBody::NoteOff { note, .. } => proc.note_off(*note),
                 EventBody::NoteOn { note, velocity, .. } => {
-                    if let Some(ref mut proc) = self.processor {
-                        if *velocity == 0 {
-                            proc.note_off(*note);
-                        } else {
-                            let vel = *velocity as f32 / 127.0;
-                            proc.note_on(*note, midi_note_to_freq(*note), vel);
-                        }
+                    if *velocity == 0 {
+                        proc.note_off(*note);
+                    } else {
+                        proc.note_on(*note, midi_note_to_freq(*note), *velocity as f32 / 127.0);
                     }
                 }
-                EventBody::ControlChange { cc, value, .. } => {
-                    if let Some(ref mut proc) = self.processor {
-                        match cc {
-                            1 => proc.set_mod_wheel(*value as f32 / 127.0),
-                            64 => proc.set_sustain(*value >= 64),
-                            120 | 123 => Self::all_notes_off(proc),
-                            _ => {}
-                        }
-                    }
-                }
+                EventBody::ControlChange { cc, value, .. } => match cc {
+                    1 => proc.set_mod_wheel(*value as f32 / 127.0),
+                    64 => proc.set_sustain(*value >= 64),
+                    120 | 123 => Self::all_notes_off(proc),
+                    _ => {}
+                },
                 EventBody::PitchBend { value, .. } => {
-                    if let Some(ref mut proc) = self.processor {
-                        let normalized = (*value as f32 - 8192.0) / 8192.0;
-                        proc.set_pitch_bend(normalized);
-                    }
+                    proc.set_pitch_bend((*value as f32 - 8192.0) / 8192.0);
                 }
                 _ => {}
             }

--- a/packages/cosmo-synth-debug/Cargo.toml
+++ b/packages/cosmo-synth-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmo-synth-debug"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Minimalist egui debug harness for cosmo-synth-engine"
 
 [[bin]]

--- a/packages/cosmo-synth-debug/src/main.rs
+++ b/packages/cosmo-synth-debug/src/main.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use cosmo_synth_engine::processor::{midi_note_to_freq, CosmoProcessor};
+use cosmo_synth_engine::processor::{CosmoProcessor, midi_note_to_freq};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use eframe::egui;
 
@@ -249,10 +249,10 @@ impl DebugApp {
     fn release_all_active_keys(&mut self, octave_offset: i32) {
         if let Ok(mut proc) = self.processor.lock() {
             for binding in KEY_BINDINGS {
-                if self.prev_keys.contains(&binding.key) {
-                    if let Some(note) = key_to_midi(*binding, octave_offset) {
-                        proc.note_off(note);
-                    }
+                if self.prev_keys.contains(&binding.key)
+                    && let Some(note) = key_to_midi(*binding, octave_offset)
+                {
+                    proc.note_off(note);
                 }
             }
         }

--- a/packages/cosmo-synth-engine/Cargo.toml
+++ b/packages/cosmo-synth-engine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cosmo-synth-engine"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "Cosmo PD-101 Phase Distortion synthesizer DSP core"
 
 [lib]

--- a/packages/cosmo-synth-engine/benches/render-bench.rs
+++ b/packages/cosmo-synth-engine/benches/render-bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 #[allow(dead_code)]

--- a/packages/cosmo-synth-engine/export_specta_bindings.rs
+++ b/packages/cosmo-synth-engine/export_specta_bindings.rs
@@ -7,28 +7,28 @@
 //! - SPECTA_TS_EXPORT_PATH: absolute/relative path to generated TypeScript file
 
 use cosmo_synth_engine::fx::{
-    fx_definitions_v1, FxControlKindV1, FxControlOptionV1, FxControlV1, FxDefinitionV1,
-    FxPresetOptionV1,
+    FxControlKindV1, FxControlOptionV1, FxControlV1, FxDefinitionV1, FxPresetOptionV1,
+    fx_definitions_v1,
 };
 use cosmo_synth_engine::generators::{
     AlgoControlAssignmentV1, AlgoControlKindV1, AlgoControlOptionV1, AlgoControlPresentationV1,
     AlgoControlV1, AlgoDefinitionV1, AlgoUiEntryV1, CzPresetV1,
 };
-use cosmo_synth_engine::module_presets::{module_preset_catalog_v1, ModulePresetGroupV1};
+use cosmo_synth_engine::module_presets::{ModulePresetGroupV1, module_preset_catalog_v1};
 use cosmo_synth_engine::params::engine_param_default_v1;
 use cosmo_synth_engine::params::{
-    engine_param_ranges_v1, engine_param_ui_meta_v1, Algo, AlgoControlValueV1, BaseWaveform,
-    BitcrusherParams, ChorusParams, CompressorParams, CzAlgo, CzWaveform, DelayParams,
-    DistortionParams, EnvStep, EqParams, FxSlotConfig, FxSlotType, GrainDelayParams,
-    JunoChorusParams, LfoParams, LfoWaveform, LineParams, LineSelect, LoFiParams, ModDestination,
-    ModEnvParams, ModMatrix, ModMode, ModRoute, ModSource, PhaseModParams, PhaserParams, PolyMode,
-    PortamentoMode, PortamentoParams, RandomParams, ReverbParams, RingModParams, ShimmerVerbParams,
-    StepEnvData, SynthParams, TremoloParams, VibratoParams, WavefolderParams, WindowType,
+    Algo, AlgoControlValueV1, BaseWaveform, BitcrusherParams, ChorusParams, CompressorParams,
+    CzAlgo, CzWaveform, DelayParams, DistortionParams, EnvStep, EqParams, FxSlotConfig, FxSlotType,
+    GrainDelayParams, JunoChorusParams, LfoParams, LfoWaveform, LineParams, LineSelect, LoFiParams,
+    ModDestination, ModEnvParams, ModMatrix, ModMode, ModRoute, ModSource, PhaseModParams,
+    PhaserParams, PolyMode, PortamentoMode, PortamentoParams, RandomParams, ReverbParams,
+    RingModParams, ShimmerVerbParams, StepEnvData, SynthParams, TremoloParams, VibratoParams,
+    WavefolderParams, WindowType, engine_param_ranges_v1, engine_param_ui_meta_v1,
 };
 use cosmo_synth_engine::preset_wire::{
-    algo_definitions_v1, algo_ui_catalog_v1, cz_presets, SynthPresetV1,
+    SynthPresetV1, algo_definitions_v1, algo_ui_catalog_v1, cz_presets,
 };
-use specta_typescript::{export, Typescript};
+use specta_typescript::{Typescript, export};
 
 fn main() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");

--- a/packages/cosmo-synth-engine/src/bin/render-bench.rs
+++ b/packages/cosmo-synth-engine/src/bin/render-bench.rs
@@ -10,7 +10,7 @@ use cosmo_synth_engine::params::{
     Algo, AlgoControlId, AlgoControlValueV1, FxSlotConfig, FxSlotType, LineSelect, ModDestination,
     ModMatrix, ModRoute, ModSource, PolyMode, SynthParams,
 };
-use cosmo_synth_engine::processor::{midi_note_to_freq, CosmoProcessor};
+use cosmo_synth_engine::processor::{CosmoProcessor, midi_note_to_freq};
 
 const DEFAULT_NOTES: [u8; 8] = [36, 40, 43, 48, 52, 55, 60, 64];
 
@@ -83,7 +83,7 @@ struct CaseResult {
 fn usage() {
     println!(
         "render-bench options:\n  --scenario <name>\n  --suite <name> (hotspots|algos)\n  --voices <n>\n  --seconds <s>\n  --sample-rate <hz>\n  --block-size <n>\n  --iterations <n>\n  --warmup <n>\n  --all\n  --json"
-	);
+    );
 }
 
 fn build_algo_bench_params(algo: Algo) -> SynthParams {
@@ -1209,20 +1209,20 @@ fn render_pass(config: &BenchmarkConfig, scenario: &Scenario, total_samples: usi
         rendered_samples += this_block;
         block_index += 1;
 
-        if let Some(churn_blocks) = scenario.note_churn_blocks {
-            if block_index.is_multiple_of(churn_blocks) {
-                let lead = DEFAULT_NOTES[(block_index / churn_blocks) % config.voices];
-                let release = DEFAULT_NOTES[(block_index / churn_blocks + 1) % config.voices];
-                processor.note_off(release);
-                processor.note_on(lead, midi_note_to_freq(lead), 0.92);
-            }
+        if let Some(churn_blocks) = scenario.note_churn_blocks
+            && block_index.is_multiple_of(churn_blocks)
+        {
+            let lead = DEFAULT_NOTES[(block_index / churn_blocks) % config.voices];
+            let release = DEFAULT_NOTES[(block_index / churn_blocks + 1) % config.voices];
+            processor.note_off(release);
+            processor.note_on(lead, midi_note_to_freq(lead), 0.92);
         }
 
-        if let (Some(swap_blocks), Some(variants)) = (scenario.param_swap_blocks, &param_variants) {
-            if block_index.is_multiple_of(swap_blocks) {
-                let variant_index = (block_index / swap_blocks) % variants.len();
-                processor.set_shared_params(Arc::clone(&variants[variant_index]));
-            }
+        if let (Some(swap_blocks), Some(variants)) = (scenario.param_swap_blocks, &param_variants)
+            && block_index.is_multiple_of(swap_blocks)
+        {
+            let variant_index = (block_index / swap_blocks) % variants.len();
+            processor.set_shared_params(Arc::clone(&variants[variant_index]));
         }
     }
 

--- a/packages/cosmo-synth-engine/src/default_envelopes.rs
+++ b/packages/cosmo-synth-engine/src/default_envelopes.rs
@@ -1,4 +1,4 @@
-use crate::envelope_map::{human_level_to_raw, human_rate_to_raw, EnvelopeKind};
+use crate::envelope_map::{EnvelopeKind, human_level_to_raw, human_rate_to_raw};
 use crate::params::{EnvStep, StepEnvData};
 
 fn step(kind: EnvelopeKind, level: u8, rate: u8) -> EnvStep {

--- a/packages/cosmo-synth-engine/src/dsp_utils.rs
+++ b/packages/cosmo-synth-engine/src/dsp_utils.rs
@@ -1,5 +1,5 @@
 use crate::params::{LfoWaveform, WindowType};
-use dasp_interpolate::{linear::Linear, Interpolator};
+use dasp_interpolate::{Interpolator, linear::Linear};
 
 pub const TWO_PI: f32 = core::f32::consts::TAU;
 const PI: f32 = core::f32::consts::PI;
@@ -9,11 +9,7 @@ const TWO_OVER_PI: f32 = 2.0 / PI;
 #[inline]
 pub fn wrap01(v: f32) -> f32 {
     let w = v - (v).floor();
-    if w < 0.0 {
-        w + 1.0
-    } else {
-        w
-    }
+    if w < 0.0 { w + 1.0 } else { w }
 }
 
 /// Linear interpolation.
@@ -173,11 +169,7 @@ pub fn apply_window(phase: f32, window: WindowType) -> f32 {
     // 2. The Casio Rectifier Trick
     // If we are in the second half of the master cycle, flip the window's sign.
     // This perfectly counteracts the carrier wave's negative polarity!
-    if phase >= 0.5 {
-        -amp
-    } else {
-        amp
-    }
+    if phase >= 0.5 { -amp } else { amp }
 }
 // ─── LFO ──────────────────────────────────────────────────────────────────────
 

--- a/packages/cosmo-synth-engine/src/envelope.rs
+++ b/packages/cosmo-synth-engine/src/envelope.rs
@@ -453,27 +453,27 @@ mod tests {
         };
 
         let timing = EnvelopeTimingCache::new(48_000.0);
-        let mut gen = EnvGen {
+        let mut r#gen = EnvGen {
             prev_level: 0.7,
             output: 0.7,
             step: 1, // at sustain
             ..Default::default()
         };
 
-        gen.start_release(&env);
+        r#gen.start_release(&env);
 
         // Consume release step 2 completely so generator transitions to step 3.
         // We don't need exact sample count, just enough to guarantee transition.
         for _ in 0..8192 {
-            gen.advance(EnvelopeKind::Dca, &env, &timing, 0.0, 60);
-            if gen.step >= 3 {
+            r#gen.advance(EnvelopeKind::Dca, &env, &timing, 0.0, 60);
+            if r#gen.step >= 3 {
                 break;
             }
         }
 
-        assert_eq!(gen.step, 3);
+        assert_eq!(r#gen.step, 3);
         // On entering the final step, output must still be above zero and then
         // decay using the final step's rate, not jump immediately to 0.
-        assert!(gen.output > 0.0);
+        assert!(r#gen.output > 0.0);
     }
 }

--- a/packages/cosmo-synth-engine/src/envelope.rs
+++ b/packages/cosmo-synth-engine/src/envelope.rs
@@ -1,8 +1,8 @@
 use crate::dsp_utils::lerp;
+pub use crate::envelope_map::EnvelopeKind;
 use crate::envelope_map::human_level_to_raw;
 use crate::envelope_map::human_rate_to_raw;
 use crate::envelope_map::raw_level_to_human;
-pub use crate::envelope_map::EnvelopeKind;
 use crate::params::{StepEnvData, SynthParams};
 
 pub fn normalize_env_to_raw_if_human(kind: EnvelopeKind, env: &mut StepEnvData) {
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn release_with_multiple_post_sustain_steps_does_not_hard_zero_on_transition() {
-        use crate::params::{EnvStep, StepEnvData, NUM_ENV_STEPS};
+        use crate::params::{EnvStep, NUM_ENV_STEPS, StepEnvData};
 
         let mut env = StepEnvData {
             steps: [EnvStep {

--- a/packages/cosmo-synth-engine/src/fx/delay.rs
+++ b/packages/cosmo-synth-engine/src/fx/delay.rs
@@ -1,5 +1,5 @@
 use super::delay_line::DelayLine;
-use crate::dsp_utils::{wrap01, TWO_PI};
+use crate::dsp_utils::{TWO_PI, wrap01};
 
 const SMOOTH_COEFF: f32 = 0.005;
 const TAPE_BRIGHT_CUTOFF_HZ: f32 = 20000.0;

--- a/packages/cosmo-synth-engine/src/fx/delay_line.rs
+++ b/packages/cosmo-synth-engine/src/fx/delay_line.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use dasp_interpolate::{linear::Linear, Interpolator};
+use dasp_interpolate::{Interpolator, linear::Linear};
 use dasp_ring_buffer::Fixed;
 
 // ---------------------------------------------------------------------------

--- a/packages/cosmo-synth-engine/src/fx/lofi.rs
+++ b/packages/cosmo-synth-engine/src/fx/lofi.rs
@@ -1,5 +1,5 @@
 use super::delay_line::DelayLine;
-use crate::dsp_utils::{wrap01, TWO_PI};
+use crate::dsp_utils::{TWO_PI, wrap01};
 
 const CENTER_DELAY_S: f32 = 0.012;
 const MAX_MOD_S: f32 = 0.010;

--- a/packages/cosmo-synth-engine/src/fx/tremolo.rs
+++ b/packages/cosmo-synth-engine/src/fx/tremolo.rs
@@ -46,11 +46,7 @@ impl TremoloFx {
             }
             2 => {
                 // Square
-                if self.phase < 0.5 {
-                    1.0
-                } else {
-                    -1.0
-                }
+                if self.phase < 0.5 { 1.0 } else { -1.0 }
             }
             _ => (self.phase * core::f32::consts::PI * 2.0).sin(),
         };

--- a/packages/cosmo-synth-engine/src/generators/bend.rs
+++ b/packages/cosmo-synth-engine/src/generators/bend.rs
@@ -69,9 +69,5 @@ pub fn warp_phase(phase: f32, amt: f32, curve: f32, bias: f32, knee: f32) -> f32
     let scale = -10.0 * (amt * (0.5 + curve * 1.5));
     let num = (knee_shaped * scale).exp_m1();
     let den = (scale).exp_m1();
-    if den == 0.0 {
-        phase
-    } else {
-        num / den
-    }
+    if den == 0.0 { phase } else { num / den }
 }

--- a/packages/cosmo-synth-engine/src/generators/catalog.rs
+++ b/packages/cosmo-synth-engine/src/generators/catalog.rs
@@ -209,7 +209,7 @@ pub fn algo_definitions_v1() -> &'static [AlgoDefinitionV1] {
 
 pub fn algo_ui_catalog_v1() -> &'static [AlgoUiEntryV1] {
     macro_rules! entry {
-        ($index:expr) => {
+        ($index:expr_2021) => {
             AlgoUiEntryV1 {
                 id: ALGO_DEFINITIONS_V1[$index].id,
                 label: ALGO_DEFINITIONS_V1[$index].name,

--- a/packages/cosmo-synth-engine/src/generators/cz101.rs
+++ b/packages/cosmo-synth-engine/src/generators/cz101.rs
@@ -1,6 +1,6 @@
 use super::{
-    lerp, wrap01, AlgoControlAssignmentV1, AlgoControlKindV1, AlgoControlOptionV1, AlgoControlV1,
-    AlgoDefinitionV1,
+    AlgoControlAssignmentV1, AlgoControlKindV1, AlgoControlOptionV1, AlgoControlV1,
+    AlgoDefinitionV1, lerp, wrap01,
 };
 use crate::params::{Algo, AlgoControlId, AlgoControlSlots, CzWaveform, WindowType};
 use serde::Serialize;
@@ -381,11 +381,7 @@ pub fn resolve_cycle_waveform(
     slot_b: CzWaveform,
     cycle_count: u32,
 ) -> CzWaveform {
-    if cycle_count & 1 == 0 {
-        slot_a
-    } else {
-        slot_b
-    }
+    if cycle_count & 1 == 0 { slot_a } else { slot_b }
 }
 
 /// Compute CZ phase transfer from front-panel CZ controls.

--- a/packages/cosmo-synth-engine/src/generators/fof.rs
+++ b/packages/cosmo-synth-engine/src/generators/fof.rs
@@ -1,4 +1,4 @@
-use super::{wrap01, AlgoControlKindV1, AlgoControlV1, AlgoDefinitionV1, NO_CONTROL_OPTIONS};
+use super::{AlgoControlKindV1, AlgoControlV1, AlgoDefinitionV1, NO_CONTROL_OPTIONS, wrap01};
 use crate::params::{Algo, EngineParamReadoutFormatV1};
 
 const CONTROLS: [AlgoControlV1; 4] = [

--- a/packages/cosmo-synth-engine/src/generators/mod.rs
+++ b/packages/cosmo-synth-engine/src/generators/mod.rs
@@ -1,4 +1,4 @@
-use crate::dsp_utils::{apply_window, lerp, wrap01, TWO_PI};
+use crate::dsp_utils::{TWO_PI, apply_window, lerp, wrap01};
 use crate::params::{Algo, AlgoControlSlots, BaseWaveform, LineParams};
 use crate::render_cache::CompiledLinePlan;
 use std::sync::LazyLock;
@@ -29,7 +29,7 @@ pub mod bend;
 pub mod catalog;
 pub mod clip;
 pub mod cz101;
-pub use cz101::{CzPresetV1, CZ_PRESETS};
+pub use cz101::{CZ_PRESETS, CzPresetV1};
 pub mod cheby;
 pub mod fof;
 pub mod fold;
@@ -46,11 +46,11 @@ pub mod terrain;
 pub mod twist;
 
 pub use catalog::{
-    algo_definitions_v1, algo_ui_catalog_v1, AlgoControlAssignmentV1, AlgoControlKindV1,
+    ALGO_BLEND_NUMBER_CONTROL, ALGO_DEFINITIONS_V1, AlgoControlAssignmentV1, AlgoControlKindV1,
     AlgoControlOptionV1, AlgoControlPresentationV1, AlgoControlV1, AlgoDefinitionV1, AlgoUiEntryV1,
-    ALGO_BLEND_NUMBER_CONTROL, ALGO_DEFINITIONS_V1, DCW_CONTROL, FINE_DETUNE_NUMBER_CONTROL,
-    KEY_FOLLOW_NUMBER_CONTROL, LEVEL_NUMBER_CONTROL, NO_CONTROLS, NO_CONTROL_OPTIONS,
-    OCTAVE_NUMBER_CONTROL, WARP_AMOUNT_CONTROL, WARP_AMOUNT_NUMBER_CONTROL,
+    DCW_CONTROL, FINE_DETUNE_NUMBER_CONTROL, KEY_FOLLOW_NUMBER_CONTROL, LEVEL_NUMBER_CONTROL,
+    NO_CONTROL_OPTIONS, NO_CONTROLS, OCTAVE_NUMBER_CONTROL, WARP_AMOUNT_CONTROL,
+    WARP_AMOUNT_NUMBER_CONTROL, algo_definitions_v1, algo_ui_catalog_v1,
 };
 
 /// Per-line render inputs passed to a voice's generator for one sample.
@@ -484,8 +484,8 @@ pub fn render_algo_sample(
 
 #[cfg(test)]
 mod tests {
-    use super::render_line_stateless;
     use super::LineRenderConfig;
+    use super::render_line_stateless;
     use crate::params::{Algo, BaseWaveform};
 
     #[test]

--- a/packages/cosmo-synth-engine/src/generators/quantize.rs
+++ b/packages/cosmo-synth-engine/src/generators/quantize.rs
@@ -45,12 +45,12 @@ const CONTROLS: [AlgoControlV1; 3] = [
 ];
 
 pub const DEFINITION: AlgoDefinitionV1 = AlgoDefinitionV1 {
-	id: Algo::Quantize,
-	name: "Quantize",
-	icon_path: "M4,12 L6,12 L6,8 L8,8 L8,16 L10,16 L10,10 L12,10 L12,14 L14,14 L14,6 L16,6 L16,18 L18,18 L18,12 L20,12",
-	visible: false,
-	default_base_waveform: crate::params::BaseWaveform::Sine,
-	controls: &CONTROLS,
+    id: Algo::Quantize,
+    name: "Quantize",
+    icon_path: "M4,12 L6,12 L6,8 L8,8 L8,16 L10,16 L10,10 L12,10 L12,14 L14,14 L14,6 L16,6 L16,18 L18,18 L18,12 L20,12",
+    visible: false,
+    default_base_waveform: crate::params::BaseWaveform::Sine,
+    controls: &CONTROLS,
 };
 
 /// Quantize algorithm phase warp.

--- a/packages/cosmo-synth-engine/src/generators/stutter.rs
+++ b/packages/cosmo-synth-engine/src/generators/stutter.rs
@@ -1,4 +1,4 @@
-use super::{wrap01, AlgoControlKindV1, AlgoControlV1, AlgoDefinitionV1, NO_CONTROL_OPTIONS};
+use super::{AlgoControlKindV1, AlgoControlV1, AlgoDefinitionV1, NO_CONTROL_OPTIONS, wrap01};
 use crate::params::{Algo, EngineParamReadoutFormatV1};
 
 const CONTROLS: [AlgoControlV1; 4] = [

--- a/packages/cosmo-synth-engine/src/lookup_tables.rs
+++ b/packages/cosmo-synth-engine/src/lookup_tables.rs
@@ -80,7 +80,7 @@ impl ConstantPowerPanTable {
         let mut i = 0;
         while i < 128 {
             let pan = i as f32 / 127.0; // [0.0, 1.0]
-                                        // Simplified linear panning (const context limitation)
+            // Simplified linear panning (const context limitation)
             left[i] = 1.0 - pan;
             right[i] = pan;
             i += 1;

--- a/packages/cosmo-synth-engine/src/module_presets.rs
+++ b/packages/cosmo-synth-engine/src/module_presets.rs
@@ -4,14 +4,14 @@ use specta::Type;
 
 use crate::{
     fx::{
-        bitcrusher::apply_bitcrusher_preset, chorus::apply_chorus_preset,
+        FxPresetOptionV1, bitcrusher::apply_bitcrusher_preset, chorus::apply_chorus_preset,
         compressor::apply_compressor_preset, delay::apply_delay_preset,
         distortion::apply_distortion_preset, eq::apply_eq_preset,
         grain_delay::apply_grain_delay_preset, juno_chorus::apply_juno_chorus_preset,
         lofi::apply_lofi_preset, phase_mod::apply_phase_mod_preset, phaser::apply_phaser_preset,
         reverb::apply_reverb_preset, ring_mod::apply_ring_mod_preset,
         shimmer_verb::apply_shimmer_verb_preset, tremolo::apply_tremolo_preset,
-        vibrato::apply_vibrato_preset, wavefolder::apply_wavefolder_preset, FxPresetOptionV1,
+        vibrato::apply_vibrato_preset, wavefolder::apply_wavefolder_preset,
     },
     params::{LfoWaveform, SynthParams},
 };

--- a/packages/cosmo-synth-engine/src/params/mod.rs
+++ b/packages/cosmo-synth-engine/src/params/mod.rs
@@ -13,7 +13,7 @@ mod waveforms;
 
 // Re-exports for backward compatibility
 pub(crate) use cache::ModMatrixCache;
-pub use envelopes::{EnvStep, StepEnvData, NUM_ENV_STEPS};
+pub use envelopes::{EnvStep, NUM_ENV_STEPS, StepEnvData};
 pub use fx_params::{
     BitcrusherParams, ChorusParams, CompressorParams, DelayParams, DistortionParams, EqParams,
     FxSlotConfig, FxSlotType, GrainDelayParams, JunoChorusParams, LoFiParams, PhaseModParams,
@@ -22,18 +22,18 @@ pub use fx_params::{
 };
 pub use lfo::{LfoParams, LfoWaveform};
 pub use line::{
-    AlgoControlId, AlgoControlSlots, AlgoControlValueV1, LineParams, LineSelect, ModMode, PolyMode,
-    MAX_ALGO_CONTROLS,
+    AlgoControlId, AlgoControlSlots, AlgoControlValueV1, LineParams, LineSelect, MAX_ALGO_CONTROLS,
+    ModMode, PolyMode,
 };
 pub use modulation::{
-    ModDestination, ModMatrix, ModRoute, ModSource, ENV_STEP_DEST_FIRST, ENV_STEP_DEST_LAST,
+    ENV_STEP_DEST_FIRST, ENV_STEP_DEST_LAST, ModDestination, ModMatrix, ModRoute, ModSource,
     NUM_MOD_DESTINATIONS,
 };
 pub use portamento::{PortamentoMode, PortamentoParams};
-pub use synth_params::{ModEnvParams, RandomParams, SynthParams, NUM_OPERATORS, NUM_VOICES};
+pub use synth_params::{ModEnvParams, NUM_OPERATORS, NUM_VOICES, RandomParams, SynthParams};
 pub use ui_meta::{
-    engine_param_default_v1, engine_param_ranges_v1, engine_param_ui_meta_v1,
     EngineEnumValueLabelV1, EngineParamRangeV1, EngineParamReadoutFormatV1, EngineParamUiMetaV1,
+    engine_param_default_v1, engine_param_ranges_v1, engine_param_ui_meta_v1,
 };
 pub use waveforms::{Algo, BaseWaveform, CzAlgo, CzWaveform, WindowType};
 

--- a/packages/cosmo-synth-engine/src/params/synth_params.rs
+++ b/packages/cosmo-synth-engine/src/params/synth_params.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "specta-bindings")]
 use specta::Type;
 
-use super::fx_params::{default_fx_slot_configs, FxSlotConfig, PhaseModParams, VibratoParams};
+use super::fx_params::{FxSlotConfig, PhaseModParams, VibratoParams, default_fx_slot_configs};
 use super::lfo::LfoParams;
 use super::line::{LineParams, LineSelect, ModMode, PolyMode};
 use super::modulation::ModMatrix;

--- a/packages/cosmo-synth-engine/src/processor/mod.rs
+++ b/packages/cosmo-synth-engine/src/processor/mod.rs
@@ -15,12 +15,12 @@ use arrayvec::ArrayVec;
 use core::array;
 
 use crate::dsp_utils::random_hold_value;
-use crate::envelope::{normalize_synth_params_envelopes_to_raw_if_human, EnvelopeTimingCache};
+use crate::envelope::{EnvelopeTimingCache, normalize_synth_params_envelopes_to_raw_if_human};
 use crate::fx::FxChain;
 use crate::module_presets;
-use crate::params::{FxSlotConfig, FxSlotType, LineParams, SynthParams, NUM_VOICES};
+use crate::params::{FxSlotConfig, FxSlotType, LineParams, NUM_VOICES, SynthParams};
 use crate::render_cache::CompiledSynthParams;
-use crate::simd::{detect_simd_backend, SimdBackend};
+use crate::simd::{SimdBackend, detect_simd_backend};
 use crate::voice::Voice;
 
 use self::cz_dac::CzDacColor;
@@ -276,7 +276,7 @@ impl CosmoProcessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::envelope_map::{human_level_to_raw, human_rate_to_raw, EnvelopeKind};
+    use crate::envelope_map::{EnvelopeKind, human_level_to_raw, human_rate_to_raw};
     use crate::params::{
         Algo, AlgoControlId, AlgoControlValueV1, DelayParams, EnvStep, FxSlotConfig, LineSelect,
         ModDestination, ModRoute, ModSource, PolyMode, ShimmerVerbParams, StepEnvData,

--- a/packages/cosmo-synth-engine/src/processor/notes.rs
+++ b/packages/cosmo-synth-engine/src/processor/notes.rs
@@ -1,9 +1,9 @@
 extern crate alloc;
 
-use crate::params::{PolyMode, NUM_VOICES};
+use crate::params::{NUM_VOICES, PolyMode};
 
-use super::state::{MonoStackEntry, NoteEntry};
 use super::CosmoProcessor;
+use super::state::{MonoStackEntry, NoteEntry};
 
 impl CosmoProcessor {
     pub(crate) fn reset_voice_envs(&mut self, voice_idx: usize) {
@@ -63,12 +63,12 @@ impl CosmoProcessor {
         voice.smoothed_dcw1 = 0.0;
         voice.smoothed_dcw2 = 0.0;
 
-        if let Some(vib) = self.params.vibrato_params() {
-            if vib.enabled {
-                voice.vibrato_phase = 0.0;
-                let delay_ms = vib.delay;
-                voice.vibrato_delay_counter = (delay_ms * self.sample_rate / 1000.0).round() as u32;
-            }
+        if let Some(vib) = self.params.vibrato_params()
+            && vib.enabled
+        {
+            voice.vibrato_phase = 0.0;
+            let delay_ms = vib.delay;
+            voice.vibrato_delay_counter = (delay_ms * self.sample_rate / 1000.0).round() as u32;
         }
     }
 
@@ -352,15 +352,13 @@ impl CosmoProcessor {
             return;
         }
 
-        if self.params.poly_mode == PolyMode::Mono {
-            if let Some(prev) = self.mono_stack.last() {
-                let voice = &mut self.voices[voice_idx];
-                *voice = prev.voice.clone();
-                voice.note = Some(prev.note);
-                self.replace_active_note_entry(voice_idx, prev.note);
-            } else {
-                self.start_release(voice_idx);
-            }
+        if self.params.poly_mode == PolyMode::Mono
+            && let Some(prev) = self.mono_stack.last()
+        {
+            let voice = &mut self.voices[voice_idx];
+            *voice = prev.voice.clone();
+            voice.note = Some(prev.note);
+            self.replace_active_note_entry(voice_idx, prev.note);
         } else {
             self.start_release(voice_idx);
         }

--- a/packages/cosmo-synth-engine/src/processor/process.rs
+++ b/packages/cosmo-synth-engine/src/processor/process.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use alloc::sync::Arc;
 
 use crate::dsp_utils::{lfo_output_with_symmetry, random_hold_value};
-use crate::params::{LineParams, ModDestination, ModMatrixCache, SynthParams, NUM_VOICES};
+use crate::params::{LineParams, ModDestination, ModMatrixCache, NUM_VOICES, SynthParams};
 use crate::render_cache::CompiledLinePlan;
 use crate::voice::modulated_line_params;
 use crate::voice::{ModSources, VoiceRenderContext};
 
+use super::CosmoProcessor;
 use super::state::RuntimeModSources;
 use super::utils::soft_clip_tanh;
-use super::CosmoProcessor;
 
 #[cfg(all(feature = "no_denormals", not(target_arch = "wasm32")))]
 use no_denormals::no_denormals;

--- a/packages/cosmo-synth-engine/src/render_cache.rs
+++ b/packages/cosmo-synth-engine/src/render_cache.rs
@@ -3,9 +3,9 @@
 //! The audio loop runs sample-by-sample, so stable work derived from
 //! `SynthParams` belongs here and is rebuilt only when parameters change.
 
-use crate::generators::{cz101, pre_resolve_controls, PER_LINE_HEADROOM};
+use crate::generators::{PER_LINE_HEADROOM, cz101, pre_resolve_controls};
 use crate::params::{
-    Algo, BaseWaveform, LineParams, ModMatrixCache, SynthParams, WindowType, NUM_VOICES,
+    Algo, BaseWaveform, LineParams, ModMatrixCache, NUM_VOICES, SynthParams, WindowType,
 };
 
 const REFERENCE_LINE_HEADROOM: f32 = 0.75;

--- a/packages/cosmo-synth-engine/src/simd/avx2.rs
+++ b/packages/cosmo-synth-engine/src/simd/avx2.rs
@@ -19,14 +19,14 @@ impl Avx2 {
     #[inline]
     unsafe fn from_m128(v: __m128) -> Self {
         let mut arr = [0.0; 4];
-        _mm_storeu_ps(arr.as_mut_ptr(), v);
+        unsafe { _mm_storeu_ps(arr.as_mut_ptr(), v) };
         Self(arr)
     }
 
     #[target_feature(enable = "avx2")]
     #[inline]
     unsafe fn to_m128(&self) -> __m128 {
-        _mm_loadu_ps(self.0.as_ptr())
+        unsafe { _mm_loadu_ps(self.0.as_ptr()) }
     }
 }
 

--- a/packages/cosmo-synth-engine/src/simd/mod.rs
+++ b/packages/cosmo-synth-engine/src/simd/mod.rs
@@ -80,7 +80,7 @@ pub trait SimdType: Sized + Copy {
 }
 
 macro_rules! simd_dispatch {
-    ($self:ident, $scalar:expr, $sse2:expr, $avx2:expr, $wasm:expr) => {
+    ($self:ident, $scalar:expr_2021, $sse2:expr_2021, $avx2:expr_2021, $wasm:expr_2021) => {
         match $self {
             SimdBackend::Scalar => $scalar,
             SimdBackend::Sse2 => {

--- a/packages/cosmo-synth-engine/src/simd/sse2.rs
+++ b/packages/cosmo-synth-engine/src/simd/sse2.rs
@@ -17,13 +17,13 @@ impl Sse2 {
     #[inline]
     unsafe fn from_m128(v: __m128) -> Self {
         let mut arr = [0.0; 4];
-        _mm_storeu_ps(arr.as_mut_ptr(), v);
+        unsafe { _mm_storeu_ps(arr.as_mut_ptr(), v) };
         Self(arr)
     }
 
     #[inline]
     unsafe fn to_m128(&self) -> __m128 {
-        _mm_loadu_ps(self.0.as_ptr())
+        unsafe { _mm_loadu_ps(self.0.as_ptr()) }
     }
 }
 

--- a/packages/cosmo-synth-engine/src/simd/wasm_simd.rs
+++ b/packages/cosmo-synth-engine/src/simd/wasm_simd.rs
@@ -17,12 +17,14 @@ impl WasmSimd {
     #[target_feature(enable = "simd128")]
     #[inline]
     unsafe fn from_v128(v: v128) -> Self {
-        Self([
-            f32x4_extract_lane::<0>(v),
-            f32x4_extract_lane::<1>(v),
-            f32x4_extract_lane::<2>(v),
-            f32x4_extract_lane::<3>(v),
-        ])
+        unsafe {
+            Self([
+                f32x4_extract_lane::<0>(v),
+                f32x4_extract_lane::<1>(v),
+                f32x4_extract_lane::<2>(v),
+                f32x4_extract_lane::<3>(v),
+            ])
+        }
     }
 
     #[target_feature(enable = "simd128")]

--- a/packages/cosmo-synth-engine/src/voice/mod.rs
+++ b/packages/cosmo-synth-engine/src/voice/mod.rs
@@ -7,9 +7,9 @@ mod modulation;
 mod render;
 
 pub use adsr::AdsrEnv;
-pub(crate) use modulation::modulated_line_params;
 pub(crate) use modulation::ModSources;
-pub(crate) use render::{render_voice, VoiceRenderContext};
+pub(crate) use modulation::modulated_line_params;
+pub(crate) use render::{VoiceRenderContext, render_voice};
 
 use crate::envelope::EnvGen;
 use crate::generators::AlgoRuntimeState;
@@ -133,7 +133,7 @@ impl Default for Voice {
 #[cfg(test)]
 mod tests {
     use super::ModSources;
-    use super::{render::*, Voice};
+    use super::{Voice, render::*};
     use crate::params::{LineParams, ModMatrixCache, SynthParams};
     use crate::render_cache::CompiledSynthParams;
 

--- a/packages/cosmo-synth-engine/src/voice/modulation.rs
+++ b/packages/cosmo-synth-engine/src/voice/modulation.rs
@@ -1,6 +1,6 @@
 use crate::params::{
-    EnvStep, LineParams, ModDestination, ModMatrixCache, StepEnvData, ENV_STEP_DEST_FIRST,
-    ENV_STEP_DEST_LAST, NUM_ENV_STEPS,
+    ENV_STEP_DEST_FIRST, ENV_STEP_DEST_LAST, EnvStep, LineParams, ModDestination, ModMatrixCache,
+    NUM_ENV_STEPS, StepEnvData,
 };
 
 // Modulation helpers

--- a/packages/cosmo-synth-engine/src/voice/render.rs
+++ b/packages/cosmo-synth-engine/src/voice/render.rs
@@ -1,4 +1,4 @@
-use crate::dsp_utils::{lfo_output, pow01, wrap01, TWO_PI};
+use crate::dsp_utils::{TWO_PI, lfo_output, pow01, wrap01};
 use crate::envelope::EnvelopeKind;
 use crate::envelope::EnvelopeTimingCache;
 use crate::generators::{self, LineRenderConfig};
@@ -8,12 +8,12 @@ use crate::params::{
 };
 use crate::render_cache::CompiledLinePlan;
 
-use super::modulation::{algo_param_slot_mods_for_line, ModSources};
+use super::modulation::{ModSources, algo_param_slot_mods_for_line};
 use super::{
-    Voice, ANTI_CLICK_ATTACK_SAMPLES, ANTI_CLICK_FADE_MAX_SAMPLES, ANTI_CLICK_FADE_SAMPLES,
+    ANTI_CLICK_ATTACK_SAMPLES, ANTI_CLICK_FADE_MAX_SAMPLES, ANTI_CLICK_FADE_SAMPLES,
     DCA_LEVEL_CURVE_EXPONENT, DCW_DEZIPPER_TIME_SECONDS, DCW_LEVEL_CURVE_EXPONENT,
     DEFAULT_BASE_FREQ, DUAL_LINE_MIX_GAIN, POP_SUPPRESS_DELTA_THRESHOLD, POP_SUPPRESS_EXCESS_KEEP,
-    RELEASE_TAIL_LEVEL_THRESHOLD, RELEASE_TAIL_LEVEL_TIME_SECONDS, SILENCE_THRESHOLD,
+    RELEASE_TAIL_LEVEL_THRESHOLD, RELEASE_TAIL_LEVEL_TIME_SECONDS, SILENCE_THRESHOLD, Voice,
     ZERO_CROSS_STOP_MAX_WAIT_SAMPLES, ZERO_CROSS_STOP_THRESHOLD,
 };
 

--- a/packages/xtask/Cargo.toml
+++ b/packages/xtask/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "xtask"

--- a/packages/xtask/src/build.rs
+++ b/packages/xtask/src/build.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::util::{
-    cargo_target_dir_for_package, combine_or_rename_binaries, to_vst3_bundle_name, Arch,
+    Arch, cargo_target_dir_for_package, combine_or_rename_binaries, to_vst3_bundle_name,
 };
 
 /// Read version from workspace Cargo.toml and convert to Apple's version integer format

--- a/packages/xtask/src/main.rs
+++ b/packages/xtask/src/main.rs
@@ -9,7 +9,7 @@ mod vst3;
 use std::path::PathBuf;
 use std::process::Command;
 
-use util::{cargo_target_dir_for_package, print_error, Arch};
+use util::{Arch, cargo_target_dir_for_package, print_error};
 
 /// Configuration for the bundle command
 struct BundleConfig {

--- a/packages/xtask/src/util.rs
+++ b/packages/xtask/src/util.rs
@@ -248,14 +248,13 @@ pub fn detect_bundle_identifier_prefix(package: &str, workspace_root: &Path) -> 
         .join(package)
         .join("Config.toml");
 
-    if let Ok(toml_str) = fs::read_to_string(&config_path) {
-        if let Ok(config) = toml::from_str::<ConfigFile>(&toml_str) {
-            if let Some(prefix) = config.bundle_identifier_prefix {
-                let trimmed = prefix.trim();
-                if !trimmed.is_empty() {
-                    return trimmed.to_string();
-                }
-            }
+    if let Ok(toml_str) = fs::read_to_string(&config_path)
+        && let Ok(config) = toml::from_str::<ConfigFile>(&toml_str)
+        && let Some(prefix) = config.bundle_identifier_prefix
+    {
+        let trimmed = prefix.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_string();
         }
     }
 

--- a/packages/xtask/src/util.rs
+++ b/packages/xtask/src/util.rs
@@ -32,7 +32,7 @@ macro_rules! status {
 /// Print verbose message (only in verbose mode)
 #[macro_export]
 macro_rules! verbose {
-    ($verbose:expr, $($arg:tt)*) => {
+    ($verbose:expr_2021, $($arg:tt)*) => {
         if $verbose {
             println!($($arg)*)
         }


### PR DESCRIPTION
## Summary

- **Edition bump**: All 5 Cargo.toml files updated from `edition = "2021"` to `"2024"`
- **Auto-fixes** (`cargo fix --edition`):
  - `#[no_mangle]` → `#[unsafe(no_mangle)]` (19 FFI functions)
  - `unsafe_op_in_unsafe_fn` — internal unsafe ops wrapped in `unsafe {}` blocks
  - `gen` → `r#gen` (reserved keyword in tests)
  - `expr` → `expr_2021` in macros (preserves pre-2024 fragment specifier behavior)
- **Manual fix**: Replaced `static mut CLASS` + `Once` with `OnceLock<&Class>` in gui.rs
- **Resolved warning**: `unsafe extern "C"` blocks in gui.rs

## Test plan

- [x] `cargo build` — clean, 0 errors, 0 warnings
- [x] `cargo test` — 70/70 passed

## 2024 features now available

- `if let` chains (`&& let` in conditions)
- Tail expr temporary scope (fewer borrow issues)
- `let` chains natively available
- Cargo resolver v3 (opt-in)
- New prelude items (`Future`, `IntoFuture`)