### PR TITLE
feat(cosmo-pd101): add user FX module presets with IndexedDB storage

### DIFF
--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/FxSlotModuleContext.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/FxSlotModuleContext.tsx
@@ -44,3 +44,5 @@ export function useFxSlotModule() {
 	}
 	return context;
 }
+
+export type { PresetOption } from "@/components/panels/drawer-modules/custom/useFxModuleController";

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/GenericFxSlotModule.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/GenericFxSlotModule.tsx
@@ -162,10 +162,14 @@ export default function GenericFxSlotModule() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		params,
 		enabled,
 		setFxSlotParams,
 		handlePresetChange,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 	const defaultColumns = clampGridColumns(config.columns ?? 4);
 	const dynamicColumnRule = config.dynamicColumns;
@@ -210,8 +214,11 @@ export default function GenericFxSlotModule() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			{visibleControls.map((control) =>
 				control.kind === "knob" ? (

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/DelayModuleRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/DelayModuleRenderer.tsx
@@ -12,10 +12,14 @@ export default function DelayModuleRenderer() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		setFxSlotParams,
 		params,
 		enabled,
 		handlePresetChange,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 	const tapeMode = asNumber(params.tapeMode, 0) === 1;
 	const columns = tapeMode ? 4 : 3;
@@ -27,8 +31,11 @@ export default function DelayModuleRenderer() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			<BadgeToggle
 				active={tapeMode}

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/Eq8BandModuleRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/Eq8BandModuleRenderer.tsx
@@ -23,10 +23,14 @@ export default function Eq8BandModuleRenderer() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		enabled,
 		handlePresetChange,
 		params,
 		setFxSlotParams,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 	const modDestinationByParam = getModDestinationByParam(config.type);
 
@@ -38,8 +42,11 @@ export default function Eq8BandModuleRenderer() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			<div className="col-span-full rounded-md bg-cz-inset/25 px-2 pt-2 pb-1.5">
 				<FxVerticalSliderGroup

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/GrainDelayModuleRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/GrainDelayModuleRenderer.tsx
@@ -7,9 +7,13 @@ export default function GrainDelayModuleRenderer() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		setFxSlotParams,
 		enabled,
 		handlePresetChange,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 
 	return (
@@ -20,8 +24,11 @@ export default function GrainDelayModuleRenderer() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			<FxSlotKnob param="time" metaParamKey="grainDelayTime" sync />
 			<FxSlotKnob param="feedback" metaParamKey="grainDelayFeedback" />

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/PhaseModModuleRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/PhaseModModuleRenderer.tsx
@@ -9,10 +9,14 @@ export default function PhaseModModuleRenderer() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		setFxSlotParams,
 		params,
 		enabled,
 		handlePresetChange,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 	const pmPreEnabled = Boolean(params.pmPre);
 
@@ -24,8 +28,11 @@ export default function PhaseModModuleRenderer() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			<BadgeToggle
 				active={pmPreEnabled}

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/TremoloModuleRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/TremoloModuleRenderer.tsx
@@ -13,10 +13,14 @@ export default function TremoloModuleRenderer() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		setFxSlotParams,
 		params,
 		enabled,
 		handlePresetChange,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 	const waveformControl = getButtonGroupControl(config, "waveform");
 	const waveformValue = asNumber(params.waveform, 0);
@@ -29,8 +33,11 @@ export default function TremoloModuleRenderer() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			<div className="join col-span-3 w-full overflow-hidden rounded-md border border-cz-border/65">
 				{waveformControl?.options.map((option) => (

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/VibratoModuleRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/VibratoModuleRenderer.tsx
@@ -13,10 +13,14 @@ export default function VibratoModuleRenderer() {
 		config,
 		slot,
 		selectedPreset,
+		presetOptions,
 		setFxSlotParams,
 		params,
 		enabled,
 		handlePresetChange,
+		builtinPresetIds,
+		handleSavePreset,
+		handleDeletePreset,
 	} = useFxSlotModule();
 	const waveformControl = getButtonGroupControl(config, "waveform");
 	const waveformValue = asNumber(params.waveform, 1);
@@ -29,8 +33,11 @@ export default function VibratoModuleRenderer() {
 			enabled={enabled}
 			onToggleEnabled={() => setFxSlotParams(slot, { enabled: !enabled })}
 			presetValue={selectedPreset}
-			presetOptions={config.presets}
+			presetOptions={presetOptions}
 			onPresetChange={handlePresetChange}
+			builtinPresetIds={builtinPresetIds}
+			onSavePreset={handleSavePreset}
+			onDeletePreset={handleDeletePreset}
 		>
 			<div className="join col-span-3 w-full overflow-hidden rounded-md border border-cz-border/65">
 				{waveformControl?.options.map((option) => (

--- a/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/useFxModuleController.ts
+++ b/packages/cosmo-pd101/src/components/panels/drawer-modules/custom/useFxModuleController.ts
@@ -1,14 +1,27 @@
-import { useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { FxSlotModuleConfig } from "@/components/panels/drawer-modules/fxSlotModuleConfig";
 import { requestApplyModulePreset } from "@/features/synth/engine/modulePresetEvents";
 import { useSynthStore } from "@/features/synth/synthStore";
+import type { StoredFxModulePreset } from "@/lib/synth/fxModulePresetStorage";
+import {
+	deleteFxModulePreset,
+	listFxModulePresets,
+	saveFxModulePreset,
+} from "@/lib/synth/fxModulePresetStorage";
 import { getPresetModuleKey, resolvePresetPatchParams } from "./utils";
+
+export type PresetOption = {
+	id: string;
+	label: string;
+	isBuiltin: boolean;
+};
 
 export function useFxModuleController(
 	config: FxSlotModuleConfig,
 	slot: number,
 ) {
 	const [selectedPreset, setSelectedPreset] = useState<string>("");
+	const [userPresets, setUserPresets] = useState<StoredFxModulePreset[]>([]);
 	const rawSlot = useSynthStore((state) => state.fxSlots[slot]);
 	const setFxSlotParams = useSynthStore((state) => state.setFxSlotParams);
 
@@ -16,34 +29,118 @@ export function useFxModuleController(
 		(rawSlot as { params: Record<string, unknown> })?.params ?? {};
 	const enabled = Boolean(rawParams.enabled);
 
-	const handlePresetChange = (presetId: string) => {
-		setSelectedPreset(presetId);
-		const preset = config.presets.find((entry) => entry.id === presetId);
-		if (!preset) {
-			return;
-		}
+	const builtinPresetIds = useMemo(
+		() => new Set(config.presets.map((p) => p.id)),
+		[config.presets],
+	);
 
-		const patchParams = resolvePresetPatchParams(
-			config,
-			preset.patch as Record<string, unknown>,
-		);
-		if (!patchParams) {
-			return;
-		}
+	const presetOptions = useMemo((): PresetOption[] => {
+		const builtins = config.presets.map((p) => ({
+			id: p.id,
+			label: p.label,
+			isBuiltin: true,
+		}));
+		const users = userPresets.map((p) => ({
+			id: p.id,
+			label: p.name,
+			isBuiltin: false,
+		}));
+		return [...builtins, ...users];
+	}, [config.presets, userPresets]);
 
-		setFxSlotParams(slot, patchParams);
-		requestApplyModulePreset({
-			module: getPresetModuleKey(config.moduleKey),
-			preset: preset.id,
-			patch: preset.patch,
-		});
-	};
+	useEffect(() => {
+		listFxModulePresets(config.type).then(setUserPresets);
+	}, [config.type]);
+
+	useEffect(() => {
+		if (config.presets.length > 0) {
+			const first = config.presets[0];
+			setSelectedPreset(first.id);
+			const patchParams = resolvePresetPatchParams(
+				config,
+				first.patch as Record<string, unknown>,
+			);
+			if (patchParams) {
+				setFxSlotParams(slot, patchParams);
+			}
+			requestApplyModulePreset({
+				module: getPresetModuleKey(config.moduleKey),
+				preset: first.id,
+				patch: first.patch,
+			});
+		}
+	}, [config, slot, setFxSlotParams]);
+
+	const handlePresetChange = useCallback(
+		(presetId: string) => {
+			setSelectedPreset(presetId);
+
+			const userPreset = userPresets.find((p) => p.id === presetId);
+			if (userPreset) {
+				const patchParams = resolvePresetPatchParams(
+					config,
+					userPreset.patch as Record<string, unknown>,
+				);
+				if (patchParams) {
+					setFxSlotParams(slot, patchParams);
+				}
+				return;
+			}
+
+			const builtinPreset = config.presets.find(
+				(entry) => entry.id === presetId,
+			);
+			if (!builtinPreset) {
+				return;
+			}
+
+			const patchParams = resolvePresetPatchParams(
+				config,
+				builtinPreset.patch as Record<string, unknown>,
+			);
+			if (!patchParams) {
+				return;
+			}
+
+			setFxSlotParams(slot, patchParams);
+			requestApplyModulePreset({
+				module: getPresetModuleKey(config.moduleKey),
+				preset: builtinPreset.id,
+				patch: builtinPreset.patch,
+			});
+		},
+		[config, slot, userPresets, setFxSlotParams],
+	);
+
+	const handleSavePreset = useCallback(
+		async (name: string) => {
+			const moduleKey = getPresetModuleKey(config.moduleKey);
+			const patch = { [moduleKey]: { ...rawParams } };
+			const saved = await saveFxModulePreset({
+				name,
+				moduleType: config.type,
+				patch,
+			});
+			setUserPresets((prev) => [...prev, saved]);
+			setSelectedPreset(saved.id);
+		},
+		[config.moduleKey, config.type, rawParams],
+	);
+
+	const handleDeletePreset = useCallback(async (presetId: string) => {
+		await deleteFxModulePreset(presetId);
+		setUserPresets((prev) => prev.filter((p) => p.id !== presetId));
+	}, []);
 
 	return {
 		selectedPreset,
+		presetOptions,
 		setFxSlotParams,
 		params: rawParams,
 		enabled,
+		builtinPresetIds,
 		handlePresetChange,
+		handleSavePreset,
+		handleDeletePreset,
 	};
 }

--- a/packages/cosmo-pd101/src/components/primitives/ModuleFrame.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/ModuleFrame.tsx
@@ -13,10 +13,7 @@ function contrastColor(hex: string): "black" | "white" {
 }
 
 // --- TYPES ---
-type ModulePresetOption = {
-	id: string;
-	label?: string;
-};
+import type { ModulePresetOption } from "@/components/primitives/ModulePresetPopover";
 
 // --- HEADER COMPONENT ---
 type ModuleHeaderProps = {
@@ -95,6 +92,9 @@ type ModuleFrameProps = {
 	presetOptions?: ModulePresetOption[];
 	onPresetChange?: (value: string) => void;
 	presetDisabled?: boolean;
+	builtinPresetIds?: Set<string>;
+	onSavePreset?: (name: string) => void;
+	onDeletePreset?: (presetId: string) => void;
 	enabled: boolean;
 	hideToggle?: boolean;
 	onToggleEnabled?: () => void;
@@ -122,6 +122,9 @@ export default function ModuleFrame({
 	presetOptions,
 	onPresetChange,
 	presetDisabled = false,
+	builtinPresetIds,
+	onSavePreset,
+	onDeletePreset,
 	enabled,
 	hideToggle = false,
 	onToggleEnabled,
@@ -178,6 +181,9 @@ export default function ModuleFrame({
 						onChange={onPresetChange}
 						accentColor={color}
 						disabled={presetDisabled || presetOptions.length === 0}
+						builtinPresetIds={builtinPresetIds}
+						onSavePreset={onSavePreset}
+						onDeletePreset={onDeletePreset}
 					/>
 				</div>
 			) : null}

--- a/packages/cosmo-pd101/src/components/primitives/ModulePresetPopover.tsx
+++ b/packages/cosmo-pd101/src/components/primitives/ModulePresetPopover.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Button from "@/components/controls/Button";
 
-type ModulePresetOption = {
+export type ModulePresetOption = {
 	id: string;
 	label?: string;
 };
@@ -13,6 +13,9 @@ type ModulePresetPopoverProps = {
 	onChange: (value: string) => void;
 	accentColor?: string;
 	disabled?: boolean;
+	builtinPresetIds?: Set<string>;
+	onSavePreset?: (name: string) => void;
+	onDeletePreset?: (presetId: string) => void;
 };
 
 function hexToRgb(hex: string) {
@@ -37,6 +40,76 @@ function colorAlpha(hex: string, alpha: number) {
 	return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${alpha})`;
 }
 
+function SaveAsDialog({
+	open,
+	onClose,
+	onSave,
+}: {
+	open: boolean;
+	onClose: () => void;
+	onSave: (name: string) => void;
+}) {
+	const [name, setName] = useState("");
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		if (open) {
+			setName("");
+			setTimeout(() => inputRef.current?.focus(), 0);
+		}
+	}, [open]);
+
+	return (
+		<dialog
+			className="modal"
+			open={open}
+			onCancel={(event) => {
+				event.preventDefault();
+				onClose();
+			}}
+		>
+			<div className="modal-box rounded-md border border-cz-border bg-cz-panel">
+				<h3 className="mb-4 font-bold text-cz-cream-light text-lg">
+					Save FX Preset As
+				</h3>
+				<input
+					ref={inputRef}
+					type="text"
+					className="input input-bordered w-full rounded-md border-cz-border bg-cz-surface text-cz-cream-light"
+					placeholder="Preset name"
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === "Enter" && name.trim()) {
+							onSave(name.trim());
+						}
+						if (e.key === "Escape") {
+							onClose();
+						}
+					}}
+				/>
+				<div className="modal-action">
+					<Button
+						type="button"
+						onClick={onClose}
+						className="btn btn-ghost btn-sm text-cz-cream/70"
+					>
+						Cancel
+					</Button>
+					<Button
+						type="button"
+						onClick={() => onSave(name.trim())}
+						disabled={!name.trim()}
+						className="btn btn-primary btn-sm"
+					>
+						Save
+					</Button>
+				</div>
+			</div>
+		</dialog>
+	);
+}
+
 export default function ModulePresetPopover({
 	title,
 	value,
@@ -44,10 +117,16 @@ export default function ModulePresetPopover({
 	onChange,
 	accentColor,
 	disabled = false,
+	builtinPresetIds,
+	onSavePreset,
+	onDeletePreset,
 }: ModulePresetPopoverProps) {
 	const detailsRef = useRef<HTMLDetailsElement | null>(null);
 	const borderColor = colorAlpha(accentColor ?? "", 0.65);
 	const activeBgColor = colorAlpha(accentColor ?? "", 0.34);
+	const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+
+	const hasManageActions = onSavePreset || (onDeletePreset && builtinPresetIds);
 
 	useEffect(() => {
 		const handleClickOutside = (e: MouseEvent) => {
@@ -89,50 +168,102 @@ export default function ModulePresetPopover({
 	}
 
 	return (
-		<details
-			ref={detailsRef}
-			className="dropdown dropdown-top dropdown-end [&_summary::-webkit-details-marker]:hidden"
-		>
-			<summary
-				className="btn btn-xs flex h-5 min-h-0 min-w-20 flex-nowrap items-center gap-1.5 rounded-sm border px-2 font-bold font-mono text-[0.54rem] text-cz-cream-light uppercase tracking-[0.14em] shadow-[0_1px_0_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.08)] hover:brightness-125"
-				aria-label={`${title} presets`}
+		<>
+			<details
+				ref={detailsRef}
+				className="dropdown dropdown-top dropdown-end [&_summary::-webkit-details-marker]:hidden"
 			>
-				<span
-					className="inline-block h-1 w-1 shrink-0 rounded-full"
-					style={{ backgroundColor: borderColor }}
-				/>
-				<span>presets</span>
-				<span className="text-cz-cream-dim">▾</span>
-			</summary>
-			<ul
-				className="menu dropdown-content z-9999 mb-1.5 w-44 rounded-md border border-cz-border bg-cz-panel p-1 shadow-[0_10px_24px_rgba(0,0,0,0.5)]"
-				style={{ borderColor: borderColor }}
-			>
-				{options.map((option) => {
-					const active = option.id === value;
-					return (
-						<li key={option.id}>
-							<Button
-								type="button"
-								className={`btn btn-ghost btn-sm min-h-0 w-full justify-start px-2 py-1 text-xs ${
-									active
-										? "text-cz-cream-light"
-										: "text-cz-cream hover:bg-cz-surface"
-								}`}
-								style={active ? { backgroundColor: activeBgColor } : undefined}
-								onClick={() => {
-									onChange(option.id);
-									if (detailsRef.current) {
-										detailsRef.current.open = false;
+				<summary
+					className="btn btn-xs flex h-5 min-h-0 min-w-20 flex-nowrap items-center gap-1.5 rounded-sm border px-2 font-bold font-mono text-[0.54rem] text-cz-cream-light uppercase tracking-[0.14em] shadow-[0_1px_0_rgba(0,0,0,0.65),inset_0_1px_0_rgba(255,255,255,0.08)] hover:brightness-125"
+					aria-label={`${title} presets`}
+				>
+					<span
+						className="inline-block h-1 w-1 shrink-0 rounded-full"
+						style={{ backgroundColor: borderColor }}
+					/>
+					<span>presets</span>
+					<span className="text-cz-cream-dim">▾</span>
+				</summary>
+				<ul
+					className="menu dropdown-content z-9999 mb-1.5 max-h-64 w-44 overflow-y-auto rounded-md border border-cz-border bg-cz-panel p-1 shadow-[0_10px_24px_rgba(0,0,0,0.5)]"
+					style={{ borderColor: borderColor }}
+				>
+					{options.map((option) => {
+						const active = option.id === value;
+						return (
+							<li key={option.id}>
+								<Button
+									type="button"
+									className={`btn btn-ghost btn-sm min-h-0 w-full justify-start px-2 py-1 text-xs ${
+										active
+											? "text-cz-cream-light"
+											: "text-cz-cream hover:bg-cz-surface"
+									}`}
+									style={
+										active ? { backgroundColor: activeBgColor } : undefined
 									}
-								}}
-							>
-								{option.label ?? option.id}
-							</Button>
-						</li>
-					);
-				})}
-			</ul>
-		</details>
+									onClick={() => {
+										onChange(option.id);
+										if (detailsRef.current) {
+											detailsRef.current.open = false;
+										}
+									}}
+								>
+									{option.label ?? option.id}
+								</Button>
+							</li>
+						);
+					})}
+					{hasManageActions ? (
+						<>
+							<li className="divider my-1 h-px bg-cz-border/50" />
+							{onSavePreset ? (
+								<li>
+									<Button
+										type="button"
+										className="btn btn-ghost btn-sm min-h-0 w-full justify-start px-2 py-1 text-cz-cream-dim text-xs hover:text-cz-cream-light"
+										onClick={() => {
+											setSaveDialogOpen(true);
+											if (detailsRef.current) {
+												detailsRef.current.open = false;
+											}
+										}}
+									>
+										+ Save
+									</Button>
+								</li>
+							) : null}
+							{onDeletePreset &&
+							builtinPresetIds &&
+							value &&
+							!builtinPresetIds.has(value) ? (
+								<li>
+									<Button
+										type="button"
+										className="btn btn-ghost btn-sm min-h-0 w-full justify-start px-2 py-1 text-red-400 text-xs hover:text-red-300"
+										onClick={() => {
+											onDeletePreset(value);
+											if (detailsRef.current) {
+												detailsRef.current.open = false;
+											}
+										}}
+									>
+										Delete
+									</Button>
+								</li>
+							) : null}
+						</>
+					) : null}
+				</ul>
+			</details>
+			<SaveAsDialog
+				open={saveDialogOpen}
+				onClose={() => setSaveDialogOpen(false)}
+				onSave={(name) => {
+					onSavePreset?.(name);
+					setSaveDialogOpen(false);
+				}}
+			/>
+		</>
 	);
 }

--- a/packages/cosmo-pd101/src/lib/synth/fxModulePresetStorage.ts
+++ b/packages/cosmo-pd101/src/lib/synth/fxModulePresetStorage.ts
@@ -1,0 +1,79 @@
+import { getDb } from "@/lib/synth/presetStorage";
+
+export type StoredFxModulePreset = {
+	id: string;
+	name: string;
+	moduleType: string;
+	patch: Record<string, unknown>;
+	createdAt: number;
+};
+
+function getAllFromStore<T>(storeName: string): Promise<T[]> {
+	return getDb().then(
+		(db) =>
+			new Promise((resolve, reject) => {
+				const tx = db.transaction(storeName, "readonly");
+				const request = tx.objectStore(storeName).getAll();
+				request.onsuccess = () => resolve(request.result as T[]);
+				request.onerror = () => reject(request.error);
+			}),
+	);
+}
+
+function putInStore(storeName: string, value: unknown): Promise<void> {
+	return getDb().then(
+		(db) =>
+			new Promise((resolve, reject) => {
+				const tx = db.transaction(storeName, "readwrite");
+				tx.objectStore(storeName).put(value);
+				tx.oncomplete = () => resolve();
+				tx.onerror = () => reject(tx.error);
+			}),
+	);
+}
+
+const STORE = "fxModulePresets";
+
+let idCounter = 0;
+
+function createFxModulePresetId(): string {
+	idCounter++;
+	return `fxmod_${Date.now()}_${idCounter}`;
+}
+
+export async function saveFxModulePreset(input: {
+	name: string;
+	moduleType: string;
+	patch: Record<string, unknown>;
+}): Promise<StoredFxModulePreset> {
+	const stored: StoredFxModulePreset = {
+		id: createFxModulePresetId(),
+		name: input.name.trim(),
+		moduleType: input.moduleType,
+		patch: input.patch,
+		createdAt: Date.now(),
+	};
+	await putInStore(STORE, stored);
+	return stored;
+}
+
+export async function listFxModulePresets(
+	moduleType: string,
+): Promise<StoredFxModulePreset[]> {
+	const all = await getAllFromStore<StoredFxModulePreset>(STORE);
+	return all
+		.filter((preset) => preset.moduleType === moduleType)
+		.sort((a, b) => a.createdAt - b.createdAt);
+}
+
+export async function deleteFxModulePreset(id: string): Promise<void> {
+	return getDb().then(
+		(db) =>
+			new Promise((resolve, reject) => {
+				const tx = db.transaction(STORE, "readwrite");
+				tx.objectStore(STORE).delete(id);
+				tx.oncomplete = () => resolve();
+				tx.onerror = () => reject(tx.error);
+			}),
+	);
+}

--- a/packages/cosmo-pd101/src/lib/synth/presetStorage.test.ts
+++ b/packages/cosmo-pd101/src/lib/synth/presetStorage.test.ts
@@ -213,7 +213,7 @@ describe("presetStorage", () => {
 async function seedKv(key: string, value: unknown): Promise<void> {
 	await deleteDatabase();
 	const db = await new Promise<IDBDatabase>((resolve, reject) => {
-		const request = indexedDB.open("cosmo-pd101-preset-storage", 1);
+		const request = indexedDB.open("cosmo-pd101-preset-storage", 2);
 		request.onupgradeneeded = () => {
 			const d = request.result;
 			if (!d.objectStoreNames.contains("kv")) {

--- a/packages/cosmo-pd101/src/lib/synth/presetStorage.ts
+++ b/packages/cosmo-pd101/src/lib/synth/presetStorage.ts
@@ -14,7 +14,7 @@ import {
 import type { FrontendPresetV1, PresetMetadata } from "@/lib/synth/presetTypes";
 
 const DB_NAME = "cosmo-pd101-preset-storage";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 export type { PresetMetadata };
 export type StoredPreset = FrontendPresetV1;
@@ -37,7 +37,7 @@ type StoredPresetInput = {
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 
-function getDb(): Promise<IDBDatabase> {
+export function getDb(): Promise<IDBDatabase> {
 	if (!dbPromise) {
 		dbPromise = new Promise((resolve, reject) => {
 			const request = indexedDB.open(DB_NAME, DB_VERSION);
@@ -51,6 +51,9 @@ function getDb(): Promise<IDBDatabase> {
 				}
 				if (!db.objectStoreNames.contains("favorites")) {
 					db.createObjectStore("favorites", { keyPath: "id" });
+				}
+				if (!db.objectStoreNames.contains("fxModulePresets")) {
+					db.createObjectStore("fxModulePresets", { keyPath: "id" });
 				}
 			};
 			request.onsuccess = () => resolve(request.result);


### PR DESCRIPTION
## Summary

Adds the ability to create and delete user FX module presets, stored in IndexedDB. Built-in presets remain non-deletable. When a new FX module type is added to a slot, the first preset is auto-selected.

## Changes

- **New `fxModulePresetStorage.ts`** — IndexedDB CRUD for user FX module presets (save, list by module type, delete)
- **`presetStorage.ts`** — bumped DB to v2 with `fxModulePresets` store
- **`useFxModuleController.ts`** — loads user presets on mount, merges with builtins into `presetOptions`, auto-selects first preset on module type change, exposes `handleSavePreset` / `handleDeletePreset`
- **`FxSlotModuleContext.tsx`** — extended context type with `presetOptions`, `builtinPresetIds`, `handleSavePreset`, `handleDeletePreset`
- **`ModulePresetPopover.tsx`** — added "+ Save" and "Delete" options in dropdown; Save opens a native `<dialog>` with name input (DaisyUI pattern)
- **`ModuleFrame.tsx`** — added `builtinPresetIds`, `onSavePreset`, `onDeletePreset` props and passes them to `ModulePresetPopover`
- **`GenericFxSlotModule.tsx` + 6 custom renderers** — switched from `config.presets` to context-provided `presetOptions` and pass through new preset management props

## Testing

All 110 cosmo-pd101 test files pass (766 tests), all 105 Rust tests pass.