### PR TITLE
refactor: replace modals with popovers for mini keyboard settings and macro label editor

### DIFF
--- a/packages/cosmo-pd101/src/components/layout/SynthInfoBar.tsx
+++ b/packages/cosmo-pd101/src/components/layout/SynthInfoBar.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useCallback, useRef, useState } from "react";
 import { MdPiano, MdSettings } from "react-icons/md";
 import Button from "@/components/controls/Button";
+import { KeyboardSettingsPopover } from "@/components/modals/KeyboardSettingsPopover";
 
 type SynthInfoBarProps = {
 	infoText: string;
@@ -8,7 +9,6 @@ type SynthInfoBarProps = {
 	showKeyboardToggle: boolean;
 	keyboardVisible: boolean;
 	onKeyboardToggle: () => void;
-	onKeyboardSettingsClick?: () => void;
 };
 
 export default function SynthInfoBar({
@@ -17,8 +17,14 @@ export default function SynthInfoBar({
 	showKeyboardToggle,
 	keyboardVisible,
 	onKeyboardToggle,
-	onKeyboardSettingsClick,
 }: SynthInfoBarProps) {
+	const [settingsOpen, setSettingsOpen] = useState(false);
+	const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
+
+	const handleSettingsClick = useCallback(() => {
+		setSettingsOpen((prev) => !prev);
+	}, []);
+
 	return (
 		<div className="relative z-20 mt-1 flex min-h-8 flex-nowrap items-center gap-x-3 gap-y-1 rounded-t-sm border border-cz-border/80 bg-cz-body px-3 py-1 font-mono text-[0.62rem] text-cz-cream/80 uppercase tracking-[0.22em] shadow-inner">
 			<span className="text-cz-light-blue/80">Info</span>
@@ -44,15 +50,19 @@ export default function SynthInfoBar({
 					>
 						<MdPiano className="h-3.5 w-3.5" />
 					</Button>
-					{onKeyboardSettingsClick ? (
-						<Button
-							type="button"
-							onClick={onKeyboardSettingsClick}
-							className="btn btn-sm border-cz-border bg-transparent px-2 py-1 text-cz-cream/70 hover:text-cz-cream"
-						>
-							<MdSettings className="h-3 w-3" />
-						</Button>
-					) : null}
+					<Button
+						ref={settingsBtnRef}
+						type="button"
+						onClick={handleSettingsClick}
+						className="btn btn-sm border-cz-border bg-transparent px-2 py-1 text-cz-cream/70 hover:text-cz-cream"
+					>
+						<MdSettings className="h-3 w-3" />
+					</Button>
+					<KeyboardSettingsPopover
+						open={settingsOpen}
+						triggerRef={settingsBtnRef}
+						onClose={() => setSettingsOpen(false)}
+					/>
 				</div>
 			) : null}
 		</div>

--- a/packages/cosmo-pd101/src/components/modals/KeyboardSettingsModal.test.tsx
+++ b/packages/cosmo-pd101/src/components/modals/KeyboardSettingsModal.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { KeyboardSettingsModal } from "./KeyboardSettingsModal";
+import { KeyboardSettingsPopover } from "./KeyboardSettingsPopover";
 
 const state = {
 	keyboardOctaves: 2,
@@ -17,9 +17,10 @@ vi.mock("@/features/synth/synthUiStore", () => ({
 	),
 }));
 
-describe("KeyboardSettingsModal", () => {
+describe("KeyboardSettingsPopover", () => {
 	it("updates range/octaves/input mode", () => {
-		render(<KeyboardSettingsModal open onClose={vi.fn()} />);
+		const ref = { current: document.createElement("button") };
+		render(<KeyboardSettingsPopover open triggerRef={ref} onClose={vi.fn()} />);
 		fireEvent.click(screen.getByRole("button", { name: "+2" }));
 		fireEvent.click(screen.getByRole("button", { name: "5" }));
 		fireEvent.click(screen.getByRole("button", { name: "Aftertouch" }));

--- a/packages/cosmo-pd101/src/components/modals/KeyboardSettingsPopover.tsx
+++ b/packages/cosmo-pd101/src/components/modals/KeyboardSettingsPopover.tsx
@@ -1,0 +1,118 @@
+import type { RefObject } from "react";
+import Button from "@/components/controls/Button";
+import Popover from "@/components/primitives/Popover";
+import { useSynthUiStore } from "@/features/synth/synthUiStore";
+
+export function KeyboardSettingsPopover({
+	open,
+	triggerRef,
+	onClose,
+}: {
+	open: boolean;
+	triggerRef: RefObject<Element | null>;
+	onClose: () => void;
+}) {
+	const keyboardOctaves = useSynthUiStore((s) => s.keyboardOctaves);
+	const keyboardRange = useSynthUiStore((s) => s.keyboardRange);
+	const keyboardInputMode = useSynthUiStore((s) => s.keyboardInputMode);
+	const setKeyboardOctaves = useSynthUiStore((s) => s.setKeyboardOctaves);
+	const setKeyboardRange = useSynthUiStore((s) => s.setKeyboardRange);
+	const setKeyboardInputMode = useSynthUiStore((s) => s.setKeyboardInputMode);
+
+	return (
+		<Popover
+			open={open}
+			onClose={onClose}
+			triggerRef={triggerRef}
+			role="dialog"
+			ariaLabel="Keyboard settings"
+			placement="top-end"
+		>
+			<div className="w-[min(26rem,94vw)] p-3">
+				<div className="mb-2 flex items-center justify-between px-1">
+					<p className="font-mono text-2xs text-cz-cream-dim uppercase tracking-[0.18em]">
+						Keyboard Settings
+					</p>
+				</div>
+				<div className="space-y-3">
+					<div className="space-y-1.5">
+						<p className="font-mono text-3xs text-cz-cream-dim uppercase tracking-[0.18em]">
+							Octave Range
+						</p>
+						<div className="flex gap-1">
+							{[-2, -1, 0, 1, 2].map((value) => (
+								<Button
+									key={`range-${value}`}
+									type="button"
+									onClick={() => setKeyboardRange(value)}
+									className={`btn btn-sm flex-1 border text-xs ${
+										keyboardRange === value
+											? "border-cz-gold bg-cz-gold/10 text-cz-gold"
+											: "border-cz-border bg-cz-inset text-cz-cream/70 hover:text-cz-cream"
+									}`}
+								>
+									{value > 0 ? `+${value}` : `${value}`}
+								</Button>
+							))}
+						</div>
+					</div>
+					<div className="space-y-1.5">
+						<p className="font-mono text-3xs text-cz-cream-dim uppercase tracking-[0.18em]">
+							Octaves
+						</p>
+						<div className="flex gap-1">
+							{[1, 2, 3, 4, 5].map((value) => (
+								<Button
+									key={`octaves-${value}`}
+									type="button"
+									onClick={() => setKeyboardOctaves(value)}
+									className={`btn btn-sm flex-1 border text-xs ${
+										keyboardOctaves === value
+											? "border-cz-gold bg-cz-gold/10 text-cz-gold"
+											: "border-cz-border bg-cz-inset text-cz-cream/70 hover:text-cz-cream"
+									}`}
+								>
+									{value}
+								</Button>
+							))}
+						</div>
+					</div>
+					<div className="space-y-1.5">
+						<p className="font-mono text-3xs text-cz-cream-dim uppercase tracking-[0.18em]">
+							Key Touch
+						</p>
+						<div className="flex gap-1">
+							<Button
+								type="button"
+								onClick={() => setKeyboardInputMode("velocity")}
+								className={`btn btn-sm flex-1 border text-xs ${
+									keyboardInputMode === "velocity"
+										? "border-cz-gold bg-cz-gold/10 text-cz-gold"
+										: "border-cz-border bg-cz-inset text-cz-cream/70 hover:text-cz-cream"
+								}`}
+							>
+								Velocity
+							</Button>
+							<Button
+								type="button"
+								onClick={() => setKeyboardInputMode("aftertouch")}
+								className={`btn btn-sm flex-1 border text-xs ${
+									keyboardInputMode === "aftertouch"
+										? "border-cz-gold bg-cz-gold/10 text-cz-gold"
+										: "border-cz-border bg-cz-inset text-cz-cream/70 hover:text-cz-cream"
+								}`}
+							>
+								Aftertouch
+							</Button>
+						</div>
+						<p className="pt-1 font-mono text-4xs text-cz-cream-dim/60">
+							{keyboardInputMode === "velocity"
+								? "Press position on key sets velocity. Top = 127, bottom = 1."
+								: "Note-on uses default velocity. Drag up after pressing for aftertouch."}
+						</p>
+					</div>
+				</div>
+			</div>
+		</Popover>
+	);
+}

--- a/packages/cosmo-pd101/src/components/modals/MacroLabelEditorModal.test.tsx
+++ b/packages/cosmo-pd101/src/components/modals/MacroLabelEditorModal.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { MacroLabelEditorModal } from "./MacroLabelEditorModal";
+import { MacroLabelEditorPopover } from "./MacroLabelEditorPopover";
 
 const setMacroLabel = vi.fn();
 const state = {
@@ -14,9 +14,10 @@ vi.mock("@/features/synth/synthStore", () => ({
 	),
 }));
 
-describe("MacroLabelEditorModal", () => {
+describe("MacroLabelEditorPopover", () => {
 	it("renders 4 macro inputs and updates label", () => {
-		render(<MacroLabelEditorModal open onClose={vi.fn()} />);
+		const ref = { current: document.createElement("button") };
+		render(<MacroLabelEditorPopover open triggerRef={ref} onClose={vi.fn()} />);
 		const input = screen.getByDisplayValue("A");
 		fireEvent.change(input, { target: { value: "Alpha" } });
 		expect(setMacroLabel).toHaveBeenCalledWith(0, "Alpha");

--- a/packages/cosmo-pd101/src/components/modals/MacroLabelEditorPopover.tsx
+++ b/packages/cosmo-pd101/src/components/modals/MacroLabelEditorPopover.tsx
@@ -1,0 +1,54 @@
+import type { RefObject } from "react";
+import Popover from "@/components/primitives/Popover";
+import { useSynthStore } from "@/features/synth/synthStore";
+
+export function MacroLabelEditorPopover({
+	open,
+	triggerRef,
+	onClose,
+}: {
+	open: boolean;
+	triggerRef: RefObject<Element | null>;
+	onClose: () => void;
+}) {
+	const labels = useSynthStore((s) => s.macroLabels);
+	const setMacroLabel = useSynthStore((s) => s.setMacroLabel);
+
+	return (
+		<Popover
+			open={open}
+			onClose={onClose}
+			triggerRef={triggerRef}
+			role="dialog"
+			ariaLabel="Macro label editor"
+			placement="top-end"
+		>
+			<div className="w-[min(30rem,94vw)] p-3">
+				<div className="mb-2 flex items-center justify-between px-1">
+					<p className="font-mono text-2xs text-cz-cream-dim uppercase tracking-[0.18em]">
+						Macro Labels
+					</p>
+				</div>
+				<div className="grid grid-cols-2 gap-2">
+					{[0, 1, 2, 3].map((idx) => (
+						<label
+							key={`macro-label-editor-${idx}`}
+							className="flex flex-col gap-1 font-mono text-4xs text-cz-cream-dim uppercase tracking-[0.12em]"
+						>
+							Macro {idx + 1}
+							<input
+								type="text"
+								className="input input-sm w-full border-cz-border bg-cz-inset font-mono text-2xs text-cz-cream"
+								maxLength={18}
+								value={labels[idx]}
+								onChange={(event) =>
+									setMacroLabel(idx, event.currentTarget.value)
+								}
+							/>
+						</label>
+					))}
+				</div>
+			</div>
+		</Popover>
+	);
+}

--- a/packages/cosmo-pd101/src/components/modals/index.ts
+++ b/packages/cosmo-pd101/src/components/modals/index.ts
@@ -1,5 +1,5 @@
 export { GlobalVoiceModal } from "./GlobalVoiceModal";
-export { KeyboardSettingsModal } from "./KeyboardSettingsModal";
-export { MacroLabelEditorModal } from "./MacroLabelEditorModal";
+export { KeyboardSettingsPopover } from "./KeyboardSettingsPopover";
+export { MacroLabelEditorPopover } from "./MacroLabelEditorPopover";
 export { PendingModifiedPresetModal } from "./PendingModifiedPresetModal";
 export { SynthBrandInfoModal } from "./SynthBrandInfoModal";

--- a/packages/cosmo-pd101/src/components/panels/macro/MacroKnobsPanel.test.tsx
+++ b/packages/cosmo-pd101/src/components/panels/macro/MacroKnobsPanel.test.tsx
@@ -32,7 +32,12 @@ vi.mock("@/features/synth/synthStore", () => ({
 				setMacro2,
 				setMacro3,
 				setMacro4,
-				macroLabels: ["M1", "M2", "M3", "M4"] as [string, string, string, string],
+				macroLabels: ["M1", "M2", "M3", "M4"] as [
+					string,
+					string,
+					string,
+					string,
+				],
 				setMacroLabel: vi.fn(),
 			}),
 	),

--- a/packages/cosmo-pd101/src/components/panels/macro/MacroKnobsPanel.test.tsx
+++ b/packages/cosmo-pd101/src/components/panels/macro/MacroKnobsPanel.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/features/synth/synthStore", () => ({
 				setMacro3: typeof setMacro3;
 				setMacro4: typeof setMacro4;
 				macroLabels: [string, string, string, string];
+				setMacroLabel: (index: number, label: string) => void;
 			}) => unknown,
 		) =>
 			selector({
@@ -31,21 +32,20 @@ vi.mock("@/features/synth/synthStore", () => ({
 				setMacro2,
 				setMacro3,
 				setMacro4,
-				macroLabels: ["M1", "M2", "M3", "M4"],
+				macroLabels: ["M1", "M2", "M3", "M4"] as [string, string, string, string],
+				setMacroLabel: vi.fn(),
 			}),
 	),
 }));
 
-const setMacroLabelEditorOpen = vi.fn();
-
-vi.mock("@/features/synth/synthUiStore", () => ({
-	useSynthUiStore: vi.fn(
-		(
-			selector: (state: {
-				setMacroLabelEditorOpen: typeof setMacroLabelEditorOpen;
-			}) => unknown,
-		) => selector({ setMacroLabelEditorOpen }),
-	),
+vi.mock("@/components/primitives/Popover", () => ({
+	default: ({
+		open,
+		children,
+	}: {
+		open: boolean;
+		children: React.ReactNode;
+	}) => (open ? <div data-testid="macro-label-popover">{children}</div> : null),
 }));
 
 vi.mock("@/features/synth/hooks/useMidiLearnTarget", () => ({
@@ -79,8 +79,9 @@ describe("MacroKnobsPanel", () => {
 	it("renders macro knobs and settings button", () => {
 		render(<MacroKnobsPanel />);
 		expect(screen.getByTestId("macro-knob-M1")).toBeInTheDocument();
+		expect(screen.queryByTestId("macro-label-popover")).not.toBeInTheDocument();
 		fireEvent.click(screen.getByLabelText("Edit macro labels"));
-		expect(setMacroLabelEditorOpen).toHaveBeenCalledWith(true);
+		expect(screen.getByTestId("macro-label-popover")).toBeInTheDocument();
 		fireEvent.click(screen.getByTestId("macro-knob-M1"));
 		expect(setMacro1).toHaveBeenCalledWith(0.75);
 	});

--- a/packages/cosmo-pd101/src/components/panels/macro/MacroKnobsPanel.tsx
+++ b/packages/cosmo-pd101/src/components/panels/macro/MacroKnobsPanel.tsx
@@ -1,9 +1,9 @@
-import { memo, useCallback } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { MdSettings } from "react-icons/md";
 import ControlKnob from "@/components/controls/ControlKnob";
+import { MacroLabelEditorPopover } from "@/components/modals/MacroLabelEditorPopover";
 import { useMidiLearnTarget } from "@/features/synth/hooks/useMidiLearnTarget";
 import { useSynthStore } from "@/features/synth/synthStore";
-import { useSynthUiStore } from "@/features/synth/synthUiStore";
 
 function useMacroValue(index: number): number {
 	return useSynthStore((s) => {
@@ -28,9 +28,9 @@ function useMacroLabel(index: number): string {
 }
 
 export default memo(function MacroKnobsPanel() {
-	const setMacroLabelEditorOpen = useSynthUiStore(
-		(s) => s.setMacroLabelEditorOpen,
-	);
+	const [labelEditorOpen, setLabelEditorOpen] = useState(false);
+	const settingsBtnRef = useRef<HTMLButtonElement | null>(null);
+
 	return (
 		<div className="h-full min-h-0 w-full">
 			<div className="h-full overflow-hidden rounded-lg border border-cz-border/70 bg-cz-surface/95 shadow-lg backdrop-blur-sm">
@@ -42,13 +42,19 @@ export default memo(function MacroKnobsPanel() {
 					</div>
 					<div className="flex items-center gap-0.5">
 						<button
+							ref={settingsBtnRef}
 							type="button"
 							className="btn btn-ghost btn-xs h-6 min-h-0 w-6 p-0 text-cz-cream/90"
-							onClick={() => setMacroLabelEditorOpen(true)}
+							onClick={() => setLabelEditorOpen((prev) => !prev)}
 							aria-label="Edit macro labels"
 						>
 							<MdSettings className="h-3.5 w-3.5" />
 						</button>
+						<MacroLabelEditorPopover
+							open={labelEditorOpen}
+							triggerRef={settingsBtnRef}
+							onClose={() => setLabelEditorOpen(false)}
+						/>
 					</div>
 				</div>
 				<div className="grid grid-cols-2 gap-1.5 px-2 py-1.5">

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.test.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.test.tsx
@@ -38,6 +38,12 @@ const mockSynthUiStoreState = {
 	setMacroLabelEditorOpen: vi.fn(),
 	keyboardSettingsOpen: false,
 	setKeyboardSettingsOpen: vi.fn(),
+	keyboardOctaves: 3,
+	setKeyboardOctaves: vi.fn(),
+	keyboardRange: 0,
+	setKeyboardRange: vi.fn(),
+	keyboardInputMode: "velocity",
+	setKeyboardInputMode: vi.fn(),
 };
 
 vi.mock("@/components/preset/SynthHeader", () => ({
@@ -56,8 +62,8 @@ vi.mock("@/components/layout/SynthSidebar", () => ({
 vi.mock("@/components/modals", () => ({
 	GlobalVoiceModal: ({ open }: { open: boolean }) =>
 		open ? <div data-testid="global-voice-panel" /> : null,
-	KeyboardSettingsModal: () => null,
-	MacroLabelEditorModal: () => null,
+	KeyboardSettingsPopover: () => null,
+	MacroLabelEditorPopover: () => null,
 	PendingModifiedPresetModal: ({
 		pendingPresetChange,
 	}: {

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -434,9 +434,6 @@ const SynthRenderer = memo(function SynthRenderer({
 									onPolyAftertouch={sendPolyAftertouch}
 									bottomBarExtra={bottomBarExtra}
 									onKeyboardToggle={() => setKeyboardVisible(!keyboardVisible)}
-									onKeyboardSettingsClick={() =>
-										useSynthUiStore.getState().setKeyboardSettingsOpen(true)
-									}
 								/>
 							</div>
 						</PresetManagerProvider>

--- a/packages/cosmo-pd101/src/components/renderer/SynthRendererOverlays.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRendererOverlays.tsx
@@ -4,8 +4,6 @@ import MiniKeyboardOverlay from "@/components/layout/MiniKeyboardOverlay";
 import SynthInfoBar from "@/components/layout/SynthInfoBar";
 import {
 	GlobalVoiceModal,
-	KeyboardSettingsModal,
-	MacroLabelEditorModal,
 	PendingModifiedPresetModal,
 	SynthBrandInfoModal,
 } from "@/components/modals";
@@ -28,7 +26,6 @@ type SynthRendererOverlaysProps = {
 	infoText: string;
 	bottomBarExtra?: ReactNode;
 	onKeyboardToggle: () => void;
-	onKeyboardSettingsClick: () => void;
 };
 
 export default memo(function SynthRendererOverlays({
@@ -42,20 +39,11 @@ export default memo(function SynthRendererOverlays({
 	infoText,
 	bottomBarExtra,
 	onKeyboardToggle,
-	onKeyboardSettingsClick,
 }: SynthRendererOverlaysProps) {
 	const brandInfoOpen = useSynthUiStore((s) => s.brandInfoOpen);
 	const setBrandInfoOpen = useSynthUiStore((s) => s.setBrandInfoOpen);
 	const globalPanelOpen = useSynthUiStore((s) => s.globalPanelOpen);
 	const setGlobalPanelOpen = useSynthUiStore((s) => s.setGlobalPanelOpen);
-	const macroLabelEditorOpen = useSynthUiStore((s) => s.macroLabelEditorOpen);
-	const setMacroLabelEditorOpen = useSynthUiStore(
-		(s) => s.setMacroLabelEditorOpen,
-	);
-	const keyboardSettingsOpen = useSynthUiStore((s) => s.keyboardSettingsOpen);
-	const setKeyboardSettingsOpen = useSynthUiStore(
-		(s) => s.setKeyboardSettingsOpen,
-	);
 	const {
 		pendingPresetChange,
 		handleSavePendingPresetChange,
@@ -74,14 +62,6 @@ export default memo(function SynthRendererOverlays({
 			<GlobalVoiceModal
 				open={globalPanelOpen}
 				onClose={() => setGlobalPanelOpen(false)}
-			/>
-			<MacroLabelEditorModal
-				open={macroLabelEditorOpen}
-				onClose={() => setMacroLabelEditorOpen(false)}
-			/>
-			<KeyboardSettingsModal
-				open={keyboardSettingsOpen}
-				onClose={() => setKeyboardSettingsOpen(false)}
 			/>
 			<PendingModifiedPresetModal
 				pendingPresetChange={pendingPresetChange}
@@ -104,7 +84,6 @@ export default memo(function SynthRendererOverlays({
 				showKeyboardToggle={showKeyboard}
 				keyboardVisible={keyboardVisible}
 				onKeyboardToggle={onKeyboardToggle}
-				onKeyboardSettingsClick={onKeyboardSettingsClick}
 			/>
 		</>
 	);


### PR DESCRIPTION
## Summary

Replaced `SynthOverlayModal`-based modals with Floating UI `Popover` components for two UI elements:

- **Keyboard Settings** — now a `KeyboardSettingsPopover` anchored to the settings button in `SynthInfoBar`, placement `top-end`
- **Macro Label Editor** — now a `MacroLabelEditorPopover` anchored to the gear button in `MacroKnobsPanel`, placement `top-end`

## Changes

- Created `KeyboardSettingsPopover.tsx` and `MacroLabelEditorPopover.tsx` using the existing `Popover` primitive
- `SynthInfoBar` — manages popover state locally, captures button ref, removed `onKeyboardSettingsClick` prop
- `MacroKnobsPanel` — manages popover state locally, removed `useSynthUiStore` dependency for label editor open/close
- `SynthRendererOverlays` — removed stale modal imports and `onKeyboardSettingsClick` prop forwarding
- `SynthRenderer.tsx` — removed `onKeyboardSettingsClick` callback

## Testing

- Updated existing tests for both popover components
- `bun run lint` — clean
- `bun run test` — 767 passed, 0 failed