### PR TITLE
feat(scope): freeze, trigger edge toggle, and stutter fix

### DIFF
--- a/packages/cosmo-pd101/src/components/panels/analysis/ScopeControls.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/ScopeControls.tsx
@@ -1,3 +1,4 @@
+import Button from "@/components/controls/Button";
 import ControlKnob from "@/components/controls/ControlKnob";
 import { useSynthUiStore } from "@/features/synth/synthUiStore";
 
@@ -5,12 +6,16 @@ export function ScopeControls() {
 	const scopeCycles = useSynthUiStore((s) => s.scopeCycles);
 	const scopeVerticalZoom = useSynthUiStore((s) => s.scopeVerticalZoom);
 	const scopeTriggerLevel = useSynthUiStore((s) => s.scopeTriggerLevel);
+	const scopeFrozen = useSynthUiStore((s) => s.scopeFrozen);
+	const scopeTriggerEdge = useSynthUiStore((s) => s.scopeTriggerEdge);
 	const setScopeCycles = useSynthUiStore((s) => s.setScopeCycles);
 	const setScopeVerticalZoom = useSynthUiStore((s) => s.setScopeVerticalZoom);
 	const setScopeTriggerLevel = useSynthUiStore((s) => s.setScopeTriggerLevel);
+	const setScopeFrozen = useSynthUiStore((s) => s.setScopeFrozen);
+	const setScopeTriggerEdge = useSynthUiStore((s) => s.setScopeTriggerEdge);
 
 	return (
-		<div className="mt-2 flex shrink-0 justify-center gap-2">
+		<div className="mt-2 flex shrink-0 items-center justify-center gap-2">
 			<ControlKnob
 				value={scopeCycles}
 				onChange={setScopeCycles}
@@ -47,6 +52,29 @@ export function ScopeControls() {
 				tooltip="Sets trigger threshold used to stabilize waveform display."
 				valueFormatter={(value) => `${Math.round(value)}`}
 			/>
+			<Button
+				active={scopeFrozen}
+				onClick={() => setScopeFrozen(!scopeFrozen)}
+				className="btn btn-xs rounded px-2 font-mono tracking-wide"
+				style={
+					scopeFrozen ? { color: "#f97316", borderColor: "#f97316" } : undefined
+				}
+			>
+				{scopeFrozen ? "▌Freeze" : "Freeze"}
+			</Button>
+			<Button
+				onClick={() =>
+					setScopeTriggerEdge(scopeTriggerEdge === "rise" ? "fall" : "rise")
+				}
+				className="btn btn-xs rounded px-2 font-mono tracking-wide"
+				style={
+					scopeTriggerEdge === "fall"
+						? { color: "#7f9de4", borderColor: "#7f9de4" }
+						: undefined
+				}
+			>
+				{scopeTriggerEdge === "rise" ? "↗ Rise" : "↘ Fall"}
+			</Button>
 		</div>
 	);
 }

--- a/packages/cosmo-pd101/src/components/panels/analysis/ScopeDisplay.test.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/ScopeDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ScopeProvider } from "@/context/ScopeContext";
 import { useSynthUiStore } from "@/features/synth/synthUiStore";
@@ -62,6 +62,8 @@ describe("ScopeMiniDisplay", () => {
 		useSynthUiStore.setState({
 			scopeVisualizationMode: "waveform",
 			scopeColorTheme: "vintage",
+			scopeFrozen: false,
+			scopeTriggerEdge: "rise",
 		});
 		vi.restoreAllMocks();
 	});
@@ -149,6 +151,45 @@ describe("ScopeMiniDisplay", () => {
 		expect(
 			screen.getByText("Wave drawer is showing the full scope view"),
 		).toBeInTheDocument();
+	});
+
+	it("toggles freeze state on freeze button click", () => {
+		renderWithScope(<ScopeMiniDisplay />);
+
+		const freezeButton = screen.getByText("Freeze");
+		expect(freezeButton).toBeInTheDocument();
+
+		act(() => {
+			fireEvent.click(freezeButton);
+		});
+		expect(screen.getByText("▌Freeze")).toBeInTheDocument();
+		expect(useSynthUiStore.getState().scopeFrozen).toBe(true);
+
+		act(() => {
+			fireEvent.click(screen.getByText("▌Freeze"));
+		});
+		expect(screen.getByText("Freeze")).toBeInTheDocument();
+		expect(useSynthUiStore.getState().scopeFrozen).toBe(false);
+	});
+
+	it("toggles trigger edge between rise and fall", () => {
+		renderWithScope(<ScopeMiniDisplay />);
+
+		const edgeButton = screen.getByText("↗ Rise");
+		expect(edgeButton).toBeInTheDocument();
+		expect(useSynthUiStore.getState().scopeTriggerEdge).toBe("rise");
+
+		act(() => {
+			fireEvent.click(edgeButton);
+		});
+		expect(screen.getByText("↘ Fall")).toBeInTheDocument();
+		expect(useSynthUiStore.getState().scopeTriggerEdge).toBe("fall");
+
+		act(() => {
+			fireEvent.click(screen.getByText("↘ Fall"));
+		});
+		expect(screen.getByText("↗ Rise")).toBeInTheDocument();
+		expect(useSynthUiStore.getState().scopeTriggerEdge).toBe("rise");
 	});
 
 	it("renders the 3D waterfall visualization when mode is set to waterfall3d", () => {

--- a/packages/cosmo-pd101/src/components/panels/analysis/ScopeVisualizationDisplay.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/ScopeVisualizationDisplay.tsx
@@ -44,6 +44,8 @@ export function ScopeVisualizationDisplay({
 		(s) => s.scopeVisualizationMode,
 	);
 	const scopeColorTheme = useSynthUiStore((s) => s.scopeColorTheme);
+	const scopeFrozen = useSynthUiStore((s) => s.scopeFrozen);
+	const scopeTriggerEdge = useSynthUiStore((s) => s.scopeTriggerEdge);
 	const setScopeVisualizationMode = useSynthUiStore(
 		(s) => s.setScopeVisualizationMode,
 	);
@@ -58,6 +60,9 @@ export function ScopeVisualizationDisplay({
 		height: 0,
 		history: null,
 	});
+	const triggerOffsetRef = useRef<{ current: number | undefined }>({
+		current: undefined,
+	});
 
 	// Keep refs to the latest values so RAF/subscription closures always read
 	// current state without needing to restart effects on every settings change.
@@ -67,6 +72,8 @@ export function ScopeVisualizationDisplay({
 		scopeTriggerLevel,
 		scopeVisualizationMode,
 		scopeColorTheme,
+		scopeFrozen,
+		scopeTriggerEdge,
 	});
 	settingsRef.current = {
 		scopeCycles,
@@ -74,6 +81,8 @@ export function ScopeVisualizationDisplay({
 		scopeTriggerLevel,
 		scopeVisualizationMode,
 		scopeColorTheme,
+		scopeFrozen,
+		scopeTriggerEdge,
 	};
 
 	const propsRef = useRef({ effectivePitchHz, analyserNodeRef, audioCtxRef });
@@ -135,6 +144,8 @@ export function ScopeVisualizationDisplay({
 		sampleRate: number,
 		frequencyBins?: Uint8Array<ArrayBufferLike>,
 	) => {
+		if (settingsRef.current.scopeFrozen) return;
+
 		const mean = calculateFrameMean(samples);
 		if (smoothedTriggerRef.current == null) {
 			smoothedTriggerRef.current = mean;
@@ -156,6 +167,7 @@ export function ScopeVisualizationDisplay({
 			frequencyBins,
 			cycles: settingsRef.current.scopeCycles,
 			triggerLevel,
+			triggerEdge: settingsRef.current.scopeTriggerEdge,
 			zoom: settingsRef.current.scopeVerticalZoom,
 			palette: getScopeThemePalette(settingsRef.current.scopeColorTheme),
 			spectrogramStateRef,
@@ -163,6 +175,7 @@ export function ScopeVisualizationDisplay({
 			intensityMultiplier: variant === "drawer" ? 1.55 : 1,
 			waterfallPreview,
 			waterfallActiveLine,
+			triggerOffsetRef,
 		});
 	};
 
@@ -193,6 +206,7 @@ export function ScopeVisualizationDisplay({
 			rafIdRef.current = window.requestAnimationFrame(draw);
 			const canvas = canvasRef.current;
 			if (!canvas) return;
+			if (settingsRef.current.scopeFrozen) return;
 			// External stream takes priority.
 			if (unsubscribeRef.current) return;
 			const {

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/AsteroidsViz.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/AsteroidsViz.tsx
@@ -274,6 +274,7 @@ export function drawAsteroidsScope(
 	sampleRate: number,
 	cycles: number,
 	triggerLevel: number,
+	triggerEdge: "rise" | "fall",
 	zoom: number,
 	palette: ScopeThemePalette,
 	pressedKeys: ReadonlySet<string>,
@@ -290,6 +291,7 @@ export function drawAsteroidsScope(
 		sampleRate,
 		cycles,
 		triggerLevel,
+		triggerEdge,
 	);
 	const normalized = normalizeWindowedSamples(
 		samples,

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/OrbitalViz.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/OrbitalViz.tsx
@@ -1,6 +1,14 @@
 import { drawScopeGrid, setupScopeCanvas } from "./canvas";
-import { normalizeWindowedSamples, resolveScopeWindow } from "./processing";
+import {
+	normalizeWindowedSamples,
+	resolveScopeWindow,
+	sampleAt,
+} from "./processing";
 import type { ScopeThemePalette } from "./types";
+
+const TRIGGER_HYSTERESIS = 0.02;
+const TRIGGER_SEARCH_MARGIN = 4;
+const ORBITAL_LAST_TRIGGER = new WeakMap<HTMLCanvasElement, number>();
 
 export function drawOrbitalScope(
 	canvas: HTMLCanvasElement,
@@ -9,8 +17,10 @@ export function drawOrbitalScope(
 	sampleRate: number,
 	cycles: number,
 	triggerLevel: number,
+	triggerEdge: "rise" | "fall",
 	zoom: number,
 	palette: ScopeThemePalette,
+	triggerOffsetRef?: { current: number | undefined },
 ) {
 	const setup = setupScopeCanvas(canvas);
 	if (!setup) return;
@@ -23,11 +33,41 @@ export function drawOrbitalScope(
 		sampleRate,
 		cycles,
 		triggerLevel,
+		triggerEdge,
 	);
+	let startIndex = window.start;
+	const lastIndex = ORBITAL_LAST_TRIGGER.get(canvas);
+	if (lastIndex !== undefined) {
+		const trigger = (triggerLevel - 128) / 128;
+		const searchStart = Math.max(1, lastIndex - TRIGGER_SEARCH_MARGIN);
+		const searchEnd = Math.min(
+			samples.length - 1,
+			lastIndex + TRIGGER_SEARCH_MARGIN,
+		);
+		for (let i = searchStart; i < searchEnd; i++) {
+			const prev = sampleAt(samples, i - 1);
+			const curr = sampleAt(samples, i);
+			if (
+				(triggerEdge === "rise" &&
+					prev <= trigger - TRIGGER_HYSTERESIS &&
+					curr >= trigger) ||
+				(triggerEdge === "fall" &&
+					prev >= trigger + TRIGGER_HYSTERESIS &&
+					curr <= trigger)
+			) {
+				startIndex = i;
+				break;
+			}
+		}
+	}
+	ORBITAL_LAST_TRIGGER.set(canvas, startIndex);
+	if (triggerOffsetRef) {
+		triggerOffsetRef.current = startIndex;
+	}
 	if (window.count < 8 || !window.samplesPerCycle) return;
 	const normalized = normalizeWindowedSamples(
 		samples,
-		window.start,
+		startIndex,
 		window.count,
 	);
 

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/TransferCurvesViz.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/TransferCurvesViz.tsx
@@ -9,6 +9,7 @@ export function drawTransferCurvesScope(
 	sampleRate: number,
 	cycles: number,
 	triggerLevel: number,
+	triggerEdge: "rise" | "fall",
 	zoom: number,
 	palette: ScopeThemePalette,
 ) {
@@ -23,6 +24,7 @@ export function drawTransferCurvesScope(
 		sampleRate,
 		cycles,
 		triggerLevel,
+		triggerEdge,
 	);
 	if (window.count < 16) return;
 	const normalized = normalizeWindowedSamples(

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/WaveformViz.tsx
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/WaveformViz.tsx
@@ -8,8 +8,10 @@ export function drawWaveformScope(
 	sampleRate: number,
 	cycles: number,
 	triggerLevel: number,
+	triggerEdge: "rise" | "fall",
 	zoom: number,
 	palette: ScopeThemePalette,
+	triggerOffsetRef?: { current: number | undefined },
 ) {
 	drawOscilloscope(
 		canvas,
@@ -18,7 +20,9 @@ export function drawWaveformScope(
 			cycles,
 			verticalZoom: zoom,
 			triggerLevel,
-			triggerMode: "rise",
+			triggerMode: triggerEdge,
+			lastTriggerIndex: triggerOffsetRef?.current,
+			triggerOffsetRef,
 			color: palette.accent,
 			gridColor: palette.grid,
 		},

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/processing.ts
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/processing.ts
@@ -1,3 +1,5 @@
+const TRIGGER_HYSTERESIS = 0.02;
+
 export function sampleAt(
 	samples: Uint8Array | Float32Array,
 	index: number,
@@ -15,6 +17,7 @@ export function resolveScopeWindow(
 	sampleRate: number,
 	cycles: number,
 	triggerLevel: number,
+	triggerEdge: "rise" | "fall" = "rise",
 ) {
 	const samplesPerCycle = Math.max(8, Math.round(sampleRate / Math.max(1, hz)));
 	const requested = Math.max(16, Math.round(samplesPerCycle * cycles));
@@ -27,7 +30,14 @@ export function resolveScopeWindow(
 	for (let i = 1; i < samples.length - windowSamples - 1; i++) {
 		const prev = sampleAt(samples, i - 1);
 		const curr = sampleAt(samples, i);
-		if (prev < trigger && curr >= trigger) {
+		if (
+			(triggerEdge === "rise" &&
+				prev <= trigger - TRIGGER_HYSTERESIS &&
+				curr >= trigger) ||
+			(triggerEdge === "fall" &&
+				prev >= trigger + TRIGGER_HYSTERESIS &&
+				curr <= trigger)
+		) {
 			start = i;
 			break;
 		}

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/renderScopeVisualization.ts
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/renderScopeVisualization.ts
@@ -33,6 +33,8 @@ export function renderScopeVisualization(params: ScopeRendererParams) {
 		sampleRate,
 		cycles,
 		triggerLevel,
+		triggerEdge,
+		triggerOffsetRef,
 		zoom,
 		palette,
 		frequencyBins,
@@ -63,8 +65,10 @@ export function renderScopeVisualization(params: ScopeRendererParams) {
 				sampleRate,
 				cycles,
 				triggerLevel,
+				triggerEdge,
 				zoom,
 				palette,
+				triggerOffsetRef,
 			);
 			return;
 
@@ -85,6 +89,7 @@ export function renderScopeVisualization(params: ScopeRendererParams) {
 				sampleRate,
 				cycles,
 				triggerLevel,
+				triggerEdge,
 				zoom,
 				palette,
 			);
@@ -97,6 +102,7 @@ export function renderScopeVisualization(params: ScopeRendererParams) {
 				sampleRate,
 				cycles,
 				triggerLevel,
+				triggerEdge,
 				zoom,
 				palette,
 				pressedKeys,
@@ -112,8 +118,10 @@ export function renderScopeVisualization(params: ScopeRendererParams) {
 				sampleRate,
 				cycles,
 				triggerLevel,
+				triggerEdge,
 				zoom,
 				palette,
+				triggerOffsetRef,
 			);
 	}
 }

--- a/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/types.ts
+++ b/packages/cosmo-pd101/src/components/panels/analysis/scope-visualizations/types.ts
@@ -1,7 +1,10 @@
-import type { ScopeColorTheme } from "@/features/synth/synthUiStore";
+import type {
+	ScopeColorTheme,
+	ScopeTriggerEdge,
+} from "@/features/synth/synthUiStore";
 import type { ScopeVisualizationMode } from "./renderScopeVisualization";
 
-export type { ScopeColorTheme };
+export type { ScopeColorTheme, ScopeTriggerEdge };
 
 export type ScopeThemePalette = {
 	theme: ScopeColorTheme;
@@ -63,6 +66,8 @@ export type ScopeRendererParams = {
 	sampleRate: number;
 	cycles: number;
 	triggerLevel: number;
+	triggerEdge: ScopeTriggerEdge;
+	triggerOffsetRef?: { current: number | undefined };
 	zoom: number;
 	palette: ScopeThemePalette;
 	frequencyBins?: Uint8Array<ArrayBufferLike>;

--- a/packages/cosmo-pd101/src/features/synth/synthUiStore.ts
+++ b/packages/cosmo-pd101/src/features/synth/synthUiStore.ts
@@ -8,6 +8,7 @@ export const SYNTH_UI_STATE_STORAGE_KEY = "cosmo-pd101-ui-state";
 
 export type MainPanelMode = "phase" | "fx" | "mod" | "display";
 export type ScopeColorTheme = "vintage" | "amber" | "plasma";
+export type ScopeTriggerEdge = "rise" | "fall";
 export type PhaseLinePanelTab =
 	| "line1-algos"
 	| "line2-algos"
@@ -31,6 +32,8 @@ type SynthUiState = {
 	scopeTriggerLevel: number;
 	scopeVisualizationMode: ScopeVisualizationMode;
 	scopeColorTheme: ScopeColorTheme;
+	scopeFrozen: boolean;
+	scopeTriggerEdge: ScopeTriggerEdge;
 	brandInfoOpen: boolean;
 	globalPanelOpen: boolean;
 	midiLearnOpen: boolean;
@@ -53,6 +56,8 @@ type SynthUiActions = {
 	setScopeTriggerLevel: (level: number) => void;
 	setScopeVisualizationMode: (mode: ScopeVisualizationMode) => void;
 	setScopeColorTheme: (theme: ScopeColorTheme) => void;
+	setScopeFrozen: (frozen: boolean) => void;
+	setScopeTriggerEdge: (edge: ScopeTriggerEdge) => void;
 	setBrandInfoOpen: (open: boolean) => void;
 	setGlobalPanelOpen: (open: boolean) => void;
 	setMidiLearnOpen: (open: boolean) => void;
@@ -80,6 +85,7 @@ const SCOPE_COLOR_THEMES = new Set<ScopeColorTheme>([
 	"amber",
 	"plasma",
 ]);
+const SCOPE_TRIGGER_EDGES = new Set<ScopeTriggerEdge>(["rise", "fall"]);
 
 const KEYBOARD_INPUT_MODES = new Set<KeyboardInputMode>([
 	"velocity",
@@ -101,6 +107,8 @@ const DEFAULT_UI_STATE: SynthUiState = {
 	scopeTriggerLevel: 128,
 	scopeVisualizationMode: "waveform",
 	scopeColorTheme: "vintage",
+	scopeFrozen: false,
+	scopeTriggerEdge: "rise",
 	brandInfoOpen: false,
 	globalPanelOpen: false,
 	midiLearnOpen: false,
@@ -126,6 +134,7 @@ const normalizeSynthUiState = (value: unknown): SynthUiState => {
 	const rawScopeColorTheme = getStringValue(candidate.scopeColorTheme);
 	const scopeColorTheme =
 		rawScopeColorTheme === "classic" ? "vintage" : rawScopeColorTheme;
+	const rawScopeTriggerEdge = getStringValue(candidate.scopeTriggerEdge);
 	const rawKeyboardInputMode = getStringValue(candidate.keyboardInputMode);
 
 	return {
@@ -203,6 +212,15 @@ const normalizeSynthUiState = (value: unknown): SynthUiState => {
 			SCOPE_COLOR_THEMES.has(scopeColorTheme as ScopeColorTheme)
 				? (scopeColorTheme as ScopeColorTheme)
 				: DEFAULT_UI_STATE.scopeColorTheme,
+		scopeFrozen:
+			typeof candidate.scopeFrozen === "boolean"
+				? candidate.scopeFrozen
+				: DEFAULT_UI_STATE.scopeFrozen,
+		scopeTriggerEdge:
+			rawScopeTriggerEdge &&
+			SCOPE_TRIGGER_EDGES.has(rawScopeTriggerEdge as ScopeTriggerEdge)
+				? (rawScopeTriggerEdge as ScopeTriggerEdge)
+				: DEFAULT_UI_STATE.scopeTriggerEdge,
 		brandInfoOpen:
 			typeof candidate.brandInfoOpen === "boolean"
 				? candidate.brandInfoOpen
@@ -245,6 +263,8 @@ export const useSynthUiStore = create<SynthUiStore>()(
 			setScopeVisualizationMode: (mode) =>
 				set({ scopeVisualizationMode: mode }),
 			setScopeColorTheme: (theme) => set({ scopeColorTheme: theme }),
+			setScopeFrozen: (frozen) => set({ scopeFrozen: frozen }),
+			setScopeTriggerEdge: (edge) => set({ scopeTriggerEdge: edge }),
 			setBrandInfoOpen: (open) => set({ brandInfoOpen: open }),
 			setGlobalPanelOpen: (open) => set({ globalPanelOpen: open }),
 			setMidiLearnOpen: (open) => set({ midiLearnOpen: open }),
@@ -269,6 +289,8 @@ export const useSynthUiStore = create<SynthUiStore>()(
 				scopeTriggerLevel: state.scopeTriggerLevel,
 				scopeVisualizationMode: state.scopeVisualizationMode,
 				scopeColorTheme: state.scopeColorTheme,
+				scopeFrozen: state.scopeFrozen,
+				scopeTriggerEdge: state.scopeTriggerEdge,
 			}),
 			merge: (persistedState, currentState) => ({
 				...currentState,

--- a/packages/cosmo-pd101/src/lib/synth/drawOscilloscope.ts
+++ b/packages/cosmo-pd101/src/lib/synth/drawOscilloscope.ts
@@ -1,3 +1,7 @@
+const TRIGGER_HYSTERESIS_U8 = 4;
+const TRIGGER_HYSTERESIS_F32 = 0.02;
+const TRIGGER_SEARCH_MARGIN = 4;
+
 export type OscilloscopeConfig = {
 	cycles: number;
 	verticalZoom: number;
@@ -5,6 +9,8 @@ export type OscilloscopeConfig = {
 	triggerMode?: "off" | "rise" | "fall";
 	fixedWindowSamples?: number;
 	startIndex?: number;
+	lastTriggerIndex?: number;
+	triggerOffsetRef?: { current: number | undefined };
 	color?: string;
 	gridColor?: string;
 };
@@ -87,11 +93,20 @@ export function drawOscilloscope(
 			: Math.max(1, Math.floor((samples.length - viewSamples) / 2));
 	if (triggerMode !== "off") {
 		const endLimit = samples.length - viewSamples - 1;
-		for (let i = 1; i < endLimit; i++) {
+		const hyst = isUint8 ? TRIGGER_HYSTERESIS_U8 : TRIGGER_HYSTERESIS_F32;
+		const searchStart =
+			typeof config.lastTriggerIndex === "number"
+				? Math.max(1, config.lastTriggerIndex - TRIGGER_SEARCH_MARGIN)
+				: 1;
+		const searchEnd =
+			typeof config.lastTriggerIndex === "number"
+				? Math.min(endLimit, config.lastTriggerIndex + TRIGGER_SEARCH_MARGIN)
+				: endLimit;
+		for (let i = searchStart; i < searchEnd; i++) {
 			const prev = samples[i - 1];
 			const curr = samples[i];
-			const riseHit = prev < triggerFloat && curr >= triggerFloat;
-			const fallHit = prev > triggerFloat && curr <= triggerFloat;
+			const riseHit = prev <= triggerFloat - hyst && curr >= triggerFloat;
+			const fallHit = prev >= triggerFloat + hyst && curr <= triggerFloat;
 			if (
 				(triggerMode === "rise" && riseHit) ||
 				(triggerMode === "fall" && fallHit)
@@ -100,6 +115,11 @@ export function drawOscilloscope(
 				break;
 			}
 		}
+		if (config.triggerOffsetRef) {
+			config.triggerOffsetRef.current = start;
+		}
+	} else if (config.triggerOffsetRef) {
+		config.triggerOffsetRef.current = start;
 	}
 
 	// Calculate mean for centering


### PR DESCRIPTION
## Summary

Adds three scope improvements:

1. **Freeze toggle** — pauses scope waveform capture so you can inspect a snapshot
2. **Trigger edge toggle** — switch between rising/falling edge trigger for waveform stabilization
3. **Hysteresis + constrained search** — fixes scope stutter/jitter between two positions by implementing Schmitt trigger hysteresis and a ±4 sample search window around the last known trigger position (waveform + orbital modes only)

## Key changes

- `synthUiStore.ts` — added `scopeFrozen`, `scopeTriggerEdge` state + actions
- `ScopeControls.tsx` — added Freeze button and Rise/Fall edge toggle
- `drawOscilloscope.ts` — hysteresis (`TRIGGER_HYSTERESIS_U8=4`, `TRIGGER_HYSTERESIS_F32=0.02`) + constrained search (`TRIGGER_SEARCH_MARGIN=4`) + `triggerOffsetRef` for position tracking across frames
- `processing.ts` — hysteresis in `resolveScopeWindow`; restored `sampleAt` export
- `OrbitalViz.tsx` — local constrained search via `WeakMap<HTMLCanvasElement, number>`
- `ScopeVisualizationDisplay.tsx` — freeze gate in draw loop + `triggerOffsetRef` wiring

## Test plan

- [x] Lint passes (`bun run lint`)
- [x] All 769 tests pass (`bun run test`)

🤖 Generated with [opencode](https://opencode.ai)