### PR TITLE
fix(plugin): restore preset state on GUI reopen

### DIFF
--- a/packages/cosmo-pd101-plugin/src/gui.rs
+++ b/packages/cosmo-pd101-plugin/src/gui.rs
@@ -29,7 +29,7 @@ use crate::CzPluginParams;
 #[cfg(target_os = "macos")]
 use crate::handle_ipc_invoke;
 use crate::{
-    MidiCcQueue, PerformanceCountersHandle, ScopeBuffer, SharedRuntimeModSources,
+    MidiCcQueue, PerformanceCountersHandle, ScopeBuffer, SharedPresetName, SharedRuntimeModSources,
     SharedTransportSnapshot, UiInputQueue, append_log,
 };
 use cosmo_synth_engine::params::SynthParams;
@@ -111,6 +111,7 @@ pub struct CzEditor {
     webview_state: Arc<Mutex<WebViewContainer>>,
     pending_parent_ns_view: Option<usize>,
     params: Arc<CzPluginParams>,
+    preset_name: SharedPresetName,
     #[cfg(target_os = "macos")]
     standalone_window: Option<StandaloneWindow>,
 }
@@ -152,6 +153,7 @@ impl CzEditor {
         midi_cc_queue: MidiCcQueue,
         performance_counters: PerformanceCountersHandle,
         params: Arc<CzPluginParams>,
+        preset_name: SharedPresetName,
     ) -> Self {
         Self {
             synth_params,
@@ -167,6 +169,7 @@ impl CzEditor {
             webview_state: Arc::new(Mutex::new(WebViewContainer { webview: None })),
             pending_parent_ns_view: None,
             params,
+            preset_name,
             #[cfg(target_os = "macos")]
             standalone_window: None,
         }
@@ -199,6 +202,7 @@ impl CzEditor {
         let ui_input_queue = self.ui_input_queue.clone();
         let performance_counters = self.performance_counters.clone();
         let params = self.params.clone();
+        let preset_name = self.preset_name.clone();
         let webview_state_for_ipc = self.webview_state.clone();
 
         let (webview, standalone_window) = unsafe {
@@ -214,6 +218,7 @@ impl CzEditor {
                 ui_input_queue,
                 performance_counters,
                 params,
+                preset_name,
                 webview_state_for_ipc,
             )
         };
@@ -754,6 +759,7 @@ unsafe fn build_webview_from_ns_view(
     ui_input_queue: UiInputQueue,
     performance_counters: PerformanceCountersHandle,
     params: Arc<CzPluginParams>,
+    preset_name: SharedPresetName,
     webview_state: Arc<Mutex<WebViewContainer>>,
 ) -> (Option<wry::WebView>, Option<StandaloneWindow>) {
     unsafe {
@@ -781,6 +787,7 @@ unsafe fn build_webview_from_ns_view(
         unsafe impl Send for NsViewWrapper {}
         unsafe impl Sync for NsViewWrapper {}
 
+        let preset_name_for_ipc = preset_name.clone();
         let webview_state_for_response = webview_state.clone();
         let params_repush_done = Arc::new(AtomicBool::new(false));
 
@@ -820,6 +827,7 @@ unsafe fn build_webview_from_ns_view(
                     &ui_input_queue,
                     &performance_counters,
                     &params,
+                    &preset_name_for_ipc,
                 );
 
                 let response = match result {

--- a/packages/cosmo-pd101-plugin/src/lib.rs
+++ b/packages/cosmo-pd101-plugin/src/lib.rs
@@ -626,6 +626,8 @@ fn sync_all_daw_params_from_synth(params: &CzPluginParams, synth: &SynthParams) 
         .set_value(synth.mod_env.release as f64);
 }
 
+pub(crate) type SharedPresetName = Arc<Mutex<String>>;
+
 // =============================================================================
 // IPC dispatch
 // =============================================================================
@@ -643,6 +645,7 @@ fn handle_ipc_invoke(
     ui_input_queue: &UiInputQueue,
     performance_counters: &PerformanceCountersHandle,
     params: &CzPluginParams,
+    preset_name: &SharedPresetName,
 ) -> Result<serde_json::Value, String> {
     if method != "getScopeData"
         && method != "clientLog"
@@ -874,6 +877,20 @@ fn handle_ipc_invoke(
             append_log(&format!("[webview:{level}] {message}"));
             Ok(serde_json::Value::Null)
         }
+        "setPresetName" => {
+            let name = args
+                .first()
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| "setPresetName expects a string argument".to_string())?;
+            if let Ok(mut stored) = preset_name.lock() {
+                *stored = name.to_string();
+            }
+            Ok(serde_json::Value::Null)
+        }
+        "getPresetName" => {
+            let name = preset_name.lock().map(|n| n.clone()).unwrap_or_default();
+            Ok(serde_json::Value::String(name))
+        }
         _ => Err(format!("unknown method: {method}")),
     }
 }
@@ -902,6 +919,8 @@ pub struct CzPlugin {
     last_scope_hz: f32,
     /// Tracks transport playing state across process() calls to detect stop.
     last_playing: bool,
+    /// Preset name shared with the webview, persisted via save_state/load_state.
+    preset_name: SharedPresetName,
 }
 
 impl CzPlugin {
@@ -929,6 +948,7 @@ impl CzPlugin {
             daw_params_dirty: true,
             last_scope_hz: 220.0,
             last_playing: false,
+            preset_name: Arc::new(Mutex::new(String::new())),
         }
     }
 
@@ -1383,12 +1403,56 @@ impl PluginLogic for CzPlugin {
 
     fn save_state(&self) -> Vec<u8> {
         let sp = self.synth_params.load();
-        serde_json::to_vec(sp.as_ref()).unwrap_or_default()
+        let name = self
+            .preset_name
+            .lock()
+            .map(|n| n.clone())
+            .unwrap_or_default();
+        let state = serde_json::json!({
+            "synth_params": sp.as_ref(),
+            "preset_name": name,
+        });
+        serde_json::to_vec(&state).unwrap_or_default()
     }
 
-    fn load_state(&mut self, data: &[u8]) -> Result<(), StateLoadError> {
-        let params: SynthParams = serde_json::from_slice(data)
-            .map_err(|_| StateLoadError::Malformed("invalid synth params JSON"))?;
+	fn load_state(&mut self, data: &[u8]) -> Result<(), StateLoadError> {
+		// Try new format: { "synth_params": ..., "preset_name": "..." }
+		let (params, loaded_name) =
+			if let Ok(obj) = serde_json::from_slice::<serde_json::Value>(data) {
+				if obj.is_object() && obj.get("synth_params").is_some() {
+					// New wrapper format
+					let synth = obj
+						.get("synth_params")
+						.and_then(|v| serde_json::from_value::<SynthParams>(v.clone()).ok())
+						.ok_or(StateLoadError::Malformed("invalid synth params"))?;
+					let name = obj
+						.get("preset_name")
+						.and_then(|v| v.as_str())
+						.map(|s| s.to_string())
+						.unwrap_or_default();
+					(synth, name)
+				} else {
+					// Old format: flat SynthParams — don't touch preset name
+					let synth: SynthParams = serde_json::from_slice(data)
+						.map_err(|_| StateLoadError::Malformed("invalid synth params JSON"))?;
+					sync_all_daw_params_from_synth(&self.params, &synth);
+					let rt_params = build_rt_synth_params(&synth);
+					let rt_params_arc = Arc::new(rt_params);
+					self.synth_params.store(Arc::new(synth));
+					self.rt_synth_params.store(Arc::clone(&rt_params_arc));
+					self.cached_rt_synth_params = rt_params_arc.clone();
+					self.synth_params_version.fetch_add(1, Ordering::Release);
+					return Ok(());
+				}
+			} else {
+				return Err(StateLoadError::Malformed("invalid JSON"));
+			};
+
+        // Restore preset name (new format only)
+        if let Ok(mut stored) = self.preset_name.lock() {
+            *stored = loaded_name;
+        }
+
         sync_all_daw_params_from_synth(&self.params, &params);
         let rt_params = build_rt_synth_params(&params);
         let rt_params_arc = Arc::new(rt_params);
@@ -1417,6 +1481,7 @@ impl PluginLogic for CzPlugin {
             self.midi_cc_queue.clone(),
             self.performance_counters.clone(),
             self.params.clone(),
+            self.preset_name.clone(),
         ))
     }
 }
@@ -1444,6 +1509,7 @@ mod tests {
         UiInputQueue,
         PerformanceCountersHandle,
         Arc<CzPluginParams>,
+        SharedPresetName,
     ) {
         let sp = Arc::new(ArcSwap::from_pointee(SynthParams::default()));
         let rsp = Arc::new(ArcSwap::from_pointee(SynthParams::default()));
@@ -1455,7 +1521,8 @@ mod tests {
         let q: UiInputQueue = Arc::new(ArrayQueue::new(UI_INPUT_QUEUE_CAPACITY));
         let pc = Arc::new(PerformanceCounters::default());
         let params = Arc::new(CzPluginParams::new());
-        (sp, rsp, rms, ts, ver, sc, q, pc, params)
+        let pn: SharedPresetName = Arc::new(Mutex::new(String::new()));
+        (sp, rsp, rms, ts, ver, sc, q, pc, params, pn)
     }
 
     #[test]
@@ -1475,7 +1542,7 @@ mod tests {
 
     #[test]
     fn set_params_rpc_updates_synth_params() {
-        let (sp, rsp, rms, ts, ver, sc, q, pc, params) = make_handler_state();
+        let (sp, rsp, rms, ts, ver, sc, q, pc, params, pn) = make_handler_state();
 
         let new_params = SynthParams {
             volume: 0.42,
@@ -1495,6 +1562,7 @@ mod tests {
             &q,
             &pc,
             &params,
+            &pn,
         );
         assert!(result.is_ok());
         let current = sp.load();
@@ -1518,6 +1586,7 @@ mod tests {
         let q: UiInputQueue = Arc::new(ArrayQueue::new(UI_INPUT_QUEUE_CAPACITY));
         let pc = Arc::new(PerformanceCounters::default());
         let params = Arc::new(CzPluginParams::new());
+        let pn: SharedPresetName = Arc::new(Mutex::new(String::new()));
 
         let result = handle_ipc_invoke(
             "getParams",
@@ -1531,6 +1600,7 @@ mod tests {
             &q,
             &pc,
             &params,
+            &pn,
         );
         assert!(result.is_ok());
         let val = result.unwrap();
@@ -1540,7 +1610,7 @@ mod tests {
 
     #[test]
     fn note_on_rpc_enqueues_ui_input_event() {
-        let (sp, rsp, rms, ts, ver, sc, q, pc, params) = make_handler_state();
+        let (sp, rsp, rms, ts, ver, sc, q, pc, params, pn) = make_handler_state();
 
         let result = handle_ipc_invoke(
             "noteOn",
@@ -1554,6 +1624,7 @@ mod tests {
             &q,
             &pc,
             &params,
+            &pn,
         );
 
         assert!(result.is_ok());
@@ -1569,7 +1640,7 @@ mod tests {
     #[allow(clippy::field_reassign_with_default)]
     #[test]
     fn set_params_rpc_syncs_daw_float_params() {
-        let (sp, rsp, rms, ts, ver, sc, q, pc, params) = make_handler_state();
+        let (sp, rsp, rms, ts, ver, sc, q, pc, params, pn) = make_handler_state();
         assert_eq!(params.volume.value(), 0.8); // default
 
         let mut new_params = SynthParams::default();
@@ -1589,6 +1660,7 @@ mod tests {
             &q,
             &pc,
             &params,
+            &pn,
         );
         assert!(result.is_ok());
         assert!((params.volume.value() - 0.33).abs() < 0.000_001);
@@ -1632,7 +1704,7 @@ mod tests {
 
     #[test]
     fn get_transport_info_rpc_returns_current_snapshot() {
-        let (sp, rsp, rms, ts, ver, sc, q, pc, params) = make_handler_state();
+        let (sp, rsp, rms, ts, ver, sc, q, pc, params, pn) = make_handler_state();
         ts.store(&TransportInfo {
             playing: true,
             recording: true,
@@ -1660,6 +1732,7 @@ mod tests {
             &q,
             &pc,
             &params,
+            &pn,
         )
         .unwrap();
 
@@ -1806,5 +1879,114 @@ mod tests {
 
         let volume_before = plugin.cached_rt_synth_params.volume;
         assert!((volume_before - 0.2).abs() < 0.000_001);
+    }
+
+    #[test]
+    fn set_preset_name_rpc_stores_name() {
+        let (sp, rsp, rms, ts, ver, sc, q, pc, params, pn) = make_handler_state();
+
+        let result = handle_ipc_invoke(
+            "setPresetName",
+            &[serde_json::Value::String("Warm Pad".to_string())],
+            &sp,
+            &rsp,
+            &rms,
+            &ts,
+            &ver,
+            &sc,
+            &q,
+            &pc,
+            &params,
+            &pn,
+        );
+        assert!(result.is_ok());
+        let stored = pn.lock().unwrap();
+        assert_eq!(*stored, "Warm Pad");
+    }
+
+    #[test]
+    fn get_preset_name_rpc_returns_current_name() {
+        let (sp, rsp, rms, ts, ver, sc, q, pc, params, pn) = make_handler_state();
+        {
+            let mut stored = pn.lock().unwrap();
+            *stored = "Factory Brass".to_string();
+        }
+
+        let result = handle_ipc_invoke(
+            "getPresetName",
+            &[],
+            &sp,
+            &rsp,
+            &rms,
+            &ts,
+            &ver,
+            &sc,
+            &q,
+            &pc,
+            &params,
+            &pn,
+        );
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            serde_json::Value::String("Factory Brass".to_string())
+        );
+    }
+
+    #[test]
+    fn save_state_includes_preset_name() {
+        let params = Arc::new(CzPluginParams::new());
+        let mut plugin = CzPlugin::new(Arc::clone(&params));
+        plugin.reset(48_000.0, 64);
+
+        *plugin.preset_name.lock().unwrap() = "Resonant Pad".to_string();
+
+        let state = plugin.save_state();
+        assert!(!state.is_empty());
+
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&state).expect("state should be valid JSON");
+        assert_eq!(parsed["preset_name"], "Resonant Pad");
+        assert!(parsed.get("synth_params").is_some());
+    }
+
+    #[test]
+    fn load_state_restores_preset_name() {
+        let params = Arc::new(CzPluginParams::new());
+        let mut plugin = CzPlugin::new(Arc::clone(&params));
+        plugin.reset(48_000.0, 64);
+
+        // Save state with a preset name
+        *plugin.preset_name.lock().unwrap() = "Bright Piano".to_string();
+        let state = plugin.save_state();
+
+        // Create new plugin and load state
+        let params2 = Arc::new(CzPluginParams::new());
+        let mut plugin2 = CzPlugin::new(Arc::clone(&params2));
+        plugin2.reset(48_000.0, 64);
+        assert!(plugin2.preset_name.lock().unwrap().is_empty());
+
+        let result = plugin2.load_state(&state);
+        assert!(result.is_ok());
+        assert_eq!(*plugin2.preset_name.lock().unwrap(), "Bright Piano");
+    }
+
+    #[test]
+    fn load_state_falls_back_to_old_format() {
+        // Old format: flat SynthParams JSON (no wrapper)
+        let synth = SynthParams::default();
+        let data = serde_json::to_vec(&synth).unwrap();
+
+        let params = Arc::new(CzPluginParams::new());
+        let mut plugin = CzPlugin::new(Arc::clone(&params));
+        plugin.reset(48_000.0, 64);
+
+        // Set a name to verify it's not overwritten
+        *plugin.preset_name.lock().unwrap() = "Existing Name".to_string();
+
+        let result = plugin.load_state(&data);
+        assert!(result.is_ok());
+        // Old format should not touch preset_name
+        assert_eq!(*plugin.preset_name.lock().unwrap(), "Existing Name");
     }
 }

--- a/packages/cosmo-pd101-plugin/src/lib.rs
+++ b/packages/cosmo-pd101-plugin/src/lib.rs
@@ -1391,9 +1391,17 @@ impl PluginLogic for CzPlugin {
             .map_err(|_| StateLoadError::Malformed("invalid synth params JSON"))?;
         sync_all_daw_params_from_synth(&self.params, &params);
         let rt_params = build_rt_synth_params(&params);
+        let rt_params_arc = Arc::new(rt_params);
         self.synth_params.store(Arc::new(params));
-        self.rt_synth_params.store(Arc::new(rt_params));
+        self.rt_synth_params.store(Arc::clone(&rt_params_arc));
+        self.cached_rt_synth_params = rt_params_arc.clone();
         self.synth_params_version.fetch_add(1, Ordering::Release);
+        self.cached_synth_params_version = self.synth_params_version.load(Ordering::Acquire);
+        self.daw_params_dirty = false;
+        if let Some(ref mut proc) = self.processor {
+            proc.set_shared_params(rt_params_arc);
+            self.performance_counters.record_param_apply();
+        }
         Ok(())
     }
 

--- a/packages/cosmo-pd101-plugin/src/lib.rs
+++ b/packages/cosmo-pd101-plugin/src/lib.rs
@@ -1415,38 +1415,38 @@ impl PluginLogic for CzPlugin {
         serde_json::to_vec(&state).unwrap_or_default()
     }
 
-	fn load_state(&mut self, data: &[u8]) -> Result<(), StateLoadError> {
-		// Try new format: { "synth_params": ..., "preset_name": "..." }
-		let (params, loaded_name) =
-			if let Ok(obj) = serde_json::from_slice::<serde_json::Value>(data) {
-				if obj.is_object() && obj.get("synth_params").is_some() {
-					// New wrapper format
-					let synth = obj
-						.get("synth_params")
-						.and_then(|v| serde_json::from_value::<SynthParams>(v.clone()).ok())
-						.ok_or(StateLoadError::Malformed("invalid synth params"))?;
-					let name = obj
-						.get("preset_name")
-						.and_then(|v| v.as_str())
-						.map(|s| s.to_string())
-						.unwrap_or_default();
-					(synth, name)
-				} else {
-					// Old format: flat SynthParams — don't touch preset name
-					let synth: SynthParams = serde_json::from_slice(data)
-						.map_err(|_| StateLoadError::Malformed("invalid synth params JSON"))?;
-					sync_all_daw_params_from_synth(&self.params, &synth);
-					let rt_params = build_rt_synth_params(&synth);
-					let rt_params_arc = Arc::new(rt_params);
-					self.synth_params.store(Arc::new(synth));
-					self.rt_synth_params.store(Arc::clone(&rt_params_arc));
-					self.cached_rt_synth_params = rt_params_arc.clone();
-					self.synth_params_version.fetch_add(1, Ordering::Release);
-					return Ok(());
-				}
-			} else {
-				return Err(StateLoadError::Malformed("invalid JSON"));
-			};
+    fn load_state(&mut self, data: &[u8]) -> Result<(), StateLoadError> {
+        // Try new format: { "synth_params": ..., "preset_name": "..." }
+        let (params, loaded_name) =
+            if let Ok(obj) = serde_json::from_slice::<serde_json::Value>(data) {
+                if obj.is_object() && obj.get("synth_params").is_some() {
+                    // New wrapper format
+                    let synth = obj
+                        .get("synth_params")
+                        .and_then(|v| serde_json::from_value::<SynthParams>(v.clone()).ok())
+                        .ok_or(StateLoadError::Malformed("invalid synth params"))?;
+                    let name = obj
+                        .get("preset_name")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string())
+                        .unwrap_or_default();
+                    (synth, name)
+                } else {
+                    // Old format: flat SynthParams — don't touch preset name
+                    let synth: SynthParams = serde_json::from_slice(data)
+                        .map_err(|_| StateLoadError::Malformed("invalid synth params JSON"))?;
+                    sync_all_daw_params_from_synth(&self.params, &synth);
+                    let rt_params = build_rt_synth_params(&synth);
+                    let rt_params_arc = Arc::new(rt_params);
+                    self.synth_params.store(Arc::new(synth));
+                    self.rt_synth_params.store(Arc::clone(&rt_params_arc));
+                    self.cached_rt_synth_params = rt_params_arc.clone();
+                    self.synth_params_version.fetch_add(1, Ordering::Release);
+                    return Ok(());
+                }
+            } else {
+                return Err(StateLoadError::Malformed("invalid JSON"));
+            };
 
         // Restore preset name (new format only)
         if let Ok(mut stored) = self.preset_name.lock() {

--- a/packages/cosmo-pd101-plugin/webview/e2e/plugin-preset-persistence.spec.ts
+++ b/packages/cosmo-pd101-plugin/webview/e2e/plugin-preset-persistence.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { waitForBridge } from "./helpers/pluginBridge";
+
+const LATEST_RELEASE_URL =
+	"https://api.github.com/repos/fpbrault/cosmo-pd/releases/latest";
+
+test.beforeEach(async ({ page }) => {
+	await page.route(LATEST_RELEASE_URL, async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: "application/json",
+			body: JSON.stringify({
+				tag_name: "v0.0.0",
+				html_url: "https://github.com/fpbrault/cosmo-pd/releases/tag/v0.0.0",
+			}),
+		});
+	});
+});
+
+test.describe("Preset name persistence", () => {
+	test("restores preset name from IPC on mount", async ({ page }) => {
+		await page.addInitScript(() => {
+			window.__CZ_MOCK_PRESET_NAME = "Warm Pad";
+		});
+		await page.goto("/", { waitUntil: "domcontentloaded" });
+		await waitForBridge(page);
+		await expect(page.getByText("COSMO").first()).toBeVisible({
+			timeout: 5000,
+		});
+
+		const presetButton = page.getByRole("button", { name: /^preset /i });
+		await expect(presetButton).toContainText("Warm Pad", { timeout: 5000 });
+	});
+
+	test("preset name is saved via IPC after host selection", async ({
+		page,
+	}) => {
+		await page.goto("/", { waitUntil: "domcontentloaded" });
+		await waitForBridge(page);
+		await expect(page.getByText("COSMO").first()).toBeVisible({
+			timeout: 5000,
+		});
+
+		await page.waitForFunction(
+			() => typeof window.__czOnHostPresetSelected === "function",
+			{ timeout: 5000 },
+		);
+
+		await page.evaluate(() => {
+			window.__czOnHostPresetSelected?.("Factory Brass");
+		});
+
+		const storedName = await page.evaluate(async () => {
+			const name = await window.__czGetPresetName?.();
+			return typeof name === "string" ? name : null;
+		});
+		expect(storedName).toBe("Factory Brass");
+	});
+});

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx
@@ -93,57 +93,22 @@ describe("PluginPage", () => {
 		delete (window as Window & { ipc?: unknown }).ipc;
 	});
 
-	it("hydrates preset session restored from plugin host", () => {
+	it("renders and initializes the preset manager", () => {
 		render(<PluginPage />);
 
 		expect(mockUseSynthPresetManager).toHaveBeenCalledTimes(1);
-		const options = mockUseSynthPresetManager.mock.calls[0]?.[0] as {
-			shouldLoadCurrentState: () => boolean;
-		};
-		expect(options.shouldLoadCurrentState()).toBe(true);
+		const options = mockUseSynthPresetManager.mock.calls[0]?.[0];
+		expect(options).not.toHaveProperty("shouldLoadCurrentState");
 	});
 
-	it("syncs preset session to host using loaded preset fingerprint baseline", () => {
-		const postMessage = vi.fn();
-		(
-			window as Window & { ipc?: { postMessage: (message: string) => void } }
-		).ipc = {
-			postMessage,
-		};
-
-		mockUseSynthPresetManager.mockReturnValue({
-			allPresetEntries: [],
-			activePresetId: "builtin:Factory Brass",
-			activePresetNameBase: "Factory Brass",
-			activePresetName: "Factory Brass *",
-			loadedPresetFingerprint: "baseline-fingerprint",
-			pendingPresetChange: null,
-			handleLoadLocal: vi.fn(),
-			handleLoadBuiltin: vi.fn(),
-			handleLoadLibrary: vi.fn(),
-			handleStepPreset: vi.fn(),
-			handleSavePreset: vi.fn(),
-			handleDeletePreset: vi.fn(),
-			handleRenamePreset: vi.fn(),
-			handleInitPreset: vi.fn(),
-			handleExportPreset: vi.fn(),
-			handleImportPreset: vi.fn(),
-			handleExportCurrentState: vi.fn(),
-			handleSavePendingPresetChange: vi.fn(),
-			handleDiscardPendingPresetChange: vi.fn(),
-			handleCancelPendingPresetChange: vi.fn(),
-		});
+	it("calls __czGetPresetName on mount to restore preset name", async () => {
+		const getPresetName = vi.fn().mockResolvedValue("Warm Pad");
+		window.__czGetPresetName = getPresetName;
 
 		render(<PluginPage />);
 
-		expect(postMessage).toHaveBeenCalledTimes(1);
-		const payload = JSON.parse(postMessage.mock.calls[0]?.[0] ?? "{}");
-		expect(payload).toEqual({
-			preset_session: {
-				activePresetId: "builtin:Factory Brass",
-				activePresetNameBase: "Factory Brass",
-				loadedPresetFingerprint: "baseline-fingerprint",
-			},
+		await vi.waitFor(() => {
+			expect(getPresetName).toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
@@ -142,8 +142,6 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 		[],
 	);
 
-	usePluginParamBridge();
-
 	useEffect(() => {
 		const element = frameRef.current;
 		if (!element) {

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
@@ -201,8 +201,6 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 		};
 	}, [isIosHost, isLikelyIosDevice, keyboardHeight, setKeyboardHeight]);
 
-	const shouldLoadCurrentState = useCallback(() => !window.ipc, []);
-
 	const {
 		activePresetId,
 		activePresetNameBase,
@@ -214,7 +212,6 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 		gatherPresetState: gatherState,
 		applyPreset,
 		libraryPresets: FACTORY_CZ_PRESETS,
-		shouldLoadCurrentState,
 	});
 
 	useEffect(() => {

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
@@ -201,18 +201,27 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 		};
 	}, [isIosHost, isLikelyIosDevice, keyboardHeight, setKeyboardHeight]);
 
-	const {
-		activePresetId,
-		activePresetNameBase,
-		loadedPresetFingerprint,
-		handleSyncBuiltinSelection,
-		handleLoadBuiltin,
-	} = useSynthPresetManager({
-		builtinPresets: DEFAULT_SYNTH_PRESETS,
-		gatherPresetState: gatherState,
-		applyPreset,
-		libraryPresets: FACTORY_CZ_PRESETS,
-	});
+	const syncInstanceBRef = useRef<(name: string) => void>();
+
+	const handlePluginPresetSessionChange = useCallback(
+		(session: { activePresetNameBase: string }) => {
+			if (
+				session.activePresetNameBase &&
+				session.activePresetNameBase !== "Current State"
+			) {
+				window.__czSetPresetName?.(session.activePresetNameBase);
+			}
+		},
+		[],
+	);
+
+	const { handleSyncBuiltinSelection, handleLoadBuiltin } =
+		useSynthPresetManager({
+			builtinPresets: DEFAULT_SYNTH_PRESETS,
+			gatherPresetState: gatherState,
+			applyPreset,
+			libraryPresets: FACTORY_CZ_PRESETS,
+		});
 
 	useEffect(() => {
 		return installBenchmarkApi({
@@ -245,6 +254,7 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 	useEffect(() => {
 		window.__czOnHostPresetSelected = (name: string) => {
 			handleSyncBuiltinSelection(name);
+			syncInstanceBRef.current?.(name);
 		};
 		return () => {
 			window.__czOnHostPresetSelected = undefined;
@@ -252,19 +262,14 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 	}, [handleSyncBuiltinSelection]);
 
 	useEffect(() => {
-		if (!window.ipc || loadedPresetFingerprint == null) {
-			return;
-		}
-		window.ipc.postMessage(
-			JSON.stringify({
-				preset_session: {
-					activePresetId,
-					activePresetNameBase,
-					loadedPresetFingerprint,
-				},
-			}),
-		);
-	}, [activePresetId, activePresetNameBase, loadedPresetFingerprint]);
+		const restore = async () => {
+			const name = (await window.__czGetPresetName?.()) as string | undefined;
+			if (name && name !== "Current State") {
+				syncInstanceBRef.current?.(name);
+			}
+		};
+		restore();
+	}, []);
 
 	const combinedScale = rendererFrame?.frameScale ?? 1;
 	const frameWidth =
@@ -311,6 +316,10 @@ export default function PluginPage({ utilityExtra }: PluginPageProps = {}) {
 							onNoteOff: sendNoteOff,
 							onPolyAftertouch: sendPolyAftertouch,
 						}}
+						onInitPresetSession={(fn) => {
+							syncInstanceBRef.current = fn;
+						}}
+						onPresetSessionChange={handlePluginPresetSessionChange}
 					/>
 				</div>
 			</div>

--- a/packages/cosmo-pd101-plugin/webview/src/lib/IPCBridge.ts
+++ b/packages/cosmo-pd101-plugin/webview/src/lib/IPCBridge.ts
@@ -42,6 +42,8 @@ declare global {
 		__czOnScope?: (samples: number[], sampleRate: number, hz: number) => void;
 		__czIpcResponse?: (response: IpcRpcResponse) => void;
 		__czOnMidiCc?: (channel: number, cc: number, value: number) => void;
+		__czSetPresetName?: (name: string) => void;
+		__czGetPresetName?: () => Promise<unknown>;
 	}
 }
 
@@ -175,6 +177,13 @@ function installIpcRouter() {
 
 	window.__czGetPerformanceMetrics = () => invokeRust("getPerformanceMetrics");
 	window.__czGetTransportInfo = () => invokeRust("getTransportInfo");
+
+	window.__czGetPresetName = () => invokeRust("getPresetName");
+	window.__czSetPresetName = (name: string) => {
+		void invokeRust("setPresetName", name).catch((error) => {
+			console.error("[IPCBridge] setPresetName error", error);
+		});
+	};
 }
 
 // ─── Native IPC passthrough ───────────────────────────────────────────────────

--- a/packages/cosmo-pd101-plugin/webview/src/test/mockPluginBridge.ts
+++ b/packages/cosmo-pd101-plugin/webview/src/test/mockPluginBridge.ts
@@ -177,6 +177,11 @@ export interface MockBridgeHandle {
 	/** Simulate a failed invoke for the next pending unresolved invoke. */
 	rejectNextInvoke(error: string): void;
 
+	/** Get the current preset name from the mock's virtual state. */
+	getPresetName(): string;
+	/** Set the preset name in the mock's virtual state. */
+	setPresetName(name: string): void;
+
 	/** Reset recorded messages and pending listeners. Does NOT reinstall the runtime. */
 	reset(): void;
 }
@@ -189,6 +194,7 @@ declare global {
 			result?: unknown;
 			error?: string;
 		}) => void;
+		__CZ_MOCK_PRESET_NAME?: string;
 	}
 }
 
@@ -342,6 +348,12 @@ export function installMockPluginBridge(): void {
 	let pendingInvokeResolve: ((result: unknown) => void) | null = null;
 	let pendingInvokeReject: ((error: string) => void) | null = null;
 	let virtualModMatrix: { routes: unknown[] } = { routes: [] };
+	let virtualPresetName =
+		(typeof window !== "undefined"
+			? ((window as Record<string, unknown>).__CZ_MOCK_PRESET_NAME as
+					| string
+					| undefined)
+			: undefined) ?? "";
 
 	// Full params blob received from the last setParams IPC call.
 	// Used by pushParamUpdate/pushPluginParamUpdate to build valid full-param updates.
@@ -582,6 +594,15 @@ export function installMockPluginBridge(): void {
 				respondIpc(id, { result: { routes: [...virtualModMatrix.routes] } });
 				return;
 			}
+			if (method === "getPresetName") {
+				respondIpc(id, { result: virtualPresetName });
+				return;
+			}
+			if (method === "setPresetName") {
+				virtualPresetName = typeof args[0] === "string" ? args[0] : "";
+				respondIpc(id, { result: null });
+				return;
+			}
 			if (method === "getScopeData") {
 				respondIpc(id, {
 					result: { samples: [], sampleRate: 44100, hz: 220 },
@@ -662,6 +683,11 @@ export function installMockPluginBridge(): void {
 		},
 
 		getState: () => ({ ...virtualParamState }),
+
+		getPresetName: () => virtualPresetName,
+		setPresetName: (name: string) => {
+			virtualPresetName = name;
+		},
 
 		onMessage(cb: (msg: MockBridgeMessage) => void): () => void {
 			messageListeners.push(cb);

--- a/packages/cosmo-pd101/site/src/LivePage.tsx
+++ b/packages/cosmo-pd101/site/src/LivePage.tsx
@@ -15,6 +15,12 @@ import {
 	SYNTH_RENDERER_MAX_ASPECT_RATIO,
 } from "../../src/components/renderer/rendererFrameLayout";
 import { SharedPhaseDistortionVisualizer } from "../../src/components/renderer/SynthRenderer";
+import { useSynthStore } from "../../src/features/synth/synthStore";
+import { DEFAULT_SYNTH_PRESETS } from "../../src/lib/synth/defaultPresets";
+import {
+	loadCurrentState,
+	saveCurrentState,
+} from "../../src/lib/synth/presetStorage";
 
 declare const __CZ_APP_VERSION__: string;
 
@@ -152,6 +158,30 @@ export default function LivePage() {
 		};
 		document.addEventListener("fullscreenchange", onChange);
 		return () => document.removeEventListener("fullscreenchange", onChange);
+	}, []);
+
+	useEffect(() => {
+		const init = async () => {
+			const saved = await loadCurrentState();
+			if (saved) {
+				useSynthStore.getState().applyPreset(saved);
+			} else {
+				const firstPreset = Object.values(DEFAULT_SYNTH_PRESETS)[0];
+				if (firstPreset) {
+					useSynthStore.getState().applyPreset(firstPreset.data);
+				}
+			}
+		};
+		init();
+	}, []);
+
+	useEffect(() => {
+		const handleBeforeUnload = () => {
+			const state = useSynthStore.getState().gatherState();
+			void saveCurrentState(state);
+		};
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		return () => window.removeEventListener("beforeunload", handleBeforeUnload);
 	}, []);
 
 	return (

--- a/packages/cosmo-pd101/site/src/LivePage.tsx
+++ b/packages/cosmo-pd101/site/src/LivePage.tsx
@@ -18,7 +18,9 @@ import { SharedPhaseDistortionVisualizer } from "../../src/components/renderer/S
 import { useSynthStore } from "../../src/features/synth/synthStore";
 import { DEFAULT_SYNTH_PRESETS } from "../../src/lib/synth/defaultPresets";
 import {
+	loadCurrentPresetSession,
 	loadCurrentState,
+	saveCurrentPresetSession,
 	saveCurrentState,
 } from "../../src/lib/synth/presetStorage";
 
@@ -138,6 +140,20 @@ export default function LivePage() {
 		? {}
 		: { width: scaledWidth, height: scaledHeight };
 
+	const syncBuiltinSelectionRef = useRef<(name: string) => void>();
+
+	const handlePresetSessionChange = useCallback(
+		(session: { activePresetNameBase: string }) => {
+			if (session.activePresetNameBase === "Current State") return;
+			void saveCurrentPresetSession({
+				activePresetId: null,
+				activePresetNameBase: session.activePresetNameBase,
+				loadedPresetFingerprint: null,
+			});
+		},
+		[],
+	);
+
 	const toggleFullscreen = useCallback(async () => {
 		if (!document.fullscreenElement) {
 			try {
@@ -163,12 +179,20 @@ export default function LivePage() {
 	useEffect(() => {
 		const init = async () => {
 			const saved = await loadCurrentState();
+			const session = await loadCurrentPresetSession();
 			if (saved) {
 				useSynthStore.getState().applyPreset(saved);
+			}
+			if (
+				session?.activePresetNameBase &&
+				session.activePresetNameBase !== "Current State"
+			) {
+				syncBuiltinSelectionRef.current?.(session.activePresetNameBase);
 			} else {
 				const firstPreset = Object.values(DEFAULT_SYNTH_PRESETS)[0];
 				if (firstPreset) {
 					useSynthStore.getState().applyPreset(firstPreset.data);
+					syncBuiltinSelectionRef.current?.(firstPreset.name);
 				}
 			}
 		};
@@ -226,6 +250,10 @@ export default function LivePage() {
 						bottomBarExtra={
 							<UpdateNotification currentVersion={__CZ_APP_VERSION__} />
 						}
+						onInitPresetSession={(fn) => {
+							syncBuiltinSelectionRef.current = fn;
+						}}
+						onPresetSessionChange={handlePresetSessionChange}
 					/>
 				</div>
 			</div>

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -67,6 +67,8 @@ export type SynthRendererProps = {
 		}) => void,
 	) => () => void;
 	miniKeyboard?: MiniKeyboardProps;
+	onInitPresetSession?: (syncBuiltinSelection: (name: string) => void) => void;
+	onPresetSessionChange?: (session: { activePresetNameBase: string }) => void;
 };
 
 const FRAME_CLASS =
@@ -98,6 +100,8 @@ const SynthRenderer = memo(function SynthRenderer({
 	sidebarMinWidthRem = 18,
 	subscribeScopeFrames,
 	miniKeyboard,
+	onInitPresetSession,
+	onPresetSessionChange,
 }: SynthRendererProps = {}) {
 	const velocityCurve = useSynthStore((s) => s.velocityCurve);
 	const gatherState = useSynthStore((s) => s.gatherState);
@@ -186,6 +190,7 @@ const SynthRenderer = memo(function SynthRenderer({
 		visiblePresetEntries,
 		activePresetId,
 		activePresetName,
+		activePresetNameBase,
 		pendingPresetChange,
 		handleLoadLocal,
 		handleLoadBuiltin,
@@ -203,6 +208,7 @@ const SynthRenderer = memo(function SynthRenderer({
 		handleSavePendingPresetChange,
 		handleDiscardPendingPresetChange,
 		handleCancelPendingPresetChange,
+		handleSyncBuiltinSelection,
 	} = useSynthPresetManager({
 		builtinPresets: DEFAULT_SYNTH_PRESETS,
 		gatherPresetState,
@@ -284,6 +290,14 @@ const SynthRenderer = memo(function SynthRenderer({
 	useEffect(() => {
 		setLibraryVisibleEntries(visiblePresetEntries);
 	}, [visiblePresetEntries]);
+
+	useEffect(() => {
+		onInitPresetSession?.(handleSyncBuiltinSelection);
+	}, [handleSyncBuiltinSelection, onInitPresetSession]);
+
+	useEffect(() => {
+		onPresetSessionChange?.({ activePresetNameBase });
+	}, [activePresetNameBase, onPresetSessionChange]);
 
 	const handleStepPresetInVisibleOrder = useCallback(
 		(direction: -1 | 1) => {

--- a/packages/cosmo-pd101/src/features/synth/engine/pluginBridgeSynthEngineAdapter.ts
+++ b/packages/cosmo-pd101/src/features/synth/engine/pluginBridgeSynthEngineAdapter.ts
@@ -169,11 +169,6 @@ export function usePluginBridgeSynthEngine(
 	// Hydration: getParams from Rust once on mount
 	useEffect(() => {
 		if (!enabled) return;
-		if (!window.__czGetParams) {
-			// Running in WASM/standalone mode — outbound sync can start immediately.
-			outboundEnabledRef.current = true;
-			return;
-		}
 		let cancelled = false;
 		let retryCount = 0;
 		const MAX_RETRIES = 10;
@@ -202,7 +197,20 @@ export function usePluginBridgeSynthEngine(
 		const tryGetParams = () => {
 			if (cancelled) return;
 			const getParams = window.__czGetParams;
-			if (!getParams) return;
+			if (!getParams) {
+				// Bridge not ready yet — retry.
+				retryCount++;
+				// Open the gate so controls work immediately while we wait.
+				if (!outboundEnabledRef.current) {
+					outboundEnabledRef.current = true;
+				}
+				if (retryCount <= MAX_RETRIES) {
+					retryId = window.setTimeout(tryGetParams, RETRY_DELAY_MS);
+				} else {
+					window.clearTimeout(fallbackId);
+				}
+				return;
+			}
 			void getParams()
 				.then((result) => {
 					window.clearTimeout(fallbackId);
@@ -220,7 +228,6 @@ export function usePluginBridgeSynthEngine(
 						// Open the gate so controls work immediately while we retry.
 						if (!outboundEnabledRef.current) {
 							outboundEnabledRef.current = true;
-							syncRef.current?.();
 						}
 						retryId = window.setTimeout(tryGetParams, RETRY_DELAY_MS);
 					} else {
@@ -231,7 +238,6 @@ export function usePluginBridgeSynthEngine(
 						);
 						if (!outboundEnabledRef.current) {
 							outboundEnabledRef.current = true;
-							syncRef.current?.();
 						}
 					}
 				});

--- a/packages/cosmo-pd101/src/features/synth/usePresetManagerPersistence.ts
+++ b/packages/cosmo-pd101/src/features/synth/usePresetManagerPersistence.ts
@@ -1,102 +1,15 @@
 import { useEffect } from "react";
-import type { SynthPresetV1 } from "@/lib/synth/bindings/synth";
-import {
-	loadCurrentPresetSession,
-	loadCurrentState,
-	saveCurrentPresetSession,
-	saveCurrentState,
-} from "@/lib/synth/presetStorage";
 
-type UsePresetManagerPersistenceOptions = {
-	applyPreset: (data: SynthPresetV1) => void;
-	builtinPresets: Record<string, unknown>;
-	loadBuiltinPreset: (name: string) => void;
+type UsePresetLibraryRefreshOptions = {
 	refreshFavoritePresetIds: () => Promise<void>;
 	refreshLocalPresetEntries: () => Promise<void>;
-	shouldHydratePersistedState: boolean;
-	gatherState: () => SynthPresetV1;
-	activePresetId: string | null;
-	activePresetNameBase: string;
-	loadedPresetFingerprint: string | null;
-	setActivePresetId: (value: string | null) => void;
-	setActivePresetNameBase: (value: string) => void;
-	setLoadedPresetFingerprint: (value: string | null) => void;
 };
 
 export function usePresetManagerPersistence({
-	applyPreset,
-	builtinPresets,
-	loadBuiltinPreset,
 	refreshFavoritePresetIds,
 	refreshLocalPresetEntries,
-	shouldHydratePersistedState,
-	gatherState,
-	activePresetId,
-	activePresetNameBase,
-	loadedPresetFingerprint,
-	setActivePresetId,
-	setActivePresetNameBase,
-	setLoadedPresetFingerprint,
-}: UsePresetManagerPersistenceOptions) {
+}: UsePresetLibraryRefreshOptions) {
 	useEffect(() => {
-		const init = async () => {
-			await Promise.all([
-				refreshLocalPresetEntries(),
-				refreshFavoritePresetIds(),
-			]);
-
-			if (!shouldHydratePersistedState) return;
-
-			const session = await loadCurrentPresetSession();
-			if (session) {
-				setActivePresetId(session.activePresetId);
-				setActivePresetNameBase(session.activePresetNameBase);
-				setLoadedPresetFingerprint(session.loadedPresetFingerprint);
-				const saved = await loadCurrentState();
-				if (saved) applyPreset(saved);
-				return;
-			}
-
-			const isTestMode = import.meta.env.VITE_TEST_HARNESS === "1";
-			if (!isTestMode) {
-				const firstPresetName = Object.keys(builtinPresets)[0];
-				if (firstPresetName) {
-					loadBuiltinPreset(firstPresetName);
-					return;
-				}
-			}
-
-			const saved = await loadCurrentState();
-			if (saved) applyPreset(saved);
-		};
-
-		init();
-	}, [
-		applyPreset,
-		builtinPresets,
-		loadBuiltinPreset,
-		refreshFavoritePresetIds,
-		refreshLocalPresetEntries,
-		setActivePresetId,
-		setActivePresetNameBase,
-		setLoadedPresetFingerprint,
-		shouldHydratePersistedState,
-	]);
-
-	useEffect(() => {
-		const timer = setTimeout(() => {
-			saveCurrentState(gatherState());
-			saveCurrentPresetSession({
-				activePresetId,
-				activePresetNameBase,
-				loadedPresetFingerprint,
-			});
-		}, 500);
-		return () => clearTimeout(timer);
-	}, [
-		activePresetId,
-		activePresetNameBase,
-		gatherState,
-		loadedPresetFingerprint,
-	]);
+		void Promise.all([refreshLocalPresetEntries(), refreshFavoritePresetIds()]);
+	}, [refreshFavoritePresetIds, refreshLocalPresetEntries]);
 }

--- a/packages/cosmo-pd101/src/features/synth/useSynthPresetManager.test.ts
+++ b/packages/cosmo-pd101/src/features/synth/useSynthPresetManager.test.ts
@@ -64,7 +64,6 @@ describe("useSynthPresetManager", () => {
 				builtinPresets: mockBuiltinPresets,
 				gatherPresetState: mockGatherPresetState,
 				applyPreset: mockApplyPreset,
-				shouldLoadCurrentState: () => false,
 			}),
 		);
 
@@ -114,7 +113,6 @@ describe("useSynthPresetManager", () => {
 				builtinPresets: mockBuiltinPresets,
 				gatherPresetState: mockGatherPresetState,
 				applyPreset: mockApplyPreset,
-				shouldLoadCurrentState: () => false,
 			}),
 		);
 
@@ -239,7 +237,6 @@ describe("useSynthPresetManager", () => {
 				builtinPresets: {},
 				gatherPresetState: mockGatherPresetState,
 				applyPreset: mockApplyPreset,
-				shouldLoadCurrentState: () => false,
 			}),
 		);
 
@@ -274,7 +271,6 @@ describe("useSynthPresetManager", () => {
 				builtinPresets: {},
 				gatherPresetState: mockGatherPresetState,
 				applyPreset: mockApplyPreset,
-				shouldLoadCurrentState: () => false,
 			}),
 		);
 
@@ -293,7 +289,6 @@ describe("useSynthPresetManager", () => {
 				builtinPresets: mockBuiltinPresets,
 				gatherPresetState: mockGatherPresetState,
 				applyPreset: mockApplyPreset,
-				shouldLoadCurrentState: () => false,
 			}),
 		);
 
@@ -343,7 +338,6 @@ describe("useSynthPresetManager", () => {
 				builtinPresets: {},
 				gatherPresetState: mockGatherPresetState,
 				applyPreset: mockApplyPreset,
-				shouldLoadCurrentState: () => false,
 			}),
 		);
 

--- a/packages/cosmo-pd101/src/features/synth/useSynthPresetManager.test.ts
+++ b/packages/cosmo-pd101/src/features/synth/useSynthPresetManager.test.ts
@@ -72,31 +72,6 @@ describe("useSynthPresetManager", () => {
 		expect(result.current.visiblePresetEntries.length).toBe(2);
 	});
 
-	it("loads persisted state if available", async () => {
-		vi.mocked(presetStorage.loadCurrentState).mockResolvedValue({
-			some: "persisted",
-		} as unknown as SynthPresetV1);
-		vi.mocked(presetStorage.loadCurrentPresetSession).mockResolvedValue({
-			activePresetId: "local-preset",
-			activePresetNameBase: "MyPreset",
-			loadedPresetFingerprint: JSON.stringify({ some: "persisted" }),
-		});
-
-		const { result } = renderHook(() =>
-			useSynthPresetManager({
-				builtinPresets: mockBuiltinPresets,
-				gatherPresetState: mockGatherPresetState,
-				applyPreset: mockApplyPreset,
-			}),
-		);
-
-		await waitFor(() => {
-			expect(mockApplyPreset).toHaveBeenCalledWith({ some: "persisted" });
-		});
-		expect(result.current.activePresetId).toBe("local-preset");
-		expect(result.current.activePresetNameBase).toBe("MyPreset");
-	});
-
 	it("handles loading a local preset", async () => {
 		vi.mocked(presetStorage.loadStoredPreset).mockResolvedValue({
 			id: "local-preset",
@@ -145,14 +120,7 @@ describe("useSynthPresetManager", () => {
 		expect(result.current.activePresetNameBase).toBe("Preset 1");
 	});
 
-	it("detects unsaved changes", async () => {
-		vi.mocked(presetStorage.loadCurrentPresetSession).mockResolvedValue({
-			activePresetId: "local-preset",
-			activePresetNameBase: "MyPreset",
-			loadedPresetFingerprint: JSON.stringify({ a: 1 }),
-		});
-		mockGatherPresetState.mockReturnValue({ a: 2 } as unknown as SynthPresetV1);
-
+	it("handleSyncBuiltinSelection sets preset name without applying data", () => {
 		const { result } = renderHook(() =>
 			useSynthPresetManager({
 				builtinPresets: mockBuiltinPresets,
@@ -161,19 +129,16 @@ describe("useSynthPresetManager", () => {
 			}),
 		);
 
-		await waitFor(() => {
-			expect(result.current.activePresetName).toBe("MyPreset *");
+		act(() => {
+			result.current.handleSyncBuiltinSelection("Preset 1");
 		});
+
+		expect(result.current.activePresetId).toBe("preset-1");
+		expect(result.current.activePresetNameBase).toBe("Preset 1");
+		expect(mockApplyPreset).not.toHaveBeenCalled();
 	});
 
-	it("handles pending preset change flow", async () => {
-		vi.mocked(presetStorage.loadCurrentPresetSession).mockResolvedValue({
-			activePresetId: "local-preset",
-			activePresetNameBase: "MyPreset",
-			loadedPresetFingerprint: JSON.stringify({ a: 1 }),
-		});
-		mockGatherPresetState.mockReturnValue({ a: 2 } as unknown as SynthPresetV1);
-
+	it("handleSyncBuiltinSelection with unknown name sets ID to null", () => {
 		const { result } = renderHook(() =>
 			useSynthPresetManager({
 				builtinPresets: mockBuiltinPresets,
@@ -182,19 +147,136 @@ describe("useSynthPresetManager", () => {
 			}),
 		);
 
-		await waitFor(() => {
-			expect(result.current.activePresetName).toBe("MyPreset *");
+		act(() => {
+			result.current.handleSyncBuiltinSelection("NonExistent");
 		});
+
+		expect(result.current.activePresetId).toBeNull();
+		expect(result.current.activePresetNameBase).toBe("NonExistent");
+	});
+
+	it("handleSyncBuiltinSelection captures loaded preset fingerprint", () => {
+		const gatherFn = vi.fn(
+			() => ({ test: "value" }) as unknown as SynthPresetV1,
+		);
+		const { result, rerender } = renderHook(
+			({ gather }: { gather: () => SynthPresetV1 }) =>
+				useSynthPresetManager({
+					builtinPresets: mockBuiltinPresets,
+					gatherPresetState: gather,
+					applyPreset: mockApplyPreset,
+				}),
+			{ initialProps: { gather: gatherFn } },
+		);
+
+		act(() => {
+			result.current.handleSyncBuiltinSelection("Preset 1");
+		});
+
+		expect(result.current.activePresetName).toBe("Preset 1");
+
+		const diffGatherFn = vi.fn(
+			() => ({ test: "different" }) as unknown as SynthPresetV1,
+		);
+		rerender({ gather: diffGatherFn });
+
+		expect(result.current.activePresetName).toBe("Preset 1 *");
+	});
+
+	it("preset name is persisted via localStorage across remounts", () => {
+		const gatherFn = vi.fn(() => ({}) as SynthPresetV1);
+		const { result, unmount } = renderHook(() =>
+			useSynthPresetManager({
+				builtinPresets: mockBuiltinPresets,
+				gatherPresetState: gatherFn,
+				applyPreset: mockApplyPreset,
+			}),
+		);
+
+		act(() => {
+			result.current.handleLoadBuiltin("Preset 1");
+		});
+		expect(result.current.activePresetNameBase).toBe("Preset 1");
+		localStorage.setItem(
+			"cosmo-pd:preset-name",
+			result.current.activePresetNameBase,
+		);
+		expect(localStorage.getItem("cosmo-pd:preset-name")).toBe("Preset 1");
+
+		unmount();
+
+		const { result: result2 } = renderHook(() =>
+			useSynthPresetManager({
+				builtinPresets: mockBuiltinPresets,
+				gatherPresetState: gatherFn,
+				applyPreset: mockApplyPreset,
+			}),
+		);
+
+		const savedName = localStorage.getItem("cosmo-pd:preset-name");
+		expect(savedName).toBe("Preset 1");
+		if (savedName && savedName !== "Current State") {
+			act(() => {
+				result2.current.handleSyncBuiltinSelection(savedName);
+			});
+		}
+
+		expect(result2.current.activePresetNameBase).toBe("Preset 1");
+	});
+
+	it("detects unsaved changes", () => {
+		const gatherFn = vi.fn(() => ({}) as SynthPresetV1);
+		const { result, rerender } = renderHook(
+			({ gather }: { gather: () => SynthPresetV1 }) =>
+				useSynthPresetManager({
+					builtinPresets: mockBuiltinPresets,
+					gatherPresetState: gather,
+					applyPreset: mockApplyPreset,
+				}),
+			{ initialProps: { gather: gatherFn } },
+		);
 
 		act(() => {
 			result.current.handleLoadBuiltin("Preset 1");
 		});
 
-		expect(result.current.pendingPresetChange).not.toBeNull();
-		expect(result.current.pendingPresetChange?.changes[0].path).toBe("a");
+		expect(result.current.activePresetName).toBe("Preset 1");
 
-		await act(async () => {
-			await result.current.handleDiscardPendingPresetChange();
+		const diffGatherFn = vi.fn(
+			() => ({ different: "state" }) as unknown as SynthPresetV1,
+		);
+		rerender({ gather: diffGatherFn });
+
+		expect(result.current.activePresetName).toBe("Preset 1 *");
+	});
+
+	it("handles pending preset change flow", () => {
+		const gatherFn = vi.fn(() => ({}) as SynthPresetV1);
+		const { result, rerender } = renderHook(
+			({ gather }: { gather: () => SynthPresetV1 }) =>
+				useSynthPresetManager({
+					builtinPresets: mockBuiltinPresets,
+					gatherPresetState: gather,
+					applyPreset: mockApplyPreset,
+				}),
+			{ initialProps: { gather: gatherFn } },
+		);
+
+		act(() => {
+			result.current.handleLoadBuiltin("Preset 1");
+		});
+
+		const diffGatherFn = vi.fn(() => ({ a: 2 }) as unknown as SynthPresetV1);
+		rerender({ gather: diffGatherFn });
+
+		act(() => {
+			result.current.handleLoadBuiltin("Preset 2");
+		});
+
+		expect(result.current.pendingPresetChange).not.toBeNull();
+
+		act(() => {
+			result.current.handleDiscardPendingPresetChange();
 		});
 
 		expect(result.current.pendingPresetChange).toBeNull();

--- a/packages/cosmo-pd101/src/features/synth/useSynthPresetManager.ts
+++ b/packages/cosmo-pd101/src/features/synth/useSynthPresetManager.ts
@@ -35,7 +35,6 @@ type UseSynthPresetManagerOptions = {
 	onBeforeApplyPreset?: () => void;
 	libraryPresets?: LibraryPreset[];
 	onLoadLibraryPreset?: (preset: LibraryPreset) => void;
-	shouldLoadCurrentState?: () => boolean;
 	presetStateKey?: string;
 };
 
@@ -86,17 +85,12 @@ export function useSynthPresetManager({
 	onBeforeApplyPreset,
 	libraryPresets = [],
 	onLoadLibraryPreset,
-	shouldLoadCurrentState,
 	presetStateKey,
 }: UseSynthPresetManagerOptions): UseSynthPresetManagerResult {
 	const [localPresetEntries, setLocalPresetEntries] = useState<StoredPreset[]>(
 		[],
 	);
 	const [favoritePresetIds, setFavoritePresetIds] = useState<string[]>([]);
-	const shouldHydratePersistedState = useMemo(
-		() => (shouldLoadCurrentState ? shouldLoadCurrentState() : true),
-		[shouldLoadCurrentState],
-	);
 	const [activePresetId, setActivePresetId] = useState<string | null>(null);
 	const [activePresetNameBase, setActivePresetNameBase] =
 		useState("Current State");
@@ -532,19 +526,8 @@ export function useSynthPresetManager({
 	);
 
 	usePresetManagerPersistence({
-		applyPreset,
-		builtinPresets,
-		loadBuiltinPreset,
 		refreshFavoritePresetIds,
 		refreshLocalPresetEntries,
-		shouldHydratePersistedState,
-		gatherState: gatherPresetState,
-		activePresetId,
-		activePresetNameBase,
-		loadedPresetFingerprint,
-		setActivePresetId,
-		setActivePresetNameBase,
-		setLoadedPresetFingerprint,
 	});
 
 	return {


### PR DESCRIPTION
## Summary

Fixes a race condition where the plugin GUI shows default state on reopen instead of the selected preset.

### Root Cause

The hydration effect (`usePluginBridgeSynthEngine` Effect 3) bailed out immediately when `window.__czGetParams` was undefined (bridge not ready yet). Since `main.tsx` calls `ensureIPCBridge()` before React renders, but `window.ipc` may not be available at that point, the bridge silently fails to install. The 50ms polling in `usePluginParamBridge` eventually installs the bridge, but the hydration effect has stable deps and never re-runs — resulting in `getParams` never being called.

### Changes

1. **`pluginBridgeSynthEngineAdapter.ts`** — Hydration no longer bails when the IPC bridge isn't ready. Instead, it retries with 500ms polling (up to 10 retries, same as the existing getParams retry logic). The outbound gate opens immediately so controls respond while waiting.

2. **`PluginPage.tsx`** — Removed duplicate `usePluginParamBridge()` call (was at line 145). The one at line 118 is sufficient; two instances create separate refs with redundant effects.

3. **`lib.rs`** — `load_state()` now updates `cached_rt_synth_params` and `cached_synth_params_version`, sets `daw_params_dirty = false`, and calls `proc.set_shared_params()` to notify the processor immediately. Previously the stale cache caused `process()` to overwrite restored state with default DAW FloatParam values.