### PR TITLE
fix: capture keyboard input on text fields instead of leaking to DAW

### DIFF
--- a/packages/cosmo-pd101-plugin/webview/src/App.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/App.tsx
@@ -54,8 +54,8 @@ export default function App() {
 			}
 		};
 
-		const handleKeyDownCapture = (event: globalThis.KeyboardEvent) => {
-			if (isEditableTarget(document.activeElement)) {
+		const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+			if (isEditableTarget(event.target)) {
 				event.stopPropagation();
 			}
 		};
@@ -63,13 +63,13 @@ export default function App() {
 		document.addEventListener("selectstart", handleSelectStart);
 		document.addEventListener("dragstart", handleDragStart);
 		document.addEventListener("selectionchange", handleSelectionChange);
-		document.addEventListener("keydown", handleKeyDownCapture, true);
+		document.addEventListener("keydown", handleKeyDown);
 
 		return () => {
 			document.removeEventListener("selectstart", handleSelectStart);
 			document.removeEventListener("dragstart", handleDragStart);
 			document.removeEventListener("selectionchange", handleSelectionChange);
-			document.removeEventListener("keydown", handleKeyDownCapture, true);
+			document.removeEventListener("keydown", handleKeyDown);
 		};
 	}, []);
 

--- a/packages/cosmo-pd101-plugin/webview/src/App.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/App.tsx
@@ -54,14 +54,22 @@ export default function App() {
 			}
 		};
 
+		const handleKeyDownCapture = (event: globalThis.KeyboardEvent) => {
+			if (isEditableTarget(document.activeElement)) {
+				event.stopPropagation();
+			}
+		};
+
 		document.addEventListener("selectstart", handleSelectStart);
 		document.addEventListener("dragstart", handleDragStart);
 		document.addEventListener("selectionchange", handleSelectionChange);
+		document.addEventListener("keydown", handleKeyDownCapture, true);
 
 		return () => {
 			document.removeEventListener("selectstart", handleSelectStart);
 			document.removeEventListener("dragstart", handleDragStart);
 			document.removeEventListener("selectionchange", handleSelectionChange);
+			document.removeEventListener("keydown", handleKeyDownCapture, true);
 		};
 	}, []);
 

--- a/packages/cosmo-pd101/src/components/controls/SynthTextInput.tsx
+++ b/packages/cosmo-pd101/src/components/controls/SynthTextInput.tsx
@@ -1,0 +1,105 @@
+import {
+	type ChangeEvent,
+	forwardRef,
+	type KeyboardEvent,
+	useRef,
+} from "react";
+
+type SynthTextInputProps = {
+	value: string;
+	onChange: (value: string) => void;
+	onBlur?: () => void;
+	onCommit?: () => void;
+	onCancel?: () => void;
+	placeholder?: string;
+	className?: string;
+	disabled?: boolean;
+	id?: string;
+	maxLength?: number;
+	multiline?: boolean;
+	autoFocus?: boolean;
+	ariaLabel?: string;
+};
+
+export default forwardRef(function SynthTextInput(
+	{
+		value,
+		onChange,
+		onBlur,
+		onCommit,
+		onCancel,
+		placeholder,
+		className = "",
+		disabled,
+		id,
+		maxLength,
+		multiline,
+		autoFocus,
+		ariaLabel,
+	}: SynthTextInputProps,
+	ref: React.ForwardedRef<HTMLInputElement | HTMLTextAreaElement>,
+) {
+	const innerRef = useRef<HTMLInputElement | HTMLTextAreaElement | null>(null);
+
+	const handleKeyDown = (e: KeyboardEvent) => {
+		e.stopPropagation();
+
+		if (e.key === "Enter") {
+			if (multiline) {
+				if (e.metaKey || e.ctrlKey) {
+					e.preventDefault();
+					onCommit?.();
+				}
+			} else {
+				e.preventDefault();
+				onCommit?.();
+			}
+		}
+		if (e.key === "Escape") {
+			e.preventDefault();
+			onCancel?.();
+		}
+	};
+
+	const setRef = (node: HTMLInputElement | HTMLTextAreaElement | null) => {
+		innerRef.current = node;
+		if (typeof ref === "function") {
+			ref(node);
+		} else if (ref) {
+			ref.current = node;
+		}
+	};
+
+	const commonProps = {
+		value,
+		placeholder,
+		disabled,
+		id,
+		maxLength,
+		autoFocus,
+		"aria-label": ariaLabel,
+		onBlur,
+		onKeyDown: handleKeyDown,
+		onChange: (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+			onChange(e.target.value),
+	};
+
+	if (multiline) {
+		return (
+			<textarea
+				ref={setRef}
+				className={`textarea textarea-sm min-h-24 w-full resize-y border-cz-border bg-cz-inset text-cz-cream ${className}`}
+				{...commonProps}
+			/>
+		);
+	}
+
+	return (
+		<input
+			ref={setRef}
+			type="text"
+			className={`input input-sm w-full border-cz-border bg-cz-inset text-cz-cream ${className}`}
+			{...commonProps}
+		/>
+	);
+});

--- a/packages/cosmo-pd101/src/components/modals/MacroLabelEditorPopover.tsx
+++ b/packages/cosmo-pd101/src/components/modals/MacroLabelEditorPopover.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import SynthTextInput from "@/components/controls/SynthTextInput";
 import Popover from "@/components/primitives/Popover";
 import { useSynthStore } from "@/features/synth/synthStore";
 
@@ -34,16 +35,15 @@ export function MacroLabelEditorPopover({
 						<label
 							key={`macro-label-editor-${idx}`}
 							className="flex flex-col gap-1 font-mono text-4xs text-cz-cream-dim uppercase tracking-[0.12em]"
+							htmlFor={`macro-label-${idx}`}
 						>
 							Macro {idx + 1}
-							<input
-								type="text"
-								className="input input-sm w-full border-cz-border bg-cz-inset font-mono text-2xs text-cz-cream"
-								maxLength={18}
+							<SynthTextInput
+								id={`macro-label-${idx}`}
 								value={labels[idx]}
-								onChange={(event) =>
-									setMacroLabel(idx, event.currentTarget.value)
-								}
+								onChange={(value) => setMacroLabel(idx, value)}
+								maxLength={18}
+								className="font-mono text-2xs"
 							/>
 						</label>
 					))}

--- a/packages/cosmo-pd101/src/components/preset/PresetLibraryDialogs.tsx
+++ b/packages/cosmo-pd101/src/components/preset/PresetLibraryDialogs.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@/components/controls/Button";
+import SynthTextInput from "@/components/controls/SynthTextInput";
 
 type PresetLibraryDialogsProps = {
 	saveAsOpen: boolean;
@@ -38,16 +39,13 @@ export default memo(function PresetLibraryDialogs({
 					<h3 className="font-bold font-mono text-lg">
 						{t("presetDialogs.saveAsTitle")}
 					</h3>
-					<input
-						type="text"
-						className="input mt-4 w-full border-cz-border bg-cz-inset text-cz-cream"
-						placeholder={t("presetDialogs.saveAsPlaceholder")}
+					<SynthTextInput
 						value={saveAsName}
-						onChange={(event) => onSaveAsNameChange(event.target.value)}
-						onKeyDown={(event) => {
-							if (event.key === "Enter") onCommitSaveAs();
-							if (event.key === "Escape") onCancelSaveAs();
-						}}
+						onChange={onSaveAsNameChange}
+						onCommit={onCommitSaveAs}
+						onCancel={onCancelSaveAs}
+						placeholder={t("presetDialogs.saveAsPlaceholder")}
+						className="mt-4"
 					/>
 					<div className="modal-action">
 						<Button

--- a/packages/cosmo-pd101/src/components/preset/PresetLibraryHeader.tsx
+++ b/packages/cosmo-pd101/src/components/preset/PresetLibraryHeader.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@/components/controls/Button";
+import SynthTextInput from "@/components/controls/SynthTextInput";
 import { getPresetTagCheckboxClassName } from "./presetTagTone";
 import type { FilterOptions } from "./usePresetLibraryState";
 
@@ -74,12 +75,11 @@ export default memo(function PresetLibraryHeader({
 						: t("presetLibrary.foundPlural")}
 				</p>
 				<div className="flex min-w-64 items-center overflow-hidden rounded-md border border-cz-border bg-cz-inset">
-					<input
-						type="text"
-						className="h-10 min-w-0 flex-1 bg-transparent px-3 text-cz-cream text-sm placeholder-cz-cream-dim/70 outline-none"
-						placeholder={t("presetLibrary.searchPlaceholder")}
+					<SynthTextInput
 						value={search}
-						onChange={(event) => onSearchChange(event.target.value)}
+						onChange={onSearchChange}
+						placeholder={t("presetLibrary.searchPlaceholder")}
+						className="h-10 min-w-0 flex-1 bg-transparent px-3 text-cz-cream text-sm placeholder-cz-cream-dim/70 outline-none"
 					/>
 					<button
 						type="button"

--- a/packages/cosmo-pd101/src/components/preset/PresetLibrarySidebar.tsx
+++ b/packages/cosmo-pd101/src/components/preset/PresetLibrarySidebar.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import Button from "@/components/controls/Button";
+import SynthTextInput from "@/components/controls/SynthTextInput";
 import type { PresetEntry } from "@/features/synth/types/presetEntry";
 import { PRESET_TAG_OPTIONS } from "@/lib/synth/presetTags";
 import PresetMultiSelect from "./PresetMultiSelect";
@@ -104,24 +105,18 @@ export default memo(function PresetLibrarySidebar({
 						{t("presetLibrary.selectedPreset")}
 					</h3>
 					{selectedEntry ? (
-						<div className="space-y-3">
+						<div className="mr-3 space-y-3">
 							<div>
 								<p className="mb-1 font-mono text-4xs text-cz-cream-dim uppercase tracking-[0.2em]">
 									{t("presetLibrary.nameLabel")}
 								</p>
 								{selectedEntry.type === "local" ? (
-									<input
-										type="text"
-										className="input input-sm w-full border-cz-border bg-cz-inset text-cz-cream"
-										placeholder="Preset name"
+									<SynthTextInput
 										value={renameValue}
-										onChange={(event) =>
-											onRenameValueChange(event.target.value)
-										}
+										onChange={onRenameValueChange}
 										onBlur={onCommitRename}
-										onKeyDown={(event) => {
-											if (event.key === "Enter") onCommitRename();
-										}}
+										onCommit={onCommitRename}
+										placeholder="Preset name"
 									/>
 								) : (
 									<p className="text-cz-cream text-sm">{selectedEntry.label}</p>
@@ -132,18 +127,12 @@ export default memo(function PresetLibrarySidebar({
 									{t("presetLibrary.authorLabel")}
 								</p>
 								{selectedEntry.type === "local" ? (
-									<input
-										type="text"
-										className="input input-sm w-full border-cz-border bg-cz-inset text-cz-cream"
-										placeholder="Preset author"
+									<SynthTextInput
 										value={authorValue}
-										onChange={(event) =>
-											onAuthorValueChange(event.target.value)
-										}
+										onChange={onAuthorValueChange}
 										onBlur={onCommitAuthor}
-										onKeyDown={(event) => {
-											if (event.key === "Enter") onCommitAuthor();
-										}}
+										onCommit={onCommitAuthor}
+										placeholder="Preset author"
 									/>
 								) : (
 									<p className="text-cz-cream text-sm">
@@ -161,22 +150,13 @@ export default memo(function PresetLibrarySidebar({
 									{t("presetLibrary.descriptionLabel")}
 								</p>
 								{selectedEntry.type === "local" ? (
-									<textarea
-										className="textarea textarea-sm min-h-16 w-full resize-y border-cz-border bg-cz-inset text-cz-cream"
-										placeholder={t("presetLibrary.descriptionPlaceholder")}
+									<SynthTextInput
+										multiline
 										value={descriptionValue}
-										onChange={(event) =>
-											onDescriptionValueChange(event.target.value)
-										}
+										onChange={onDescriptionValueChange}
 										onBlur={onCommitDescription}
-										onKeyDown={(event) => {
-											if (
-												event.key === "Enter" &&
-												(event.metaKey || event.ctrlKey)
-											) {
-												onCommitDescription();
-											}
-										}}
+										onCommit={onCommitDescription}
+										placeholder={t("presetLibrary.descriptionPlaceholder")}
 									/>
 								) : (
 									<p className="whitespace-pre-wrap text-cz-cream text-sm">


### PR DESCRIPTION
## Summary

Keyboard events on text inputs (author, preset name, description, search, macro labels) were propagating to the host DAW, causing unwanted actions (e.g. space bar triggering play/pause instead of inserting a space).

### Changes

- **New `SynthTextInput` component** (`packages/cosmo-pd101/src/components/controls/SynthTextInput.tsx`)
  - Shared React component wrapping `<input>` and `<textarea>`
  - Calls `e.stopPropagation()` on React `onKeyDown` to prevent events from reaching host
  - Handles Enter (commit), Escape (cancel), Cmd+Enter (commit multiline)
  - Supports `multiline` prop for textareas, standard input otherwise
  - Exposes `id`, `ariaLabel`, `autoFocus`, custom className

- **Replaced raw inputs in 4 files:**
  - `PresetLibrarySidebar.tsx` — rename, author, description
  - `PresetLibraryDialogs.tsx` — save-as name
  - `PresetLibraryHeader.tsx` — search box
  - `MacroLabelEditorPopover.tsx` — 4× macro label inputs

- **Capture-phase keydown guard** in plugin `App.tsx`
  - Added `document.addEventListener("keydown", ..., true)` that calls `stopPropagation` when `document.activeElement` is an editable target
  - Defense-in-depth against DAW keyboard leak

## Test plan

- [x] `bun run lint` — clean (only pre-existing errors)
- [x] `bun run test` — all 938 tests pass
- [x] `bun run build` — builds successfully (only pre-existing codesign failure)