### PR TITLE
feat(auv3): add standalone app settings

### DIFF
--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Common/Audio/SimplePlayEngine.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Common/Audio/SimplePlayEngine.swift
@@ -13,6 +13,23 @@ import os
 
 private let speLog = OSLog(subsystem: "com.cosmo.pd101.auv3", category: "SPE")
 
+private enum StandaloneAudioSettings {
+    static let groupId = "group.ca.purraudio.CosmoPD101Host"
+    static let bufferSizeKey = "com.cosmo.pd101.standalone.bufferSize"
+    static let defaultBufferSize = 128
+    static let allowedBufferSizes = [128, 256, 512, 1024]
+
+    private static var defaults: UserDefaults {
+        UserDefaults(suiteName: groupId) ?? .standard
+    }
+
+    static var bufferSize: Int {
+        let stored = defaults.object(forKey: bufferSizeKey) as? Int
+        let value = stored ?? defaultBufferSize
+        return allowedBufferSizes.contains(value) ? value : defaultBufferSize
+    }
+}
+
 #if os(iOS) || os(visionOS)
 import UIKit
 #elseif os(macOS)
@@ -163,6 +180,7 @@ public class SimplePlayEngine {
     
     // File to play.
     private var file: AVAudioFile?
+    private var loopBuffer: AVAudioPCMBuffer?
     
     // Whether we are playing.
     private(set) var isPlaying = false
@@ -388,6 +406,14 @@ public class SimplePlayEngine {
         do {
             let file = try AVAudioFile(forReading: fileURL)
             self.file = file
+            if let buffer = AVAudioPCMBuffer(
+                pcmFormat: file.processingFormat,
+                frameCapacity: AVAudioFrameCount(file.length)
+            ) {
+                try file.read(into: buffer)
+                file.framePosition = 0
+                self.loopBuffer = buffer
+            }
             engine.connect(player, to: engine.mainMixerNode, format: file.processingFormat)
         } catch {
             os_log(.error, log: speLog, "Could not create AVAudioFile instance: %@", error.localizedDescription)
@@ -399,7 +425,21 @@ public class SimplePlayEngine {
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.playback, mode: .default)
+            if active {
+                let sampleRate = session.sampleRate > 0 ? session.sampleRate : 48_000
+                let duration = Double(StandaloneAudioSettings.bufferSize) / sampleRate
+                try session.setPreferredIOBufferDuration(duration)
+            }
             try session.setActive(active)
+            os_log(
+                "Audio session active=%{public}@ category=%{public}@ sampleRate=%{public}.1f ioBuffer=%{public}.5f",
+                log: speLog,
+                type: .default,
+                active ? "yes" : "no",
+                session.category.rawValue,
+                session.sampleRate,
+                session.ioBufferDuration
+            )
         } catch {
             os_log(.error, log: speLog, "Could not set Audio Session active: %@", error.localizedDescription)
         }
@@ -536,17 +576,12 @@ public class SimplePlayEngine {
     }
     
     private func scheduleEffectLoop() {
-        guard let file = file else {
-            os_log(.error, log: speLog, "`file` must not be nil in scheduleEffectLoop")
+        guard let loopBuffer else {
+            os_log(.error, log: speLog, "`loopBuffer` must not be nil in scheduleEffectLoop")
             return
         }
-        
-        Task {
-            await player.scheduleFile(file, at: nil)
-            if self.isPlaying {
-                self.scheduleEffectLoop()
-            }
-        }
+
+        player.scheduleBuffer(loopBuffer, at: nil, options: .loops)
     }
     
     private func resetAudioLoop() {

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Common/UI/ViewControllerRepresentable.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Common/UI/ViewControllerRepresentable.swift
@@ -17,6 +17,11 @@ func configureStandaloneAuv3ViewController(_ viewController: NSObject) {
 	if viewController.responds(to: runtimeModeSelector) {
 		viewController.setValue("standalone", forKey: "cosmoAuv3RuntimeMode")
 	}
+
+	let appSettingsSelector = NSSelectorFromString("setCosmoAuv3SupportsStandaloneAppSettings:")
+	if viewController.responds(to: appSettingsSelector) {
+		viewController.setValue(true, forKey: "cosmoAuv3SupportsStandaloneAppSettings")
+	}
 }
 
 #if os(iOS) || os(visionOS)

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/CosmoPD101AUv3Ext_macOSApp.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/CosmoPD101AUv3Ext_macOSApp.swift
@@ -13,6 +13,7 @@ struct CosmoPD101AUv3Ext_macOSApp: App {
 	private static let minimumWindowHeight: CGFloat = 480
 
     @StateObject private var hostModel = AudioUnitHostModel()
+	@Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
@@ -21,6 +22,9 @@ struct CosmoPD101AUv3Ext_macOSApp: App {
 					minWidth: Self.minimumWindowWidth,
 					minHeight: Self.minimumWindowHeight
 				)
+				.onChange(of: scenePhase) { phase in
+					hostModel.handleScenePhaseChange(phase)
+				}
         }
 		.defaultSize(width: Self.minimumWindowWidth, height: Self.minimumWindowHeight)
 		.windowResizability(.contentSize)

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Info.plist
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Model/AudioUnitHostModel.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOS/Model/AudioUnitHostModel.swift
@@ -11,6 +11,20 @@ import AudioToolbox
 import AVFAudio
 import Combine
 
+private enum StandaloneHostSettings {
+    static let groupId = "group.ca.purraudio.CosmoPD101Host"
+    static let keepRunningInBackgroundKey = "com.cosmo.pd101.standalone.keepRunningInBackground"
+    static let defaultKeepRunningInBackground = false
+
+    private static var defaults: UserDefaults {
+        UserDefaults(suiteName: groupId) ?? .standard
+    }
+
+    static var keepRunningInBackground: Bool {
+        defaults.object(forKey: keepRunningInBackgroundKey) as? Bool ?? defaultKeepRunningInBackground
+    }
+}
+
 @MainActor
 class AudioUnitHostModel: ObservableObject {
     /// The playback engine used to play audio.
@@ -182,10 +196,12 @@ class AudioUnitHostModel: ObservableObject {
 
     func handleScenePhaseChange(_ phase: ScenePhase) {
 #if os(iOS) || os(visionOS)
+        let keepRunningInBackground = StandaloneHostSettings.keepRunningInBackground
         let backgroundModes = (Bundle.main.object(forInfoDictionaryKey: "UIBackgroundModes") as? [String])?.joined(separator: ",") ?? "<none>"
         NSLog(
-            "[AUHostModel] scenePhase=%@ isPlaying=%@ suspendedForBackground=%@ backgroundModes=%@",
+            "[AUHostModel] scenePhase=%@ keepRunningInBackground=%@ isPlaying=%@ suspendedForBackground=%@ backgroundModes=%@",
             String(describing: phase),
+            keepRunningInBackground ? "yes" : "no",
             playEngine.isPlaying ? "yes" : "no",
             suspendedForBackground ? "yes" : "no",
             backgroundModes
@@ -201,6 +217,11 @@ class AudioUnitHostModel: ObservableObject {
         case .inactive:
             break
         case .background:
+            guard !keepRunningInBackground else {
+                suspendedForBackground = false
+                playEngine.cancelPendingFadeOut()
+                return
+            }
             if playEngine.isPlaying {
                 suspendedForBackground = true
                 playEngine.fadeOutAndStop()

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/Audio Unit/CosmoPD101AUv3Ext_macOSExtensionAudioUnit.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/Audio Unit/CosmoPD101AUv3Ext_macOSExtensionAudioUnit.swift
@@ -15,6 +15,7 @@ public final class CosmoPD101AUv3Ext_macOSExtensionAudioUnit: AUAudioUnit, @unch
 	private var engine: CosmoPd101FfiEngineRef?
 	private var maxFrames: Int = 1024
 	private var voiceLimit: Int = 8
+	private var midiChannel: Int = 0
 	private var parameterObserverToken: AUParameterObserverToken?
 	/// Full-state JSON buffered when `fullStateForDocument` is set before `allocateRenderResources`.
 	private var pendingParamsJson: String?
@@ -171,6 +172,15 @@ public final class CosmoPD101AUv3Ext_macOSExtensionAudioUnit: AUAudioUnit, @unch
 		} else {
 			syncParametersToEngine()
 		}
+	}
+
+	public func setMidiChannel(_ channel: Int) {
+		let nextChannel = max(0, min(channel, 16))
+		guard nextChannel != midiChannel else { return }
+		if engine != nil {
+			_ = cosmo_pd101_ffi_all_notes_off(engine)
+		}
+		midiChannel = nextChannel
 	}
 
 	public override func deallocateRenderResources() {
@@ -475,6 +485,10 @@ public final class CosmoPD101AUv3Ext_macOSExtensionAudioUnit: AUAudioUnit, @unch
 
 	private func handleMidi(status: UInt8, data1: UInt8, data2: UInt8) {
 		let message = status & 0xF0
+		let channel = Int(status & 0x0F) + 1
+		if midiChannel != 0 && channel != midiChannel {
+			return
+		}
 		switch message {
 		case 0x80:
 			_ = cosmo_pd101_ffi_note_off(engine, data1)

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/UI/AudioUnitViewController.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/UI/AudioUnitViewController.swift
@@ -31,6 +31,53 @@ private enum VoiceLimitSettings {
 	}
 }
 
+private enum StandaloneAppSettings {
+	static let groupId = "group.ca.purraudio.CosmoPD101Host"
+	static let midiChannelKey = "com.cosmo.pd101.standalone.midiChannel"
+	static let keepRunningInBackgroundKey = "com.cosmo.pd101.standalone.keepRunningInBackground"
+	static let bufferSizeKey = "com.cosmo.pd101.standalone.bufferSize"
+	static let defaultMidiChannel = 0
+	static let defaultKeepRunningInBackground = false
+	static let defaultBufferSize = 128
+	static let allowedBufferSizes = [128, 256, 512, 1024]
+
+	private static var defaults: UserDefaults {
+		UserDefaults(suiteName: groupId) ?? .standard
+	}
+
+	static func clampMidiChannel(_ value: Int) -> Int {
+		max(0, min(value, 16))
+	}
+
+	static func clampBufferSize(_ value: Int) -> Int {
+		allowedBufferSizes.contains(value) ? value : defaultBufferSize
+	}
+
+	static func load() -> [String: Any] {
+		let storedMidiChannel = defaults.object(forKey: midiChannelKey) as? Int
+		let storedBufferSize = defaults.object(forKey: bufferSizeKey) as? Int
+		return [
+			"midiChannel": clampMidiChannel(storedMidiChannel ?? defaultMidiChannel),
+			"keepRunningInBackground": defaults.object(forKey: keepRunningInBackgroundKey) as? Bool ?? defaultKeepRunningInBackground,
+			"bufferSize": clampBufferSize(storedBufferSize ?? defaultBufferSize),
+		]
+	}
+
+	static func save(_ payload: [String: Any]) -> [String: Any] {
+		let midiChannel = clampMidiChannel(payload["midiChannel"] as? Int ?? defaultMidiChannel)
+		let keepRunningInBackground = payload["keepRunningInBackground"] as? Bool ?? defaultKeepRunningInBackground
+		let bufferSize = clampBufferSize(payload["bufferSize"] as? Int ?? defaultBufferSize)
+		defaults.set(midiChannel, forKey: midiChannelKey)
+		defaults.set(keepRunningInBackground, forKey: keepRunningInBackgroundKey)
+		defaults.set(bufferSize, forKey: bufferSizeKey)
+		return [
+			"midiChannel": midiChannel,
+			"keepRunningInBackground": keepRunningInBackground,
+			"bufferSize": bufferSize,
+		]
+	}
+}
+
 public class AudioUnitViewController: AUViewController, AUAudioUnitFactory, WebEditorSessionDelegate {
 	private static let minimumWidth: CGFloat = 640
 	private static let minimumHeight: CGFloat = 480
@@ -62,6 +109,9 @@ public class AudioUnitViewController: AUViewController, AUAudioUnitFactory, WebE
 	}
 	@objc public var cosmoAuv3RuntimeMode: String = "auv3-hosted" {
 		didSet { currentSession?.publishHostContext(currentHostContext(), reason: "runtimeMode") }
+	}
+	@objc public var cosmoAuv3SupportsStandaloneAppSettings = false {
+		didSet { currentSession?.publishHostContext(currentHostContext(), reason: "standaloneAppSettingsSupport") }
 	}
 
 	nonisolated(unsafe) var audioUnit: AUAudioUnit?
@@ -180,6 +230,7 @@ public class AudioUnitViewController: AUViewController, AUAudioUnitFactory, WebE
 	nonisolated public func createAudioUnit(with componentDescription: AudioComponentDescription) throws -> AUAudioUnit {
 		let unit = try CosmoPD101AUv3Ext_macOSExtensionAudioUnit(componentDescription: componentDescription, options: [])
 		unit.setVoiceLimit(VoiceLimitSettings.load())
+		applyStandaloneAppSettings(StandaloneAppSettings.load(), to: unit)
 		audioUnit = unit
 		observation = unit.observe(\.allParameterValues, options: [.new]) { _, _ in }
 		unit.paramsChangedHandler = { [weak self] json, presetName in
@@ -349,6 +400,12 @@ public class AudioUnitViewController: AUViewController, AUAudioUnitFactory, WebE
 				applied ? "true" : "false"
 			)
 			sendResponse(session: session, id: id, result: NSNull())
+		case "getStandaloneAppSettings":
+			sendResponse(session: session, id: id, result: StandaloneAppSettings.load())
+		case "setStandaloneAppSettings":
+			let settings = StandaloneAppSettings.save(methodPayload as? [String: Any] ?? [:])
+			applyStandaloneAppSettings(settings, to: audioUnit)
+			sendResponse(session: session, id: id, result: settings)
 		case "addPreset", "savePreset", "deletePreset", "renamePreset", "toggleStarred", "setPresetAuthor", "setPresetDescription", "setPresetTags", "exportPreset", "importPresetBank", "listFxModulePresets", "saveFxModulePreset", "deleteFxModulePreset":
 			sendError(session: session, id: id, message: "AUv3 preset library editing is not supported yet")
 		case "clientLog":
@@ -425,7 +482,8 @@ public class AudioUnitViewController: AUViewController, AUAudioUnitFactory, WebE
 	private func currentHostContext() -> WebEditorHostContext {
 		WebEditorHostContext(
 			runtimeMode: cosmoAuv3RuntimeMode,
-			fitMode: cosmoAuv3FitMode
+			fitMode: cosmoAuv3FitMode,
+			supportsStandaloneAppSettings: cosmoAuv3SupportsStandaloneAppSettings
 		)
 	}
 
@@ -516,6 +574,21 @@ public class AudioUnitViewController: AUViewController, AUAudioUnitFactory, WebE
 			NSStringFromRect(screenFrame)
 		)
 		#endif
+	}
+
+	private func applyStandaloneAppSettings(_ settings: [String: Any], to audioUnit: CosmoPD101AUv3Ext_macOSExtensionAudioUnit) {
+		let midiChannel = StandaloneAppSettings.clampMidiChannel(settings["midiChannel"] as? Int ?? StandaloneAppSettings.defaultMidiChannel)
+		let bufferSize = StandaloneAppSettings.clampBufferSize(settings["bufferSize"] as? Int ?? StandaloneAppSettings.defaultBufferSize)
+		audioUnit.setMidiChannel(midiChannel)
+		audioUnit.maximumFramesToRender = AUAudioFrameCount(bufferSize)
+		os_log(
+			.default,
+			log: czVCLog,
+			"standalone app settings applied midiChannel=%d bufferSize=%d keepBackground=%{public}@",
+			midiChannel,
+			bufferSize,
+			(settings["keepRunningInBackground"] as? Bool ?? StandaloneAppSettings.defaultKeepRunningInBackground) ? "true" : "false"
+		)
 	}
 
 	private func sendResponse(session: WebEditorSession, id: Int, result: Any) {

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/UI/WebEditorSession.swift
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/UI/WebEditorSession.swift
@@ -14,14 +14,16 @@ typealias WebEditorHostView = NSView
 struct WebEditorHostContext: Equatable {
 	let runtimeMode: String
 	let fitMode: String
+	let supportsStandaloneAppSettings: Bool
 
 	func script(dispatchEvent: Bool) -> String {
 		let runtimeMode = Self.javaScriptStringLiteral(runtimeMode)
 		let fitMode = Self.javaScriptStringLiteral(fitMode)
+		let supportsStandaloneAppSettings = supportsStandaloneAppSettings ? "true" : "false"
 		let eventScript = dispatchEvent
-			? "window.dispatchEvent(new CustomEvent('cz-host-context-changed',{detail:{runtimeMode:window.__czRuntimeMode,fitMode:window.__czAuv3FitMode}}));"
+			? "window.dispatchEvent(new CustomEvent('cz-host-context-changed',{detail:{runtimeMode:window.__czRuntimeMode,fitMode:window.__czAuv3FitMode,supportsStandaloneAppSettings:window.__czSupportsStandaloneAppSettings}}));"
 			: ""
-		return "window.__czRuntimeMode=\(runtimeMode);window.__czAuv3FitMode=\(fitMode);\(eventScript)"
+		return "window.__czRuntimeMode=\(runtimeMode);window.__czAuv3FitMode=\(fitMode);window.__czSupportsStandaloneAppSettings=\(supportsStandaloneAppSettings);\(eventScript)"
 	}
 
 	private static func javaScriptStringLiteral(_ value: String) -> String {
@@ -211,6 +213,7 @@ final class WebEditorSession: NSObject, WKNavigationDelegate, WKScriptMessageHan
 			assignments: [
 				"__czRuntimeMode": javaScriptStringLiteral(context.runtimeMode),
 				"__czAuv3FitMode": javaScriptStringLiteral(context.fitMode),
+				"__czSupportsStandaloneAppSettings": context.supportsStandaloneAppSettings ? "true" : "false",
 			]
 		)
 	}

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101Host-Info.plist
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101Host-Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>

--- a/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101Host.xcodeproj/project.pbxproj
+++ b/packages/cosmo-pd101-plugin-auv3/CosmoPD101Host/CosmoPD101Host.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1A3DB63E2FAB6671008A88D4 /* CosmoPD101AUv3Ext-macOSExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "CosmoPD101AUv3Ext-macOSExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A3DB6AB2FAB6671008A88D4 /* CosmoPd101Plugin.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CosmoPd101Plugin.xcframework; path = ../Artifacts/CosmoPd101Plugin.xcframework; sourceTree = "<group>"; };
 		1A834E852FDDBFA300EF1AD8 /* TelemetryController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TelemetryController.swift; path = ../Sources/CosmoPd101AUv3Support/TelemetryController.swift; sourceTree = "<group>"; };
+		1AC4783D2FFAA600005A1339 /* CosmoPD101Host-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "CosmoPD101Host-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -52,11 +53,21 @@
 			);
 			target = 1A3DB63D2FAB6671008A88D4 /* CosmoPD101AUv3Ext-macOSExtension */;
 		};
+		1AC4783F2FFAA61C005A1339 /* Exceptions for "CosmoPD101AUv3Ext-macOS" folder in "CosmoPD101AUv3Ext-macOS" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 1A3DB6182FAB6670008A88D4 /* CosmoPD101AUv3Ext-macOS */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		1A3DB61A2FAB6670008A88D4 /* CosmoPD101AUv3Ext-macOS */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				1AC4783F2FFAA61C005A1339 /* Exceptions for "CosmoPD101AUv3Ext-macOS" folder in "CosmoPD101AUv3Ext-macOS" target */,
+			);
 			path = "CosmoPD101AUv3Ext-macOS";
 			sourceTree = "<group>";
 		};
@@ -100,6 +111,7 @@
 		1A3DB5FE2FAB6546008A88D4 = {
 			isa = PBXGroup;
 			children = (
+				1AC4783D2FFAA600005A1339 /* CosmoPD101Host-Info.plist */,
 				1A3DB61A2FAB6670008A88D4 /* CosmoPD101AUv3Ext-macOS */,
 				1A3DB6422FAB6671008A88D4 /* CosmoPD101AUv3Ext-macOSExtension */,
 				1A3DB6AB2FAB6671008A88D4 /* CosmoPd101Plugin.xcframework */,
@@ -478,6 +490,7 @@
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CosmoPD101Host-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -530,6 +543,7 @@
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CosmoPD101Host-Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -682,6 +696,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CosmoPD101AUv3Ext-macOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Cosmo PD-101 AUv3";
 				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = "Cosmo PD-101 AUv3";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
@@ -689,6 +704,8 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphoneos*]" = audio;
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphonesimulator*]" = audio;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarHidden[sdk=iphoneos*]" = YES;
@@ -744,6 +761,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CosmoPD101AUv3Ext-macOS/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Cosmo PD-101 AUv3";
 				"INFOPLIST_KEY_CFBundleDisplayName[sdk=macosx*]" = "Cosmo PD-101 AUv3";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.music";
@@ -751,6 +769,8 @@
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphoneos*]" = audio;
+				"INFOPLIST_KEY_UIBackgroundModes[sdk=iphonesimulator*]" = audio;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIStatusBarHidden[sdk=iphoneos*]" = YES;

--- a/packages/cosmo-pd101-plugin-auv3/tests/auv3BridgeContract.test.ts
+++ b/packages/cosmo-pd101-plugin-auv3/tests/auv3BridgeContract.test.ts
@@ -258,9 +258,29 @@ describe("AUv3 bridge contract", () => {
 		expect(hostAppSource).toContain(
 			'viewController.setValue("standalone", forKey: "cosmoAuv3RuntimeMode")',
 		);
+		expect(hostAppSource).toContain(
+			'viewController.setValue(true, forKey: "cosmoAuv3SupportsStandaloneAppSettings")',
+		);
 		expect(simplePlayEngineSource).toContain(
 			"configureStandaloneAuv3ViewController(viewController)",
 		);
+	});
+
+	it("injects standalone app settings support into the AUv3 webview", () => {
+		const controllerSource = readText(xcodeControllerPath);
+		const sessionSource = readText(xcodeWebEditorSessionPath);
+
+		expect(controllerSource).toContain(
+			"@objc public var cosmoAuv3SupportsStandaloneAppSettings = false",
+		);
+		expect(sessionSource).toContain(
+			"window.__czSupportsStandaloneAppSettings=\\(supportsStandaloneAppSettings);",
+		);
+		expect(controllerSource).toContain(
+			"publishHostContext(currentHostContext()",
+		);
+		expect(sessionSource).toContain("func publishHostContext(");
+		expect(sessionSource).toContain("cz-host-context-changed");
 	});
 
 	it("keeps restored document params on the raw restore path", () => {
@@ -281,7 +301,7 @@ describe("AUv3 bridge contract", () => {
 		expect(swiftSource).toContain("savedStateJson = json");
 	});
 
-	it("keeps AUv3 standalone buffer choices aligned and allocates at the supported maximum", () => {
+	it("keeps AUv3 standalone buffer choices aligned and applies the render frame limit", () => {
 		const swiftSource = readText(xcodeControllerPath);
 		const audioUnitSource = readText(
 			path.join(
@@ -294,7 +314,7 @@ describe("AUv3 bridge contract", () => {
 			"static let allowedBufferSizes = [128, 256, 512, 1024]",
 		);
 		expect(swiftSource).toContain(
-			"audioUnit.maximumFramesToRender = AUAudioFrameCount(CosmoPD101AUv3Ext_macOSExtensionAudioUnit.maxSupportedFrameCount)",
+			"audioUnit.maximumFramesToRender = AUAudioFrameCount(bufferSize)",
 		);
 		expect(audioUnitSource).toContain(
 			"static let maxSupportedFrameCount = 1024",
@@ -305,5 +325,19 @@ describe("AUv3 bridge contract", () => {
 		expect(audioUnitSource).toContain(
 			"maxFrames = max(Int(maximumFramesToRender), Self.maxSupportedFrameCount)",
 		);
+	});
+
+	it("sends all notes off before changing the AUv3 MIDI channel filter", () => {
+		const audioUnitSource = readText(
+			path.join(
+				packageRoot,
+				"CosmoPD101Host/CosmoPD101AUv3Ext-macOSExtension/Common/Audio Unit/CosmoPD101AUv3Ext_macOSExtensionAudioUnit.swift",
+			),
+		);
+
+		expect(audioUnitSource).toContain(
+			"guard nextChannel != midiChannel else { return }",
+		);
+		expect(audioUnitSource).toContain("cosmo_pd101_ffi_all_notes_off(engine)");
 	});
 });

--- a/packages/cosmo-pd101-plugin/webview/src/Auv3StandaloneSettingsSection.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/Auv3StandaloneSettingsSection.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from "react";
+import type { StandaloneAppSettings } from "./lib/auv3Bridge";
+
+const DEFAULT_SETTINGS: StandaloneAppSettings = {
+	midiChannel: 0,
+	keepRunningInBackground: false,
+	bufferSize: 128,
+};
+
+const BUFFER_SIZES = [128, 256, 512, 1024] as const;
+
+function channelLabel(channel: number) {
+	return channel === 0 ? "Omni" : `${channel}`;
+}
+
+function clampSettings(settings: Partial<StandaloneAppSettings>) {
+	return {
+		midiChannel:
+			typeof settings.midiChannel === "number"
+				? Math.max(0, Math.min(16, Math.round(settings.midiChannel)))
+				: DEFAULT_SETTINGS.midiChannel,
+		keepRunningInBackground:
+			typeof settings.keepRunningInBackground === "boolean"
+				? settings.keepRunningInBackground
+				: DEFAULT_SETTINGS.keepRunningInBackground,
+		bufferSize: BUFFER_SIZES.includes(
+			settings.bufferSize as (typeof BUFFER_SIZES)[number],
+		)
+			? (settings.bufferSize as StandaloneAppSettings["bufferSize"])
+			: DEFAULT_SETTINGS.bufferSize,
+	};
+}
+
+export default function Auv3StandaloneSettingsSection() {
+	const [settings, setSettings] =
+		useState<StandaloneAppSettings>(DEFAULT_SETTINGS);
+
+	useEffect(() => {
+		let cancelled = false;
+		window
+			.__czGetStandaloneAppSettings?.()
+			.then((next) => {
+				if (!cancelled) {
+					setSettings(clampSettings(next));
+				}
+			})
+			.catch(() => {});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	const updateSettings = (patch: Partial<StandaloneAppSettings>) => {
+		const next = clampSettings({ ...settings, ...patch });
+		setSettings(next);
+		void window
+			.__czSetStandaloneAppSettings?.(next)
+			.then((applied) => setSettings(clampSettings(applied)))
+			.catch(() => {});
+	};
+
+	return (
+		<div className="space-y-3 border-cz-border/70 border-t pt-3">
+			<p className="font-mono text-2xs text-cz-cream-dim uppercase tracking-[0.18em]">
+				AUv3 App
+			</p>
+			<div className="space-y-1.5">
+				<p className="font-mono text-3xs text-cz-cream-dim uppercase tracking-[0.18em]">
+					MIDI Channel
+				</p>
+				<select
+					className="select select-xs w-full border-cz-border bg-cz-inset font-mono text-[0.6rem] text-cz-cream"
+					value={String(settings.midiChannel)}
+					onChange={(event) =>
+						updateSettings({
+							midiChannel: Number.parseInt(event.currentTarget.value, 10),
+						})
+					}
+				>
+					{[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16].map(
+						(channel) => (
+							<option key={`midi-channel-${channel}`} value={channel}>
+								{channelLabel(channel)}
+							</option>
+						),
+					)}
+				</select>
+			</div>
+			<div className="flex items-center justify-between gap-3">
+				<span className="font-mono text-3xs text-cz-cream-dim uppercase tracking-[0.18em]">
+					Run In Background
+				</span>
+				<input
+					type="checkbox"
+					className="toggle toggle-sm"
+					checked={settings.keepRunningInBackground}
+					onChange={(event) =>
+						updateSettings({
+							keepRunningInBackground: event.currentTarget.checked,
+						})
+					}
+				/>
+			</div>
+			<div className="space-y-1.5">
+				<p className="font-mono text-3xs text-cz-cream-dim uppercase tracking-[0.18em]">
+					Buffer Size
+				</p>
+				<div className="flex gap-1">
+					{BUFFER_SIZES.map((bufferSize) => (
+						<button
+							key={`buffer-${bufferSize}`}
+							type="button"
+							onClick={() => updateSettings({ bufferSize })}
+							className={`btn btn-xs flex-1 border px-1 text-[0.6rem] ${
+								settings.bufferSize === bufferSize
+									? "border-cz-gold bg-cz-gold/10 text-cz-gold"
+									: "border-cz-border bg-cz-inset text-cz-cream/70 hover:text-cz-cream"
+							}`}
+						>
+							{bufferSize}
+						</button>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.test.tsx
@@ -227,9 +227,25 @@ describe("PluginPage", () => {
 				__czHostPlatform?: string;
 				__czHostSize?: { width: number; height: number };
 				__czRuntimeMode?: string;
+				__czSupportsStandaloneAppSettings?: boolean;
 				ipc?: unknown;
 			}
 		).__czRuntimeMode;
+		delete (
+			window as Window & {
+				__czSupportsStandaloneAppSettings?: boolean;
+			}
+		).__czSupportsStandaloneAppSettings;
+		delete (
+			window as Window & {
+				__czGetStandaloneAppSettings?: unknown;
+			}
+		).__czGetStandaloneAppSettings;
+		delete (
+			window as Window & {
+				__czSetStandaloneAppSettings?: unknown;
+			}
+		).__czSetStandaloneAppSettings;
 		delete (window as Window & { ipc?: unknown }).ipc;
 	});
 
@@ -597,6 +613,171 @@ describe("PluginPage", () => {
 		} finally {
 			getBoundingClientRect.mockRestore();
 		}
+	});
+
+	it("shows AUv3 app settings in AUv3 webviews without waiting for the standalone support flag", () => {
+		(
+			window as Window & {
+				__czHostPlatform?: string;
+				__czRuntimeMode?: string;
+				__czSupportsStandaloneAppSettings?: boolean;
+			}
+		).__czHostPlatform = "ios";
+		(
+			window as Window & {
+				__czRuntimeMode?: string;
+			}
+		).__czRuntimeMode = "auv3-hosted";
+
+		const { getByText } = render(<PluginPage appVersion="0.2.0" />);
+
+		expect(getByText("AUv3 App")).toBeInstanceOf(HTMLElement);
+	});
+
+	it("shows AUv3 app settings in the standalone AUv3 app", () => {
+		(
+			window as Window & {
+				__czHostPlatform?: string;
+				__czRuntimeMode?: string;
+				__czSupportsStandaloneAppSettings?: boolean;
+				__czGetStandaloneAppSettings?: () => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+				__czSetStandaloneAppSettings?: (settings: {
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}) => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+			}
+		).__czHostPlatform = "ios";
+		(
+			window as Window & {
+				__czRuntimeMode?: string;
+			}
+		).__czRuntimeMode = "standalone";
+		(
+			window as Window & {
+				__czGetStandaloneAppSettings?: () => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+			}
+		).__czGetStandaloneAppSettings = vi.fn(async () => ({
+			midiChannel: 0,
+			keepRunningInBackground: false,
+			bufferSize: 128,
+		}));
+		(
+			window as Window & {
+				__czSetStandaloneAppSettings?: (settings: {
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}) => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+			}
+		).__czSetStandaloneAppSettings = vi.fn(async (settings) => settings);
+
+		const { getByText } = render(<PluginPage appVersion="0.2.0" />);
+
+		expect(getByText("AUv3 App")).toBeInstanceOf(HTMLElement);
+		expect(getByText("MIDI Channel")).toBeInstanceOf(HTMLElement);
+		expect(getByText("Run In Background")).toBeInstanceOf(HTMLElement);
+		expect(getByText("Buffer Size")).toBeInstanceOf(HTMLElement);
+	});
+
+	it("shows AUv3 app settings when standalone support arrives after render", () => {
+		(
+			window as Window & {
+				__czHostPlatform?: string;
+				__czRuntimeMode?: string;
+				__czSupportsStandaloneAppSettings?: boolean;
+				__czGetStandaloneAppSettings?: () => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+				__czSetStandaloneAppSettings?: (settings: {
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}) => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+			}
+		).__czHostPlatform = undefined;
+		(
+			window as Window & {
+				__czRuntimeMode?: string;
+			}
+		).__czRuntimeMode = "plugin";
+		(
+			window as Window & {
+				__czGetStandaloneAppSettings?: () => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+			}
+		).__czGetStandaloneAppSettings = vi.fn(
+			() =>
+				new Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>(() => {}),
+		);
+		(
+			window as Window & {
+				__czSetStandaloneAppSettings?: (settings: {
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}) => Promise<{
+					midiChannel: number;
+					keepRunningInBackground: boolean;
+					bufferSize: number;
+				}>;
+			}
+		).__czSetStandaloneAppSettings = vi.fn(async (settings) => settings);
+
+		const { getByText, queryByText } = render(
+			<PluginPage appVersion="0.2.0" />,
+		);
+
+		expect(queryByText("AUv3 App")).toBeNull();
+
+		act(() => {
+			(
+				window as Window & {
+					__czRuntimeMode?: string;
+					__czSupportsStandaloneAppSettings?: boolean;
+				}
+			).__czRuntimeMode = "standalone";
+			(
+				window as Window & {
+					__czSupportsStandaloneAppSettings?: boolean;
+				}
+			).__czSupportsStandaloneAppSettings = true;
+			window.dispatchEvent(new Event("cz-host-context-changed"));
+		});
+
+		expect(getByText("AUv3 App")).toBeInstanceOf(HTMLElement);
+		expect(getByText("MIDI Channel")).toBeInstanceOf(HTMLElement);
+		expect(getByText("Run In Background")).toBeInstanceOf(HTMLElement);
+		expect(getByText("Buffer Size")).toBeInstanceOf(HTMLElement);
 	});
 
 	it("centers the AUv3 standalone wrapper while keeping the scaled renderer anchored top-left", () => {

--- a/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
+++ b/packages/cosmo-pd101-plugin/webview/src/PluginPage.tsx
@@ -21,6 +21,7 @@ import {
 	useRef,
 	useState,
 } from "react";
+import Auv3StandaloneSettingsSection from "./Auv3StandaloneSettingsSection";
 import { createPluginPresetManagerRepository } from "./hooks/createPluginPresetManagerRepository";
 import { usePluginParamBridge } from "./hooks/usePluginParamBridge";
 import { usePluginSynthRuntime } from "./hooks/usePluginSynthRuntime";
@@ -43,6 +44,7 @@ type HostSize = {
 type HostContext = {
 	hostPlatform?: Window["__czHostPlatform"];
 	runtimeMode?: Window["__czRuntimeMode"];
+	supportsStandaloneAppSettings: boolean;
 };
 
 type PluginRendererLayout = {
@@ -109,6 +111,8 @@ function readHostContext(): HostContext {
 	return {
 		hostPlatform: window.__czHostPlatform,
 		runtimeMode: window.__czRuntimeMode,
+		supportsStandaloneAppSettings:
+			window.__czSupportsStandaloneAppSettings === true,
 	};
 }
 
@@ -184,6 +188,10 @@ export default function PluginPage({
 	const isIosHost = hostContext.hostPlatform === "ios";
 	const isAuv3WebView =
 		hostContext.hostPlatform === "ios" || hostContext.hostPlatform === "macos";
+	const showStandaloneIosSettings =
+		isAuv3WebView ||
+		hostContext.supportsStandaloneAppSettings ||
+		hostContext.runtimeMode === "standalone";
 	const isLikelyIosDevice =
 		/iPad|iPhone|iPod/.test(window.navigator.userAgent) ||
 		(window.navigator.platform === "MacIntel" &&
@@ -509,6 +517,11 @@ export default function PluginPage({
 								runtime={runtime}
 								appVersion={appVersion}
 								bottomBarExtra={utilityExtra}
+								keyboardSettingsExtra={
+									showStandaloneIosSettings ? (
+										<Auv3StandaloneSettingsSection />
+									) : undefined
+								}
 								disableAudioGate
 								miniKeyboard={{
 									activeNotes: runtime.activeNotes,
@@ -546,6 +559,11 @@ export default function PluginPage({
 							runtime={runtime}
 							appVersion={appVersion}
 							bottomBarExtra={utilityExtra}
+							keyboardSettingsExtra={
+								showStandaloneIosSettings ? (
+									<Auv3StandaloneSettingsSection />
+								) : undefined
+							}
 							disableAudioGate
 							miniKeyboard={{
 								activeNotes: runtime.activeNotes,

--- a/packages/cosmo-pd101-plugin/webview/src/lib/auv3Bridge.ts
+++ b/packages/cosmo-pd101-plugin/webview/src/lib/auv3Bridge.ts
@@ -25,13 +25,24 @@ declare global {
 		};
 		__czHostPlatform?: "macos" | "ios";
 		__czRuntimeMode?: "auv3-hosted" | "plugin" | "standalone";
+		__czSupportsStandaloneAppSettings?: boolean;
 		__czAuv3HostActive?: boolean;
 		__czOnHostPresetSelected?: (name: string) => void;
 		__czOnRuntimeVoiceStates?: (json: string) => void;
 		__czOnRuntimeModSources?: (json: string) => void;
 		__czOnTransport?: (json: string) => void;
+		__czGetStandaloneAppSettings?: () => Promise<StandaloneAppSettings>;
+		__czSetStandaloneAppSettings?: (
+			settings: StandaloneAppSettings,
+		) => Promise<StandaloneAppSettings>;
 	}
 }
+
+export type StandaloneAppSettings = {
+	midiChannel: number;
+	keepRunningInBackground: boolean;
+	bufferSize: number;
+};
 
 const IPC_TIMEOUT_MS = 250;
 const AUV3_SCOPE_POLLING_ENABLED = true;
@@ -746,6 +757,13 @@ function installTransportSubscription() {
 	});
 }
 
+function installStandaloneAppSettingsBridge() {
+	window.__czGetStandaloneAppSettings = () =>
+		invokeAuv3<StandaloneAppSettings>("getStandaloneAppSettings");
+	window.__czSetStandaloneAppSettings = (settings) =>
+		invokeAuv3<StandaloneAppSettings>("setStandaloneAppSettings", settings);
+}
+
 export function ensureAuv3Bridge(): boolean {
 	if (installed) {
 		return true;
@@ -765,5 +783,6 @@ export function ensureAuv3Bridge(): boolean {
 	installRuntimeVoiceStatesSubscription();
 	installRuntimeModSourcesSubscription();
 	installTransportSubscription();
+	installStandaloneAppSettingsBridge();
 	return true;
 }

--- a/packages/cosmo-pd101/src/components/layout/SynthInfoBar.tsx
+++ b/packages/cosmo-pd101/src/components/layout/SynthInfoBar.tsx
@@ -7,6 +7,7 @@ import { KeyboardSettingsPopover } from "@/components/modals/KeyboardSettingsPop
 type SynthInfoBarProps = {
 	infoText: string;
 	bottomBarExtra?: ReactNode;
+	keyboardSettingsExtra?: ReactNode;
 	showKeyboardToggle: boolean;
 	keyboardVisible: boolean;
 	onKeyboardToggle: () => void;
@@ -15,6 +16,7 @@ type SynthInfoBarProps = {
 export default function SynthInfoBar({
 	infoText,
 	bottomBarExtra,
+	keyboardSettingsExtra,
 	showKeyboardToggle,
 	keyboardVisible,
 	onKeyboardToggle,
@@ -66,6 +68,7 @@ export default function SynthInfoBar({
 						open={settingsOpen}
 						triggerRef={settingsBtnRef}
 						onClose={() => setSettingsOpen(false)}
+						extraSettings={keyboardSettingsExtra}
 					/>
 				</div>
 			) : null}

--- a/packages/cosmo-pd101/src/components/modals/KeyboardSettingsPopover.tsx
+++ b/packages/cosmo-pd101/src/components/modals/KeyboardSettingsPopover.tsx
@@ -1,4 +1,4 @@
-import type { RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
 import Button from "@/components/controls/Button";
 import Popover from "@/components/primitives/Popover";
 import { useSynthUiStore } from "@/features/synth/synthUiStore";
@@ -7,10 +7,12 @@ export function KeyboardSettingsPopover({
 	open,
 	triggerRef,
 	onClose,
+	extraSettings,
 }: {
 	open: boolean;
 	triggerRef: RefObject<Element | null>;
 	onClose: () => void;
+	extraSettings?: ReactNode;
 }) {
 	const keyboardOctaves = useSynthUiStore((s) => s.keyboardOctaves);
 	const keyboardRange = useSynthUiStore((s) => s.keyboardRange);
@@ -149,6 +151,7 @@ export function KeyboardSettingsPopover({
 							Shows PC keyboard key labels on the on-screen mini keyboard.
 						</p>
 					</div>
+					{extraSettings}
 				</div>
 			</div>
 		</Popover>

--- a/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
+++ b/packages/cosmo-pd101/src/components/renderer/SynthRenderer.tsx
@@ -41,6 +41,7 @@ export type SynthRendererProps = {
 	frameStyle?: CSSProperties;
 	headerExtra?: ReactNode;
 	bottomBarExtra?: ReactNode;
+	keyboardSettingsExtra?: ReactNode;
 	runtime: SynthRuntime;
 	onAudioLevelChange?: (level: number) => void;
 	disableAudioGate?: boolean;
@@ -57,6 +58,7 @@ const SynthRenderer = memo(function SynthRenderer({
 	frameStyle,
 	headerExtra,
 	bottomBarExtra,
+	keyboardSettingsExtra,
 	runtime,
 	onAudioLevelChange,
 	disableAudioGate = false,
@@ -236,6 +238,7 @@ const SynthRenderer = memo(function SynthRenderer({
 								appVersion={appVersion}
 								audioGate={audioGate}
 								bottomBarExtra={bottomBarExtra}
+								keyboardSettingsExtra={keyboardSettingsExtra}
 								keyboardVisible={keyboardVisible}
 								onKeyboardToggle={handleKeyboardToggle}
 							/>
@@ -251,6 +254,7 @@ type SynthBottomSectionProps = {
 	appVersion: string;
 	audioGate: { ready: boolean; onResume: () => void };
 	bottomBarExtra?: ReactNode;
+	keyboardSettingsExtra?: ReactNode;
 	keyboardVisible: boolean;
 	onKeyboardToggle: () => void;
 };
@@ -259,6 +263,7 @@ function SynthBottomSection({
 	appVersion,
 	audioGate,
 	bottomBarExtra,
+	keyboardSettingsExtra,
 	keyboardVisible,
 	onKeyboardToggle,
 }: SynthBottomSectionProps) {
@@ -269,6 +274,7 @@ function SynthBottomSection({
 			<SynthInfoBar
 				infoText={infoText}
 				bottomBarExtra={bottomBarExtra}
+				keyboardSettingsExtra={keyboardSettingsExtra}
 				showKeyboardToggle
 				keyboardVisible={keyboardVisible}
 				onKeyboardToggle={onKeyboardToggle}

--- a/packages/cosmo-pd101/src/features/synth/engine/pluginBridgeSynthEngineAdapter.test.tsx
+++ b/packages/cosmo-pd101/src/features/synth/engine/pluginBridgeSynthEngineAdapter.test.tsx
@@ -25,6 +25,7 @@ describe("usePluginBridgeSynthEngine", () => {
 		window.__czGetParamsVersion = undefined;
 		window.__czGetPendingParamChanges = undefined;
 		window.__czSetParams = undefined;
+		window.__czAuv3HostActive = undefined;
 	});
 
 	afterEach(() => {
@@ -34,6 +35,7 @@ describe("usePluginBridgeSynthEngine", () => {
 		window.__czGetParamsVersion = undefined;
 		window.__czGetPendingParamChanges = undefined;
 		window.__czSetParams = undefined;
+		window.__czAuv3HostActive = undefined;
 	});
 
 	it("does not push default params before hydration completes", async () => {
@@ -196,6 +198,39 @@ describe("usePluginBridgeSynthEngine", () => {
 			});
 		});
 		expect(onExternalParamChange).toHaveBeenCalledOnce();
+
+		unmount();
+	});
+
+	it("pauses params-version polling while the AUv3 host is inactive", async () => {
+		vi.useFakeTimers();
+		window.__czAuv3HostActive = false;
+		window.__czGetParams = vi.fn(async () => makeParams(0.42));
+		window.__czGetParamsVersion = vi.fn(async () => 1);
+		captureSetParams([]);
+
+		const { unmount } = renderHook(() => usePluginBridgeSynthEngine());
+
+		await act(async () => {
+			await Promise.resolve();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1000);
+			await Promise.resolve();
+		});
+
+		expect(window.__czGetParamsVersion).not.toHaveBeenCalled();
+
+		act(() => {
+			window.__czAuv3HostActive = true;
+			window.dispatchEvent(new Event("cz-auv3-host-active"));
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(250);
+			await Promise.resolve();
+		});
+
+		expect(window.__czGetParamsVersion).toHaveBeenCalled();
 
 		unmount();
 	});


### PR DESCRIPTION
## Summary
- adds AUv3 standalone app settings for MIDI channel, background running, and buffer size
- wires standalone settings through the AUv3 native/web bridge and keyboard settings UI
- applies the selected buffer size to the AU render frame limit instead of always using the supported maximum

## Validation
- bun run lint
- bun run build
- bun run test