### PR TITLE
ci: add Rust tests job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,24 @@ jobs:
         run: exit 1
         shell: bash
 
+  rust-tests:
+    name: Rust Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests (excluding cosmo-pd101-plugin)
+        run: cargo test --workspace --exclude cosmo-pd101-plugin
+
+      - name: Run cosmo-pd101-plugin tests (single-threaded)
+        run: cargo test -p cosmo-pd101-plugin -- --test-threads=1
+
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,16 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      
+      - name: Install Linux native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libglib2.0-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libwebkit2gtk-4.1-dev
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2

--- a/packages/cosmo-synth-engine/src/simd/avx2.rs
+++ b/packages/cosmo-synth-engine/src/simd/avx2.rs
@@ -169,9 +169,9 @@ mod tests {
         let a = Avx2::splat(2.0);
         let b = Avx2::splat(3.0);
 
-        assert_eq!(a.add(b).to_array(), [5.0; 4]);
-        assert_eq!(a.mul(b).to_array(), [6.0; 4]);
-        assert_eq!(b.sub(a).to_array(), [1.0; 4]);
+        assert_eq!(SimdType::add(a, b).to_array(), [5.0; 4]);
+        assert_eq!(SimdType::mul(a, b).to_array(), [6.0; 4]);
+        assert_eq!(SimdType::sub(b, a).to_array(), [1.0; 4]);
         assert_eq!(a.max(b).to_array(), [3.0; 4]);
         assert_eq!(a.min(b).to_array(), [2.0; 4]);
         assert_eq!(a.sum(), 8.0);


### PR DESCRIPTION
## What

Adds a new `rust-tests` job to CI that runs all Rust unit tests.

## Why

The CI pipeline only ran TypeScript tests. ~150+ Rust unit tests across cosmo-synth-engine and cosmo-pd101-plugin crates were never executed in CI, letting engine/IPC regressions land silently.

## Changes

- Added `rust-tests` job to `.github/workflows/ci.yml`:
  - Runs on `ubuntu-latest` in parallel with TS test jobs
  - Uses `Swatinem/rust-cache@v2` for Rust artifact caching
  - Runs `cargo test --workspace --exclude cosmo-pd101-plugin`
  - Runs `cargo test -p cosmo-pd101-plugin -- --test-threads=1` (single-threaded for plugin crate to work around known race condition in `voice_limit_round_trips_through_save_load`)

Closes audit-followup-01